### PR TITLE
Collecting commits without Docker

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -18,8 +18,8 @@ from .commit import commit
 )
 @click.option(
     '--source',
-    help='repository name and repository district. please specify' \
-    'REPO_DIST like --source . ' \
+    help='repository name and repository district. please specify'
+    'REPO_DIST like --source . '
     'or REPO_NAME=REPO_DIST like --source main=./main --source lib=./main/lib',
     default=["."],
     metavar="REPO_NAME",
@@ -31,7 +31,8 @@ def build(ctx, build_number, source, with_commit):
     token, org, workspace = parse_token()
 
     # This command accepts REPO_NAME=REPO_DIST and REPO_DIST
-    repos = [s.split('=') if re.match(r'[^=]+=[^=]+', s) else (s, s) for s in source]
+    repos = [s.split('=') if re.match(r'[^=]+=[^=]+', s) else (s, s)
+             for s in source]
 
     if with_commit:
         for (name, repo_dist) in repos:
@@ -88,7 +89,7 @@ def build(ctx, build_number, source, with_commit):
         }
 
         url = "https://api.mercury.launchableinc.com/intake/"\
-          "organizations/{}/workspaces/{}/builds".format(org, workspace)
+            "organizations/{}/workspaces/{}/builds".format(org, workspace)
         request = urllib.request.Request(
             url, data=json.dumps(payload).encode(), headers=headers)
         with urllib.request.urlopen(request) as response:

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -2,6 +2,7 @@ from ...utils.token import parse_token
 import os
 import click
 from ...utils.ingester_image import ingester_image
+import subprocess
 
 
 @click.command()
@@ -9,12 +10,40 @@ from ...utils.ingester_image import ingester_image
               help="repository path",
               default=os.getcwd(),
               type=str
-              )
-def commit(source):
-    token, org, workspace = parse_token()
+)
+@click.option('--executable',
+              help="",
+              type=click.Choice(['jar', 'docker']),
+              default='jar'
+)
+def commit(source, executable):
     source = os.path.abspath(source)
+
+    if executable == 'jar':
+        exec_jar(source)
+    elif executable == 'docker':
+        exec_docker(source)
+
+
+def exec_jar(source):
+    res = subprocess.run(["which", "java"], stdout=subprocess.DEVNULL)
+    java = None
+    if res.returncode == 0:
+        java = "java"
+    elif os.access(os.path.expandvars("$JAVA_HOME/bin/java"), os.X_OK):
+        java = "$JAVA_HOME/bin/java"
+
+    if not java:
+        exit("You need to install Java or try --executable docker")
+
     os.system(
-        "docker run -u $(id -u) -i --rm \
-        -v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}"
+        "{} -jar bin/exe_deploy.jar ingest:commit {}"
+        .format(java, source))
+
+
+def exec_docker(source):
+    os.system(
+        "docker run -u $(id -u) -i --rm " \
+        "-v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}"
         .format(source, source, ingester_image, source)
     )

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -58,7 +58,8 @@ def download_jar():
                 sys.stdout.flush()
 
         f.close()
-        print("\nexe_deploy.jar is downloaded in {}", jar_dir_path)
+        print("")
+        print("exe_deploy.jar is downloaded in {}".format(jar_dir_path))
 
 
 def exec_jar(source):

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -58,7 +58,6 @@ def download_jar():
                 sys.stdout.flush()
 
         f.close()
-        print("")
         print("exe_deploy.jar is downloaded in {}".format(jar_dir_path))
 
 

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -41,7 +41,7 @@ def download_jar():
     total_length = int(res.headers.get('content-length'))
 
     if os.path.exists(jar_file_path) and os.path.getsize(jar_file_path) == total_length:
-        print("exe_deploy.jar exits at {}".format(jar_dir_path))
+        print("exe_deploy.jar exists at {}".format(jar_dir_path))
     else:
         total_downloaded = 0
         f = open(jar_file_path, 'wb')

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -44,7 +44,7 @@ def download_jar():
         print("exe_deploy.jar exits at {}".format(jar_dir_path))
     else:
         total_downloaded = 0
-        f = open(file_path, 'wb')
+        f = open(jar_file_path, 'wb')
         for chunk in res.iter_content(chunk_size=512 * 1024):
             if chunk:
                 f.write(chunk)

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -41,7 +41,7 @@ def download_jar():
     total_length = int(res.headers.get('content-length'))
 
     if os.path.exists(jar_file_path) and os.path.getsize(jar_file_path) == total_length:
-        print("exe_deploy.jar exists at {}".format(jar_dir_path))
+        print("exe_deploy.jar exists in {}".format(jar_dir_path))
     else:
         total_downloaded = 0
         f = open(jar_file_path, 'wb')
@@ -58,7 +58,7 @@ def download_jar():
                 sys.stdout.flush()
 
         f.close()
-        print("\nexe_deploy.jar is downloaded at {}", jar_dir_path)
+        print("\nexe_deploy.jar is downloaded in {}", jar_dir_path)
 
 
 def exec_jar(source):

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -58,7 +58,7 @@ def download_jar():
                 sys.stdout.flush()
 
         f.close()
-        print("exe_deploy.jar is downloaded in {}".format(jar_dir_path))
+        sys.stdout.write("\nexe_deploy.jar is downloaded in {}\n".format(jar_dir_path))
 
 
 def exec_jar(source):

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -31,8 +31,11 @@ def commit(source, executable):
     source = os.path.abspath(source)
 
     if executable == 'jar':
-        download_jar()
-        exec_jar(source)
+        try:
+            download_jar()
+            exec_jar(source)
+        except Exception as e:
+            print(e)
     elif executable == 'docker':
         exec_docker(source)
 

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -12,7 +12,7 @@ tmp_dir_path = os.path.expanduser(
     "/tmp/launchable/jar/ingester/{}".format(ingester_jar_version))
 tmp_file_path = tmp_dir_path + "/exe_deploy.jar"
 jar_dir_path = os.path.expanduser(
-    "~/.launchable/jar/ingester/{}".format(ingester_jar_version))
+    "~/.cache/launchable/jar/ingester/{}".format(ingester_jar_version))
 jar_file_path = jar_dir_path + "/exe_deploy.jar"
 
 

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -1,4 +1,3 @@
-from ...utils.token import parse_token
 import os
 import click
 from ...utils.ingester_image import ingester_image
@@ -52,10 +51,10 @@ def download_jar():
 
                 total_downloaded += len(chunk)
                 sys.stdout.write("\rDownloading exe_deploy.jar: {:.1f}% ({:,} / {:,} byte)".format(
-                    (total_downloaded / total_length) * 100),
+                    (total_downloaded / total_length) * 100,
                     total_downloaded,
                     total_length
-                )
+                ))
                 sys.stdout.flush()
 
         f.close()

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -52,15 +52,17 @@ def download_jar():
 
         os.makedirs(tmp_dir_path, exist_ok=True)
         f = open(tmp_file_path, 'wb')
-        for chunk in res.iter_content(chunk_size=512 * 1024):
+
+        print("Downloading exe_deploy.jar ({:,.2f} MB)".format(
+            total_length / (1024 * 1024)))
+
+        for chunk in res.iter_content(chunk_size=1024 * 1024 * 10):
             if chunk:
                 f.write(chunk)
-
                 total_downloaded += len(chunk)
-                sys.stdout.write("\rDownloading exe_deploy.jar: {:.1f}% ({:,} / {:,} byte)".format(
-                    (total_downloaded / total_length) * 100,
-                    total_downloaded,
-                    total_length
+
+                sys.stdout.write("\r{}".format(
+                    "." * int(total_downloaded / (1024 * 1024 * 10))
                 ))
                 sys.stdout.flush()
 

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -2,7 +2,15 @@ from ...utils.token import parse_token
 import os
 import click
 from ...utils.ingester_image import ingester_image
+from ...utils.ingester_jar import ingester_jar_url, ingester_jar_version
 import subprocess
+import requests
+import pathlib
+import sys
+
+
+jar_dir_path = os.path.expanduser("~/.launchable/jar/ingester/{}".format(ingester_jar_version))
+jar_file_path = jar_dir_path + "/exe_deploy.jar"
 
 
 @click.command()
@@ -20,9 +28,37 @@ def commit(source, executable):
     source = os.path.abspath(source)
 
     if executable == 'jar':
+        download_jar()
         exec_jar(source)
     elif executable == 'docker':
         exec_docker(source)
+
+
+def download_jar():
+    pathlib.Path(jar_dir_path).mkdir(parents=True, exist_ok=True)
+
+    res = requests.get(ingester_jar_url, stream=True)
+    total_length = int(res.headers.get('content-length'))
+
+    if os.path.exists(jar_file_path) and os.path.getsize(jar_file_path) == total_length:
+        print("exe_deploy.jar exits at {}".format(jar_dir_path))
+    else:
+        total_downloaded = 0
+        f = open(file_path, 'wb')
+        for chunk in res.iter_content(chunk_size=512 * 1024):
+            if chunk:
+                f.write(chunk)
+
+                total_downloaded += len(chunk)
+                sys.stdout.write("\rDownloading exe_deploy.jar: {:.1f}% ({:,} / {:,} byte)".format(
+                    (total_downloaded / total_length) * 100),
+                    total_downloaded,
+                    total_length
+                )
+                sys.stdout.flush()
+
+        f.close()
+        print("\nexe_deploy.jar is downloaded at {}", jar_dir_path)
 
 
 def exec_jar(source):
@@ -37,8 +73,8 @@ def exec_jar(source):
         exit("You need to install Java or try --executable docker")
 
     os.system(
-        "{} -jar bin/exe_deploy.jar ingest:commit {}"
-        .format(java, source))
+        "{} -jar {} ingest:commit {}"
+        .format(java, jar_file_path, source))
 
 
 def exec_docker(source):

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -9,7 +9,8 @@ import pathlib
 import sys
 
 
-jar_dir_path = os.path.expanduser("~/.launchable/jar/ingester/{}".format(ingester_jar_version))
+jar_dir_path = os.path.expanduser(
+    "~/.launchable/jar/ingester/{}".format(ingester_jar_version))
 jar_file_path = jar_dir_path + "/exe_deploy.jar"
 
 
@@ -18,12 +19,12 @@ jar_file_path = jar_dir_path + "/exe_deploy.jar"
               help="repository path",
               default=os.getcwd(),
               type=str
-)
+              )
 @click.option('--executable',
               help="",
               type=click.Choice(['jar', 'docker']),
               default='jar'
-)
+              )
 def commit(source, executable):
     source = os.path.abspath(source)
 
@@ -79,7 +80,7 @@ def exec_jar(source):
 
 def exec_docker(source):
     os.system(
-        "docker run -u $(id -u) -i --rm " \
+        "docker run -u $(id -u) -i --rm "
         "-v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}"
         .format(source, source, ingester_image, source)
     )

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -20,7 +20,7 @@ jar_file_path = jar_dir_path + "/exe_deploy.jar"
               type=str
               )
 @click.option('--executable',
-              help="",
+              help="collect commits with Jar or Docker",
               type=click.Choice(['jar', 'docker']),
               default='jar'
               )

--- a/launchable/utils/ingester_jar.py
+++ b/launchable/utils/ingester_jar.py
@@ -1,2 +1,3 @@
 ingester_jar_version = "0.1.0"
-ingester_jar_url = "https://launchable-cli.s3-us-west-2.amazonaws.com/jar/ingester/{}/exe_deploy.jar".format(ingester_jar_version)
+ingester_jar_url = "https://launchable-cli.s3-us-west-2.amazonaws.com/jar/ingester/{}/exe_deploy.jar".format(
+    ingester_jar_version)

--- a/launchable/utils/ingester_jar.py
+++ b/launchable/utils/ingester_jar.py
@@ -1,0 +1,2 @@
+ingester_jar_version = "0.1.0"
+ingester_jar_url = "https://launchable-cli.s3-us-west-2.amazonaws.com/jar/ingester/{}/exe_deploy.jar".format(ingester_jar_version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click==7.1.2
+requests==2.24.0


### PR DESCRIPTION
- Add `--executable` option to the `commit` command
  - It has `jar` and `docker` options. `jar` is the default.
- Download `exec_deploy.jar` if it doesn't exist

## What point do I want you to review?
- I added versioning to `exec_deploy.jar` on S3 and local. Do you agree it works well?
- I added `~/.launchable` as a jar cache directory. Do you think is this directory right place to store jar files?