### PR TITLE
Rename commands

### DIFF
--- a/launchable/commands/optimize/__init__.py
+++ b/launchable/commands/optimize/__init__.py
@@ -1,4 +1,4 @@
-from .test import test
+from .tests import tests
 import click
 
 
@@ -7,4 +7,4 @@ def optimize():
     pass
 
 
-optimize.add_command(test)
+optimize.add_command(tests)

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -37,7 +37,7 @@ from ...utils.token import parse_token
     type=str,
     metavar='BUILD_ID'
 )
-def test(test_paths, target, session_id, source, build_name):
+def tests(test_paths, target, session_id, source, build_name):
     token, org, workspace = parse_token()
 
     test_paths = [os.path.relpath(
@@ -73,3 +73,38 @@ def test(test_paths, target, session_id, source, build_name):
             raise e
         else:
             click.echo(e, err=True)
+
+@click.command(help="Subsetting tests")
+@click.argument('test_paths', required=True, nargs=-1)
+@click.option(
+    '--target',
+    'target',
+    help='subsetting target percentage 0.0-1.0',
+    required=True,
+    type=float,
+    default=0.8,
+)
+@click.option(
+    '--session',
+    'session_id',
+    help='Test session ID',
+    required=True,
+    type=int,
+)
+@click.option(
+    '--source',
+    help='repository district'
+    'REPO_DIST like --source . ',
+    metavar="REPO_NAME",
+)
+@click.option(
+    '--name',
+    'build_name',
+    help='build identifier',
+    required=True,
+    type=str,
+    metavar='BUILD_ID'
+)
+@click.pass_context
+def test(ctx, test_paths, target, session_id, source, build_name):
+    ctx.forward(tests)

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -74,6 +74,7 @@ def tests(test_paths, target, session_id, source, build_name):
         else:
             click.echo(e, err=True)
 
+# for backward compatibility
 @click.command(help="Subsetting tests")
 @click.argument('test_paths', required=True, nargs=-1)
 @click.option(
@@ -108,3 +109,4 @@ def tests(test_paths, target, session_id, source, build_name):
 @click.pass_context
 def test(ctx, test_paths, target, session_id, source, build_name):
     ctx.forward(tests)
+    

--- a/launchable/commands/record/__init__.py
+++ b/launchable/commands/record/__init__.py
@@ -1,6 +1,6 @@
 from .build import build
 from .commit import commit
-from .test import test
+from .tests import tests
 from .session import session
 import click
 
@@ -12,5 +12,5 @@ def record():
 
 record.add_command(build)
 record.add_command(commit)
-record.add_command(test)
+record.add_command(tests)
 record.add_command(session)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -39,7 +39,7 @@ from ...utils.env_keys import REPORT_ERROR_KEY
     required=True,
     type=int,
 )
-def test(xml_paths, path, build_name, source, session_id):
+def tests(xml_paths, path, build_name, source, session_id):
     token, org, workspace = parse_token()
 
     # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful
@@ -76,3 +76,37 @@ def test(xml_paths, path, build_name, source, session_id):
             raise e
         else:
             print(e)
+
+# for backward compatibility
+@click.command()
+@click.argument('xml_paths', required=True, nargs=-1)
+@click.option(
+    '--path',
+    help='Test result file path',
+    type=str
+)
+@click.option(
+    '--name',
+    'build_name',
+    help='build identifier',
+    required=True,
+    type=str,
+    metavar='BUILD_ID'
+)
+@click.option(
+    '--source',
+    help='repository district'
+    'REPO_DIST like --source . ',
+    default=".",
+    metavar="REPO_NAME",
+)
+@click.option(
+    '--session',
+    'session_id',
+    help='Test session ID',
+    required=True,
+    type=int,
+)
+@click.pass_context
+def test(ctx, xml_paths, path, build_name, source, session_id):
+    ctx.forward(tests)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -110,3 +110,4 @@ def tests(xml_paths, path, build_name, source, session_id):
 @click.pass_context
 def test(ctx, xml_paths, path, build_name, source, session_id):
     ctx.forward(tests)
+    


### PR DESCRIPTION
- Rename `launchable record test` to `launchable record tests`
- Rename `launchable optimize test` to `launchable optimize tests`
- Still keeping backward compatibility