### PR TITLE
Grab module version from Git tag

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,8 +26,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose
+        pip install flake8 nose setuptools setuptools_scm
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Build
+      run: python setup.py sdist bdist_wheel
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose setuptools setuptools_scm
+        pip install flake8 nose setuptools setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: python setup.py sdist bdist_wheel

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,9 @@ jobs:
         pip install flake8 nose setuptools setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
-      run: python setup.py sdist bdist_wheel
+      run: |
+        python setup.py sdist bdist_wheel
+        pip install -U .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools setuptools_scm wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ launchable_verify:
         name: launchable verify?
         command: launchable verify || true
 ```
+
+# How to release
+Create new release on Github, then Github Actions automatically uploads the module to PyPI.
+

--- a/launchable/version.py
+++ b/launchable/version.py
@@ -1,1 +1,7 @@
-__version__ = '0.1.9'
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution("launchable").version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==7.1.2
 requests==2.24.0
 junitparser==1.6.3
+setuptools==51.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==7.1.2
 requests==2.24.0
 junitparser==1.6.3
-setuptools==51.0.0
+setuptools>=50.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==7.1.2
 requests==2.24.0
 junitparser==1.6.3
-setuptools>=50.0.0
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-from launchable.version import __version__
 
 from os import path
 this_directory = path.abspath(path.dirname(__file__))
@@ -13,7 +12,6 @@ def _requirements(file):
 
 setup(
     name='launchable',
-    version=__version__,
     license='Apache Software License v2',
     author='Launchable, Inc.',
     url='https://launchableinc.com/',
@@ -24,6 +22,8 @@ setup(
     install_requires=_requirements('requirements.txt'),
     packages=find_packages(),
     package_data={'launchable': ['jar/exe_deploy.jar']},
+    setup_require=['setuptools_scm'],
+    use_scm_version=True,
     entry_points={
         'console_scripts': [
             'launchable = launchable.__main__:main',


### PR DESCRIPTION
We maintain two version representatives such as `/version.py` and [Git tags](https://github.com/launchableinc/cli/tags). This PR integrates them into Git tag via [setuptools_scm](https://pypi.org/project/setuptools-scm/).