### PR TITLE
Accept relative path on the "commit" command

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -4,8 +4,9 @@ import click
 from ...utils.ingester_image import ingester_image
 
 @click.command()
-@click.option('--source', help="repository path", default="$(pwd)", type=str)
+@click.option('--source', help="repository path", default=os.getcwd(), type=str)
 def commit(source):
   token, org, workspace = parse_token()
+  source = os.path.abspath(source)
   os.system("docker run -u $(id -u) -i --rm -v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}".format(source ,source, ingester_image, source))
 


### PR DESCRIPTION
`commit` command accepted absolute path becaus Docker only accepts it. However, `build` command accepts relative and absolute paths. To standardize those interfaces, add a converter that converts relative path to absolute path.