### PR TITLE
Better test runner support

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -1,9 +1,11 @@
 from .version import __version__
 import click
+import importlib
+from os.path import dirname, basename, join
+import glob
 from .commands.record import record
 from .commands.optimize import optimize
 from .commands.verify import verify
-
 
 @click.group()
 @click.version_option(version=__version__, prog_name='launchable-cli')
@@ -14,6 +16,13 @@ def main():
 main.add_command(record)
 main.add_command(optimize)
 main.add_command(verify)
+
+# load all test runners
+for f in glob.glob(join(dirname(__file__), 'test_runners', "*.py")):
+    f = basename(f)[:-3]
+    if f=='__init__':
+        continue
+    m = importlib.import_module('launchable.test_runners.%s' % f)
 
 if __name__ == '__main__':
     main()

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -2,7 +2,7 @@ from .version import __version__
 import click
 import importlib
 from os.path import dirname, basename, join
-import glob
+from glob import glob
 from .commands.record import record
 from .commands.optimize import optimize
 from .commands.verify import verify
@@ -11,7 +11,7 @@ from .commands.verify import verify
 @click.version_option(version=__version__, prog_name='launchable-cli')
 def main():
     # load all test runners
-    for f in glob.glob(join(dirname(__file__), 'test_runners', "*.py")):
+    for f in glob(join(dirname(__file__), 'test_runners', "*.py")):
         f = basename(f)[:-3]
         if f == '__init__':
             continue

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -10,19 +10,18 @@ from .commands.verify import verify
 @click.group()
 @click.version_option(version=__version__, prog_name='launchable-cli')
 def main():
-    pass
+    # load all test runners
+    for f in glob.glob(join(dirname(__file__), 'test_runners', "*.py")):
+        f = basename(f)[:-3]
+        if f == '__init__':
+            continue
+        importlib.import_module('launchable.test_runners.%s' % f)
 
 
 main.add_command(record)
 main.add_command(optimize)
 main.add_command(verify)
 
-# load all test runners
-for f in glob.glob(join(dirname(__file__), 'test_runners', "*.py")):
-    f = basename(f)[:-3]
-    if f=='__init__':
-        continue
-    m = importlib.import_module('launchable.test_runners.%s' % f)
 
 if __name__ == '__main__':
     main()

--- a/launchable/commands/optimize/__init__.py
+++ b/launchable/commands/optimize/__init__.py
@@ -1,13 +1,12 @@
 from .tests import tests
 import click
+from launchable.utils.click import GroupWithAlias
 
 
-@click.group()
+@click.group(cls=GroupWithAlias)
 def optimize():
     pass
 
 
 optimize.add_command(tests)
-
-# for backward compatibility
-optimize.add_command(tests, name="test")
+optimize.add_alias('test',tests)    # for backward compatibility

--- a/launchable/commands/optimize/__init__.py
+++ b/launchable/commands/optimize/__init__.py
@@ -8,3 +8,6 @@ def optimize():
 
 
 optimize.add_command(tests)
+
+# for backward compatibility
+optimize.add_command(tests, name="test")

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -74,8 +74,7 @@ def tests(context, target, session_id, source, build_name):
                 - post-process the matching file names, by returning a string, or
                 - skip items by returning a False-like object
             """
-            itr = glob.iglob(os.path.join(base, pattern), recursive=True)
-            while t := next(itr,False):
+            for t in glob.iglob(os.path.join(base, pattern), recursive=True):
                 t = t[len(base)+1:] # drop the base portion
                 t = filter(t)
                 if t:

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -1,82 +1,13 @@
 import click
 import json
-import os
+import os, glob
+from typing import Callable
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from ...utils.token import parse_token
 
 
-@click.command(help="Subsetting tests")
-@click.argument('test_paths', required=True, nargs=-1)
-@click.option(
-    '--target',
-    'target',
-    help='subsetting target percentage 0.0-1.0',
-    required=True,
-    type=float,
-    default=0.8,
-)
-@click.option(
-    '--session',
-    'session_id',
-    help='Test session ID',
-    required=True,
-    type=int,
-)
-@click.option(
-    '--source',
-    help='repository district'
-    'REPO_DIST like --source . ',
-    metavar="REPO_NAME",
-)
-@click.option(
-    '--name',
-    'build_name',
-    help='build identifier',
-    required=True,
-    type=str,
-    metavar='BUILD_ID'
-)
-def tests(test_paths, target, session_id, source, build_name):
-    token, org, workspace = parse_token()
-
-    test_paths = [os.path.relpath(
-        path, start=source) if source else path for path in test_paths]
-
-    try:
-        headers = {
-            "Content-Type": "application/json",
-        }
-
-        payload = {
-            "testNames": test_paths,
-            "target": target,
-            "session": {
-                "id": session_id
-            }
-        }
-
-        path = "/intake/organizations/{}/workspaces/{}/subset".format(
-            org, workspace)
-
-        client = LaunchableClient(token)
-        res = client.request("post", path, data=json.dumps(
-            payload).encode(), headers=headers)
-        res.raise_for_status()
-
-        subsetted_paths = res.json()["testNames"]
-        click.echo(" ".join(subsetted_paths))
-    except Exception as e:
-        # When Error occurs, return the test name as it is passed.
-        click.echo(" ".join(test_paths))
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(e, err=True)
-
-# for backward compatibility
-@click.command(help="Subsetting tests")
-@click.argument('test_paths', required=True, nargs=-1)
+@click.group(help="Subsetting tests")
 @click.option(
     '--target',
     'target',
@@ -107,6 +38,85 @@ def tests(test_paths, target, session_id, source, build_name):
     metavar='BUILD_ID'
 )
 @click.pass_context
-def test(ctx, test_paths, target, session_id, source, build_name):
-    ctx.forward(tests)
-    
+def tests(context, target, session_id, source, build_name):
+    token, org, workspace = parse_token()
+
+    # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
+    # PR merge hell. This should be moved to a top-level class
+    class Optimize:
+        def __init__(self):
+            self.tests = []
+            self._formatter = lambda x: x
+
+        @property
+        def formatter(self) -> Callable[[str], str]:
+            """
+            This function, if supplied, is used to format test names
+            from the format Launchable uses to the format test runners expect.
+            """
+            return self._formatter
+
+        @formatter.setter
+        def formatter(self, v):
+            self._formatter = v
+
+        def test(self, name):
+            """register one test"""
+            self.tests.append(name)
+
+        def scan(self, base, pattern, filter=(lambda x: x)):
+            """
+            Starting at the 'base' path, recursively add everything that matches the given GLOB pattern
+
+            glob('src/test/java', '**/*.java')
+
+            'filter' argument can be used to:
+                - post-process the matching file names, by returning a string, or
+                - skip items by returning a False-like object
+            """
+            itr = glob.iglob(os.path.join(base, pattern), recursive=True)
+            while t := next(itr,False):
+                t = t[len(base)+1:] # drop the base portion
+                t = filter(t)
+                if t:
+                    self.test(t)
+
+        def run(self):
+            """called after tests are scanned to compute the optimized order"""
+
+            # When Error occurs, return the test name as it is passed.
+            output = self.tests
+
+            try:
+                headers = {
+                    "Content-Type": "application/json",
+                }
+
+                payload = {
+                    "testNames": self.tests,
+                    "target": target,
+                    "session": {
+                        "id": session_id
+                    }
+                }
+
+                path = "/intake/organizations/{}/workspaces/{}/subset".format(
+                    org, workspace)
+
+                client = LaunchableClient(token)
+                res = client.request("post", path, data=json.dumps(
+                    payload).encode(), headers=headers)
+                res.raise_for_status()
+
+                output = res.json()["testNames"]
+            except Exception as e:
+                if os.getenv(REPORT_ERROR_KEY):
+                    raise e
+                else:
+                    click.echo(e, err=True)
+
+            for t in output:
+                click.echo(self.formatter(t))
+
+    context.obj = Optimize()
+

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -68,7 +68,7 @@ def tests(context, target, session_id, source, build_name):
             """
             Starting at the 'base' path, recursively add everything that matches the given GLOB pattern
 
-            glob('src/test/java', '**/*.java')
+            scan('src/test/java', '**/*.java')
 
             'filter' argument can be used to:
                 - post-process the matching file names, by returning a string, or

--- a/launchable/commands/record/__init__.py
+++ b/launchable/commands/record/__init__.py
@@ -3,9 +3,10 @@ from .commit import commit
 from .tests import tests
 from .session import session
 import click
+from launchable.utils.click import GroupWithAlias
 
 
-@click.group()
+@click.group(cls=GroupWithAlias)
 def record():
     pass
 
@@ -13,4 +14,5 @@ def record():
 record.add_command(build)
 record.add_command(commit)
 record.add_command(tests)
+record.add_alias('test',tests)    # for backward compatibility
 record.add_command(session)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -1,7 +1,7 @@
 import click
 import json
 from itertools import chain
-import os
+import os, glob
 from junitparser import JUnitXml, Failure, Error, Skipped, TestSuite, TestCase
 
 from .case_event import CaseEvent
@@ -11,12 +11,6 @@ from ...utils.env_keys import REPORT_ERROR_KEY
 
 
 @click.group()
-@click.argument('xml_paths', required=True, nargs=-1)
-@click.option(
-    '--path',
-    help='Test result file path',
-    type=str
-)
 @click.option(
     '--name',
     'build_name',
@@ -39,40 +33,63 @@ from ...utils.env_keys import REPORT_ERROR_KEY
     required=True,
     type=int,
 )
-def tests(xml_paths, path, build_name, source, session_id):
-    token, org, workspace = parse_token()
+@click.pass_context
+def tests(context, build_name, source, session_id):
+    # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
+    # PR merge hell. This should be moved to a top-level class
+    class RecordTests:
+        def __init__(self):
+            self.reports = []
 
-    # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful
-    xmls = [JUnitXml.fromfile(p) for p in xml_paths]
-    testsuites = []
-    for xml in xmls:
-        if isinstance(xml, JUnitXml):
-            testsuites += [suite for suite in xml]
-        elif isinstance(xml, TestSuite):
-            testsuites.append(xml)
+        def report(self, junit_report_file:str):
+            """Add one report file by its path name"""
+            self.reports.append(junit_report_file)
 
-    events = list(chain.from_iterable([CaseEvent.from_case_and_suite(case, suite, source).to_json()
-                                       for case in suite] for suite in testsuites))
+        def scan(self, base, pattern):
+            """
+            Starting at the 'base' path, recursively add everything that matches the given GLOB pattern
 
-    headers = {
-        "Content-Type": "application/json",
-    }
+            scan('build/test-reports', '**/*.xml')
+            """
+            for t in glob.iglob(os.path.join(base, pattern), recursive=True):
+                self.report(t)
 
-    client = LaunchableClient(token)
+        def run(self):
+            token, org, workspace = parse_token()
 
-    try:
-        payload = {"events": events}
-        print(payload)
-        case_path = "/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/events".format(
-            org, workspace, build_name, session_id)
-        res = client.request("post", case_path, data=json.dumps(
-            payload).encode(), headers=headers)
-        res.raise_for_status()
+            # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful
+            xmls = [JUnitXml.fromfile(p) for p in self.reports]
+            testsuites = []
+            for xml in xmls:
+                if isinstance(xml, JUnitXml):
+                    testsuites += [suite for suite in xml]
+                elif isinstance(xml, TestSuite):
+                    testsuites.append(xml)
 
-        print(res.status_code)
+            events = list(chain.from_iterable([CaseEvent.from_case_and_suite(case, suite, source).to_json()
+                                               for case in suite] for suite in testsuites))
 
-    except Exception as e:
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            print(e)
+            headers = {
+                "Content-Type": "application/json",
+            }
+
+            client = LaunchableClient(token)
+
+            try:
+                payload = {"events": events}
+                print(payload)
+                case_path = "/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/events".format(
+                    org, workspace, build_name, session_id)
+                res = client.request("post", case_path, data=json.dumps(
+                    payload).encode(), headers=headers)
+                res.raise_for_status()
+
+                print(res.status_code)
+
+            except Exception as e:
+                if os.getenv(REPORT_ERROR_KEY):
+                    raise e
+                else:
+                    print(e)
+
+    context.obj = RecordTests()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -76,37 +76,3 @@ def tests(xml_paths, path, build_name, source, session_id):
             raise e
         else:
             print(e)
-
-# for backward compatibility
-@click.command()
-@click.argument('xml_paths', required=True, nargs=-1)
-@click.option(
-    '--path',
-    help='Test result file path',
-    type=str
-)
-@click.option(
-    '--name',
-    'build_name',
-    help='build identifier',
-    required=True,
-    type=str,
-    metavar='BUILD_ID'
-)
-@click.option(
-    '--source',
-    help='repository district'
-    'REPO_DIST like --source . ',
-    default=".",
-    metavar="REPO_NAME",
-)
-@click.option(
-    '--session',
-    'session_id',
-    help='Test session ID',
-    required=True,
-    type=int,
-)
-@click.pass_context
-def test(ctx, xml_paths, path, build_name, source, session_id):
-    ctx.forward(tests)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -10,7 +10,7 @@ from ...utils.token import parse_token
 from ...utils.env_keys import REPORT_ERROR_KEY
 
 
-@click.command()
+@click.group()
 @click.argument('xml_paths', required=True, nargs=-1)
 @click.option(
     '--path',
@@ -110,4 +110,3 @@ def tests(xml_paths, path, build_name, source, session_id):
 @click.pass_context
 def test(ctx, xml_paths, path, build_name, source, session_id):
     ctx.forward(tests)
-    

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -25,3 +25,5 @@ def record_tests(client, workspace):
     for xml in glob.iglob(join(base, '**/test.xml'), recursive=True):
         pkg = xml[len(base)+1:-8]    # extract the part that matches '**' which represents the pacakge
         client.scan(xml, pkg)  # TODO: how we do this depends on how we design this abstraction
+
+    client.run()

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -1,0 +1,27 @@
+import click, sys, os, glob
+from . import launchable
+from os.path import join
+
+@launchable.test_scanner
+def scan_tests(optimize):
+    # Read targets from stdin, which generally looks like //foo/bar:zot
+    for pkg in sys.stdin:
+        # //foo/bar:zot -> foo/bar/zot
+        optimize.test(pkg.lstrip('/').replace(':','/'))
+
+    optimize.run()
+
+
+
+@click.argument('workspace', required=True)
+@launchable.report_scanner
+def scan_reports(scanner, workspace):
+    """
+    Takes Bazel workspace, then report all its test results
+    """
+    base = join(workspace, 'bazel-testlogs')
+    if not os.path.exists(base):
+        exit("No such directory: %s" % base)
+    for xml in glob.iglob(join(base, '**/test.xml'), recursive=True):
+        pkg = xml[len(base)+1:-8]    # extract the part that matches '**' which represents the pacakge
+        scanner.scan(xml, pkg)  # TODO: how we do this depends on how we design this abstraction

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -2,20 +2,20 @@ import click, sys, os, glob
 from . import launchable
 from os.path import join
 
-@launchable.test_scanner
-def scan_tests(optimize):
+@launchable.optimize.tests
+def optimize_tests(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
     for pkg in sys.stdin:
         # //foo/bar:zot -> foo/bar/zot
-        optimize.test(pkg.lstrip('/').replace(':','/'))
+        client.test(pkg.lstrip('/').replace(':', '/'))
 
-    optimize.run()
+    client.run()
 
 
 
 @click.argument('workspace', required=True)
-@launchable.report_scanner
-def scan_reports(scanner, workspace):
+@launchable.record.tests
+def record_tests(client, workspace):
     """
     Takes Bazel workspace, then report all its test results
     """
@@ -24,4 +24,4 @@ def scan_reports(scanner, workspace):
         exit("No such directory: %s" % base)
     for xml in glob.iglob(join(base, '**/test.xml'), recursive=True):
         pkg = xml[len(base)+1:-8]    # extract the part that matches '**' which represents the pacakge
-        scanner.scan(xml, pkg)  # TODO: how we do this depends on how we design this abstraction
+        client.scan(xml, pkg)  # TODO: how we do this depends on how we design this abstraction

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -6,16 +6,16 @@ from . import launchable
 
 
 @click.argument('tests', required=True, nargs=-1)
-@launchable.test_scanner
-def scan_tests(optimize, tests):
+@launchable.optimize.tests
+def optimize_tests(client, tests):
     # TODO: I think it's better to read tests from stdin
     for t in tests:
-        optimize.test(t)
-    optimize.run()
+        client.test(t)
+    client.run()
 
 
 @click.argument('source_roots', required=True, nargs=-1)
-@launchable.report_scanner
-def scan_reports(scanner, source_roots):
+@launchable.record.tests
+def record_tests(client, source_roots):
     for root in source_roots:
-        scanner.scan(root, '*.xml')
+        client.scan(root, '*.xml')

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -14,8 +14,9 @@ def optimize_tests(client, tests):
     client.run()
 
 
-@click.argument('source_roots', required=True, nargs=-1)
+@click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
-def record_tests(client, source_roots):
-    for root in source_roots:
-        client.scan(root, '*.xml')
+def record_tests(client, reports):
+    for r in reports:
+        client.report(r)
+    client.run()

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -1,0 +1,20 @@
+#
+# The most bare-bone versions of the test runner support
+#
+import click
+from . import launchable
+
+
+@click.argument('tests', required=True, nargs=-1)
+@launchable.test_scanner
+def scan_tests(optimize, tests):
+    for t in tests:
+        optimize.test(t)
+    optimize.run()
+
+
+@click.argument('source_roots', required=True, nargs=-1)
+@launchable.report_scanner
+def scan_reports(scanner, source_roots):
+    for root in source_roots:
+        scanner.scan(root, '*.xml')

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -8,6 +8,7 @@ from . import launchable
 @click.argument('tests', required=True, nargs=-1)
 @launchable.test_scanner
 def scan_tests(optimize, tests):
+    # TODO: I think it's better to read tests from stdin
     for t in tests:
         optimize.test(t)
     optimize.run()

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,0 +1,28 @@
+import click, os
+from . import launchable
+
+print("Loading gradle support")
+
+@click.argument('source_roots', required=True, nargs=-1)
+@launchable.test_scanner
+def scan_tests(optimize, source_roots):
+    def file2test(f:str):
+        if f.endswith('.java') or f.endswith('.scala') or f.endswith('.kt'):
+            f = f[:f.rindex('.')]   # remove extension
+            f = f.replace(os.path.sep,'.')  # directory -> package name conversion
+            return f
+        else:
+            return None
+
+    for root in source_roots:
+        optimize.scan(root, '**/*', file2test)
+
+    optimize.run()
+
+
+
+@click.argument('source_roots', required=True, nargs=-1)
+@launchable.report_scanner
+def scan_reports(scanner, source_roots):
+    for root in source_roots:
+        scanner.scan(root,"*.xml")

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -24,3 +24,4 @@ def optimize_tests(client, source_roots):
 def record_tests(client, source_roots):
     for root in source_roots:
         client.scan(root, "*.xml")
+    client.run()

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,8 +1,6 @@
 import click, os
 from . import launchable
 
-print("Loading gradle support")
-
 @click.argument('source_roots', required=True, nargs=-1)
 @launchable.test_scanner
 def scan_tests(optimize, source_roots):

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -2,8 +2,8 @@ import click, os
 from . import launchable
 
 @click.argument('source_roots', required=True, nargs=-1)
-@launchable.test_scanner
-def scan_tests(optimize, source_roots):
+@launchable.optimize.tests
+def optimize_tests(client, source_roots):
     def file2test(f:str):
         if f.endswith('.java') or f.endswith('.scala') or f.endswith('.kt'):
             f = f[:f.rindex('.')]   # remove extension
@@ -13,14 +13,14 @@ def scan_tests(optimize, source_roots):
             return None
 
     for root in source_roots:
-        optimize.scan(root, '**/*', file2test)
+        client.scan(root, '**/*', file2test)
 
-    optimize.run()
+    client.run()
 
 
 
 @click.argument('source_roots', required=True, nargs=-1)
-@launchable.report_scanner
-def scan_reports(scanner, source_roots):
+@launchable.record.tests
+def record_tests(client, source_roots):
     for root in source_roots:
-        scanner.scan(root,"*.xml")
+        client.scan(root, "*.xml")

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -1,0 +1,28 @@
+import click
+from launchable.commands.optimize.tests import tests as optimize_tests
+from launchable.commands.record.tests import tests as record_tests
+
+def cmdname(f):
+    """figure out the sub-command name from a test runner function"""
+
+    # a.b.cde -> cde
+    m = f.__module__
+    return m[m.rindex('.')+1:]
+
+def wrap(f, group):
+    """
+    Wraps a 'plugin' function into a click command and registers it to the given group.
+
+    a plugin function receives the scanner object in its first argument
+    """
+    d = click.command(name=cmdname(f))
+    cmd = d(click.pass_obj(f))
+    group.add_command(cmd)
+    return cmd
+
+
+def test_scanner(f):
+    return wrap(f, optimize_tests)
+
+def report_scanner(f):
+    return wrap(f, record_tests)

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -1,6 +1,7 @@
 import click
-from launchable.commands.optimize.tests import tests as optimize_tests
-from launchable.commands.record.tests import tests as record_tests
+import types
+from launchable.commands.optimize.tests import tests as optimize_tests_cmd
+from launchable.commands.record.tests import tests as record_tests_cmd
 
 def cmdname(f):
     """figure out the sub-command name from a test runner function"""
@@ -21,8 +22,8 @@ def wrap(f, group):
     return cmd
 
 
-def test_scanner(f):
-    return wrap(f, optimize_tests)
+optimize = types.SimpleNamespace()
+optimize.tests = lambda f: wrap(f, optimize_tests_cmd)
 
-def report_scanner(f):
-    return wrap(f, record_tests)
+record = types.SimpleNamespace()
+record.tests = lambda f: wrap(f, record_tests_cmd)

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -1,0 +1,14 @@
+import click
+
+# click.Group has the notion of hidden commands but it doesn't allow us to easily add
+# the same command under multiple names and hide all but one.
+class GroupWithAlias(click.Group):
+    def __init__(self, name=None, commands=None, **attrs):
+        super().__init__(name, commands, **attrs)
+        self.aliases = {}
+
+    def get_command(self, ctx, cmd_name):
+        return super().get_command(ctx, cmd_name) or self.aliases.get(cmd_name)
+
+    def add_alias(self, name, cmd):
+        self.aliases[name] = cmd


### PR DESCRIPTION
Based on our discussion Friday, here is my first shot at the extensibility to enable rapidly supporting lots of test runners with minimal effort.

# User Experience
From the user experience perspective, the key change here is to introduce one more layer of sub-command in `launchable optimize tests`. For example,
```
launchable optimize tests --target ... --session ... gradle path/to/testRoots
```
This will scan a directory recursively, find `*.java`, and massage file names to test names.

Another key story of the extensibility is that people who use "other" test runners can directly access our underlying capability, which is exposed as 'generic':
```
launchable optimize tests <options> generic test1 test2 test3
```

# Developer Experience
`test_runners` directory is meant to be the extensibility point. This is the directory where people who are relatively unfamiliar with Launchable CLI can come in and add test runner support rapidly by monkey-see-monkey-do.

Each test runner support consists of two functions. One is to decorate `launchable optimize tests` and the other is to decorate `launchable record tests`. They both use Click style functions, but the key addition is that they get an object that represents the underlying capability.

Because the primary purpose of this PR is to show the design intent, I've only implemented this so far for the `optimize tests` side. But hopefully it's easy to see the design and replicate that on the `record tests` side.

I'd imagine we'd define a number of stereotypical scan methods as Python decorators, for example one that takes directories as arguments, scan them, filter them, then optionally transform file names.
