### PR TITLE
We require Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Installation
 
 ```shell
-pip install launchable
+pip3 install launchable
 ```
 
 ## Set your API token

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Installation
 
 ```shell
-pip3 install launchable
+pip3 install --user launchable
 ```
+
+This creates executable `~/.local/bin/launchable` that should be on your `PATH`. See [PEP-370](https://www.python.org/dev/peps/pep-0370/) for further details.
 
 ## Set your API token
 


### PR DESCRIPTION
As per https://www.python.org/dev/peps/pep-0394/, as we require Python3, our instruction should be `pip3` to be more portable regardless of the Python version that `pip` resolves to.