### PR TITLE
Disambiguate submodules across different repositories.

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -27,7 +27,7 @@ def build(build_number, source):
         hash = matched.group('hash')
         name = matched.group('name')        
         if hash and name:
-          submodules.append((name, hash))
+          submodules.append((repo_name+"/"+name, hash))
 
   # Note: currently becomes unique command args and submodules by the hash. But they can be conflict between repositories.
   uniq_submodules = {hash: (name, hash) for name, hash in sources + submodules}.values()


### PR DESCRIPTION
If the user specifies two repositories that each has submodule "xyz",
then the current code creates colliding names to them.

When a submodule contains a submodule, the current code produces names
like "xyz/abc" due to the way git-submodules work, so here I extended
that convention to the top-level submodules, not just nested ones.