### PR TITLE
Specify Ingester image tag

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -1,10 +1,11 @@
 from ...utils.token import parse_token
 import os
 import click
+from ...utils.ingester_image import ingester_image
 
 @click.command()
 @click.option('--source', help="repository path", default="$(pwd)", type=str)
 def commit(source):
   token, org, workspace = parse_token()
-  os.system("docker run -u $(id -u) -i --rm -v {}:{} --env LAUNCHABLE_TOKEN launchableinc/ingester:latest ingest:commit {}".format(source ,source, source))
+  os.system("docker run -u $(id -u) -i --rm -v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}".format(source ,source, ingester_image, source))
 

--- a/launchable/utils/ingester_image.py
+++ b/launchable/utils/ingester_image.py
@@ -1,0 +1,4 @@
+# Launchable's ingester Docker image with tag
+# If you need up-to-date image, please replace the image tag
+# You can see the docker image tags at https://hub.docker.com/repository/registry-1.docker.io/launchableinc/ingester/tags
+ingester_image = 'launchableinc/ingester:976171f4005f8a1c6d0e706d20760890b44c5373'


### PR DESCRIPTION
- Specify Inagester image tag instead of `latest` for avoiding broke the CLI because of the unexpected update