### PR TITLE
Implement a verify command

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -1,6 +1,7 @@
 from .version import __version__
 import click
 from .commands.record import record
+from .commands.verify import verify
 
 
 @click.group()
@@ -10,6 +11,7 @@ def main():
 
 
 main.add_command(record)
+main.add_command(verify)
 
 if __name__ == '__main__':
     main()

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -1,9 +1,11 @@
 import os
+
 import click
-from ...utils.ingester_image import ingester_image
-import subprocess
+
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import get_base_url
+from ...utils.ingester_image import ingester_image
+from ...utils.java import get_java_command
 
 jar_file_path = os.path.normpath(os.path.join(
     os.path.dirname(__file__), "../../jar/exe_deploy.jar"))
@@ -36,12 +38,7 @@ def commit(source, executable):
 
 
 def exec_jar(source):
-    res = subprocess.run(["which", "java"], stdout=subprocess.DEVNULL)
-    java = None
-    if res.returncode == 0:
-        java = "java"
-    elif os.access(os.path.expandvars("$JAVA_HOME/bin/java"), os.X_OK):
-        java = "$JAVA_HOME/bin/java"
+    java = get_java_command()
 
     if not java:
         exit("You need to install Java or try --executable docker")

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -8,13 +8,12 @@ from ..utils.http_client import LaunchableClient
 from ..utils.token import parse_token
 from ..utils.java import get_java_command
 
-
 @click.command(name="verify")
 def verify():
     try:
         if os.getenv("LAUNCHABLE_TOKEN") is None:
-            click.echo(click.style(f"Could not find the LAUNCHABLE_TOKEN environment variable. Please check if you "
-                                   f"set it properly.", fg="red"))
+            click.echo(click.style("Could not find the LAUNCHABLE_TOKEN environment variable. Please check if you "
+                                   "set it properly.", fg="red"))
             return
 
         token, org, workspace = parse_token()
@@ -23,14 +22,15 @@ def verify():
             "Content-Type": "application/json",
         }
 
-        path = "/intake/organizations/{}/workspaces/{}/verification".format(org, workspace)
+        path = "/intake/organizations/{}/workspaces/{}/verification".format(
+            org, workspace)
 
         client = LaunchableClient(token)
         res = client.request("get", path, headers=headers)
 
         if res.status_code == 401:
-            click.echo(click.style(f"Authentication failed. Most likely the value for the LAUNCHABLE_TOKEN "
-                                   f"environment variable is invalid.", fg="red"))
+            click.echo(click.style("Authentication failed. Most likely the value for the LAUNCHABLE_TOKEN "
+                                   "environment variable is invalid.", fg="red"))
             return
 
         res.raise_for_status()
@@ -41,12 +41,14 @@ def verify():
         java = get_java_command()
 
         if java is None:
-            click.echo(click.style(f"Java is not installed. You need Java to use the Launchable CLI", fg="red"))
+            click.echo(click.style(
+                "Java is not installed. You need Java to use the Launchable CLI.", fg="red"))
             return
 
         click.echo("Java command: " + java)
 
-        click.echo(click.style(f"Your CLI configuration is successfully verified \U0001f389", fg="green"))
+        click.echo(click.style(
+            "Your CLI configuration is successfully verified \U0001f389", fg="green"))
 
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -1,0 +1,55 @@
+import os
+
+import click
+import platform
+
+from ..utils.env_keys import REPORT_ERROR_KEY
+from ..utils.http_client import LaunchableClient
+from ..utils.token import parse_token
+from ..utils.java import get_java_command
+
+
+@click.command(name="verify")
+def verify():
+    try:
+        if os.getenv("LAUNCHABLE_TOKEN") is None:
+            click.echo(click.style(f"Could not find the LAUNCHABLE_TOKEN environment variable. Please check if you "
+                                   f"set it properly.", fg="red"))
+            return
+
+        token, org, workspace = parse_token()
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        path = "/intake/organizations/{}/workspaces/{}/verification".format(org, workspace)
+
+        client = LaunchableClient(token)
+        res = client.request("get", path, headers=headers)
+
+        if res.status_code == 401:
+            click.echo(click.style(f"Authentication failed. Most likely the value for the LAUNCHABLE_TOKEN "
+                                   f"environment variable is invalid.", fg="red"))
+            return
+
+        res.raise_for_status()
+
+        click.echo("Platform: " + platform.platform())
+        click.echo("Python version: " + platform.python_version())
+
+        java = get_java_command()
+
+        if java is None:
+            click.echo(click.style(f"Java is not installed. You need Java to use the Launchable CLI", fg="red"))
+            return
+
+        click.echo("Java command: " + java)
+
+        click.echo(click.style(f"Your CLI configuration is successfully verified \U0001f389", fg="green"))
+
+    except Exception as e:
+        if os.getenv(REPORT_ERROR_KEY):
+            raise e
+        else:
+            print(e)

--- a/launchable/utils/java.py
+++ b/launchable/utils/java.py
@@ -1,0 +1,13 @@
+import os
+import subprocess
+
+
+def get_java_command():
+    res = subprocess.run(["which", "java"], stdout=subprocess.DEVNULL)
+    if res.returncode == 0:
+        return "java"
+
+    if os.access(os.path.expandvars("$JAVA_HOME/bin/java"), os.X_OK):
+        return "$JAVA_HOME/bin/java"
+
+    return None


### PR DESCRIPTION
I implemented a verify command to test if the Launchable CLI is configured properly or not.

Success

```
Platform: macOS-10.15.7-x86_64-i386-64bit
Python version: 3.8.3
Java command: java
Your CLI configuration is successfully verified 🎉
```

Failure

```
Authentication failed. Most likely the value for LAUNCHABLE_TOKEN environment variable is invalid.

or 

Authentication failed. Most likely the value for the LAUNCHABLE_TOKEN environment variable is invalid.

or 

Java is not installed. You need Java to use the Launchable CLI.
```