### PR TITLE
Pass LAUNCHABLE_BASE_URL to Ingester jar file

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -3,6 +3,7 @@ import click
 from ...utils.ingester_image import ingester_image
 import subprocess
 from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.http_client import get_base_url
 
 jar_file_path = os.path.normpath(os.path.join(
     os.path.dirname(__file__), "../../jar/exe_deploy.jar"))
@@ -45,14 +46,16 @@ def exec_jar(source):
     if not java:
         exit("You need to install Java or try --executable docker")
 
+    base_url = get_base_url()
     os.system(
-        "{} -jar {} ingest:commit {}"
-        .format(java, jar_file_path, source))
+        "{} -jar {} ingest:commit -endpoint {} {}"
+        .format(java, jar_file_path, "{}/intake/".format(base_url), source))
 
 
 def exec_docker(source):
+    base_url = get_base_url()
     os.system(
         "docker run -u $(id -u) -i --rm "
-        "-v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit {}"
-        .format(source, source, ingester_image, source)
+        "-v {}:{} --env LAUNCHABLE_TOKEN {} ingest:commit -endpoint {} {}"
+        .format(source, source, ingester_image, "{}/intake/".format(base_url), source)
     )

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -8,9 +8,13 @@ BASE_URL_KEY = "LAUNCHABLE_BASE_URL"
 DEFAULT_BASE_URL = "https://api.mercury.launchableinc.com"
 
 
+def get_base_url():
+    return os.getenv(BASE_URL_KEY) or DEFAULT_BASE_URL
+
+
 class LaunchableClient:
     def __init__(self, token, base_url="", http=requests):
-        self.base_url = base_url or os.getenv(BASE_URL_KEY) or DEFAULT_BASE_URL
+        self.base_url = base_url or get_base_url()
         self.http = http
         self.token = token
 


### PR DESCRIPTION
Ingester has `-endpoint` flag which overrides its API host. To override the jar internal API host variable from the CLI, pass `LAUNCHABLE_BASE_URL` as a `-endpoint` flag.