### PR TITLE
Ignore session creation failure

### DIFF
--- a/launchable/commands/optimize/test.py
+++ b/launchable/commands/optimize/test.py
@@ -20,8 +20,8 @@ from ...utils.token import parse_token
     '--session',
     'session_id',
     help='Test session ID',
-    required=True,
     type=int,
+    required=os.getenv(REPORT_ERROR_KEY),
 )
 @click.option(
     '--source',
@@ -38,6 +38,12 @@ from ...utils.token import parse_token
     metavar='BUILD_ID'
 )
 def test(test_paths, target, session_id, source, build_name):
+    if not session_id:
+        # Session ID in --session is missing. It might be caused by Launchable API errors.
+        # The CLI surpress the error because it have to keep working CIs.
+        click.echo(" ".join(test_paths))
+        return
+
     token, org, workspace = parse_token()
 
     test_paths = [os.path.relpath(

--- a/launchable/commands/optimize/test.py
+++ b/launchable/commands/optimize/test.py
@@ -21,7 +21,7 @@ from ...utils.token import parse_token
     'session_id',
     help='Test session ID',
     type=int,
-    required=os.getenv(REPORT_ERROR_KEY),
+    required=os.getenv(REPORT_ERROR_KEY), # validate session_id under debug mode
 )
 @click.option(
     '--source',

--- a/launchable/commands/optimize/test.py
+++ b/launchable/commands/optimize/test.py
@@ -77,5 +77,4 @@ def test(test_paths, target, session_id, source, build_name):
         click.echo(" ".join(test_paths))
         if os.getenv(REPORT_ERROR_KEY):
             raise e
-        else:
-            click.echo(e, err=True)
+        

--- a/launchable/commands/optimize/test.py
+++ b/launchable/commands/optimize/test.py
@@ -40,7 +40,7 @@ from ...utils.token import parse_token
 def test(test_paths, target, session_id, source, build_name):
     if not session_id:
         # Session ID in --session is missing. It might be caused by Launchable API errors.
-        # The CLI surpress the error because it have to keep working CIs.
+        # The CLI surpress the error and return original test_paths because it have to keep working CIs.
         click.echo(" ".join(test_paths))
         return
 

--- a/launchable/commands/record/test.py
+++ b/launchable/commands/record/test.py
@@ -36,10 +36,14 @@ from ...utils.env_keys import REPORT_ERROR_KEY
     '--session',
     'session_id',
     help='Test session ID',
-    required=True,
+    required=os.getenv(REPORT_ERROR_KEY), # validate session_id under debug mode
     type=int,
 )
 def test(xml_paths, path, build_name, source, session_id):
+    if not session_id:
+        click.echo("Session ID in --session is missing. It might be caused by Launchable API errors.", err=True)
+        return
+
     token, org, workspace = parse_token()
 
     # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful


### PR DESCRIPTION
Current `record test` and `optimize test` require `session_id`. However, if Launchable API caused an error in the session creation phase, those commands would be failed. To keep working customer's CI, I modified the CLI to ignore missing session_id.