### PR TITLE
No guarantee 'python' points to Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ launchable record build --name 12345678 --source main=. --source sub1=modules/su
 # Development
 You can use Python's `-m` option to launch module directly.
 ```shell
-python -m launchable record commit
+python3 -m launchable record commit
 ```


### PR DESCRIPTION
As per PEP-394 https://legacy.python.org/dev/peps/pep-0394/ it's better to refer to `python3` given that we require python3 to run

BTW I also had to do `python3 setup.py develop` what exactly is the step to develop this?