### PR TITLE
Pushed test name handling forward.

### DIFF
--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -46,7 +46,7 @@ def tests(context, target, session_id, source, build_name):
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class
     class Optimize:
-        test_paths: List[TestPath]
+        # test_paths: List[TestPath]  # doesn't work with Python 3.5
 
         # Where we take TestPath, we also accept a path name as a string.
         TestPathLike = Union[str,TestPath]

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -80,7 +80,7 @@ def tests(context, target, session_id, source, build_name):
             else:
                 return x
 
-        def scan(self, base: str, pattern: str, path_builder: Callable[[str], Union[TestPath, str]] = lambda x:x):
+        def scan(self, base: str, pattern: str, path_builder: Callable[[str], Union[TestPath, str, None]] = lambda x:x):
             """
             Starting at the 'base' path, recursively add everything that matches the given GLOB pattern
 

--- a/launchable/commands/optimize/tests.py
+++ b/launchable/commands/optimize/tests.py
@@ -53,7 +53,9 @@ def tests(context, target, session_id, source, build_name):
 
         def __init__(self):
             self.test_paths = []
-            self._formatter = lambda x: x
+            # default formatter t hat's in line with to_test_path(str)
+            # TODO: robustness improvement.
+            self._formatter = lambda x: x[0]['name']
 
         @property
         def formatter(self) -> Callable[[TestPath], str]:

--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -1,7 +1,8 @@
 import datetime
-from junitparser import JUnitXml, Failure, Error, Skipped, TestCase
 import os
-
+from typing import Callable, Dict
+from junitparser import JUnitXml, Failure, Error, Skipped, TestCase, TestSuite
+from ...testpath import TestPath
 
 class CaseEvent:
     EVENT_TYPE = "case"
@@ -9,55 +10,48 @@ class CaseEvent:
     TEST_PASSED = 1
     TEST_FAILED = 0
 
+    # function that computes TestPath from a test case
+    # The 3rd argument is the report file path
+    TestPathBuilder = Callable[[TestCase,TestSuite,str], TestPath]
+
+    @staticmethod
+    def default_path_builder(base_path) -> TestPathBuilder:
+        """
+        Obtains a default TestPathBuilder that uses a base directory to relativize the file name
+        """
+
+        def f(case: TestCase, suite: TestSuite, report_file: str) -> TestPath:
+            classname = case.classname or suite._elem.attrib.get("classname")
+            filepath = case._elem.attrib.get("file") or suite._elem.attrib.get("filepath")
+            if filepath:
+                filepath = os.path.relpath(filepath, start=base_path),
+
+            test_path = []
+            if classname:
+                test_path.append({"type": "class", "name": classname})
+            if filepath:
+                test_path.append({"type": "file", "name": filepath})
+            if case.name:
+                test_path.append(
+                    {"type": "testcase", "name": case.name, "_lineno": case._elem.attrib.get("lineno")})
+            return test_path
+
+        return f
+
     @classmethod
-    def from_case_and_suite(cls, case, suite, base_path):
+    def from_case_and_suite(cls, path_builder: TestPathBuilder, case: TestCase, suite: TestSuite, report_file:str, data: Dict = None) -> Dict:
+        "Builds a JSON representation of CaseEvent"
+
         status = CaseEvent.TEST_FAILED if case.result and any(isinstance(case.result, s) for s in (
             Failure, Error)) else CaseEvent.TEST_SKIPPED if isinstance(case.result, Skipped) else CaseEvent.TEST_PASSED
-        filepath = case._elem.attrib.get(
-            "file") or suite._elem.attrib.get("filepath")
-        if filepath:
-            filepath = os.path.relpath(filepath, start=base_path),
-        return CaseEvent(
-            case.name,
-            case.time,
-            status,
-            case.system_out or "",
-            case.system_err or "",
-            suite.timestamp,
-            case.classname or suite._elem.attrib.get("classname"),
-            filepath,
-            case._elem.attrib.get("lineno")
-        )
 
-    def __init__(self, test_name, duration, status, stdout, stderr, timestamp, classname=None, filename=None, lineno=None):
-        self.testName = test_name
-        self.duration = duration
-        self.status = status
-        self.stdout = stdout
-        self.stderr = stderr
-        self.created_at = timestamp or datetime.datetime.now(
-            datetime.timezone.utc).isoformat()
-
-        self.data = {}
-        test_path = []
-        if classname:
-            test_path.append({"type": "class", "name": classname})
-        if filename:
-            test_path.append({"type": "file", "name": filename})
-        if test_name:
-            test_path.append(
-                {"type": "testcase", "name": test_name, "lineno": lineno})
-
-        self.data["test_paths"] = test_path
-
-    def to_json(self):
         return {
-            "type": self.EVENT_TYPE,
-            "testName": self.testName,
-            "duration": self.duration,
-            "status": self.status,
-            "stdout": self.stdout,
-            "stderr": self.stderr,
-            "created_at": self.created_at,
-            "data": self.data
+            "type": cls.EVENT_TYPE,
+            "testName": path_builder(case, suite, report_file),
+            "duration": case.time,
+            "status": status,
+            "stdout": case.system_out or "",
+            "stderr": case.system_err or "",
+            "created_at": suite.timestamp or datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "data": data
         }

--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -47,7 +47,7 @@ class CaseEvent:
 
         return {
             "type": cls.EVENT_TYPE,
-            "testName": path_builder(case, suite, report_file),
+            "testPath": path_builder(case, suite, report_file),
             "duration": case.time,
             "status": status,
             "stdout": case.system_out or "",

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -87,7 +87,6 @@ def tests(context, build_name, source, session_id):
                     # TODO: robustness: what's the best way to deal with broken XML file, if any?
                     xml = JUnitXml.fromfile(p)
 
-                    testsuites: List[TestSuite]
                     if isinstance(xml, JUnitXml):
                         testsuites = [suite for suite in xml]
                     elif isinstance(xml, TestSuite):

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -20,7 +20,6 @@ def optimize_tests(client):
         pkg,target = label.split(':')
         # TODO: error checks and more robustness
 
-        # TODO: This test path naming "build" may need to be revisited.
         client.test_path(make_test_path(pkg, target))
 
     client.run()
@@ -41,6 +40,7 @@ def record_tests(client, workspace):
     def f(case: TestCase, suite: TestSuite, report_file: str) -> TestPath:
         # In Bazel, report path name contains package & target.
         # for example, for //foo/bar:zot, the report file is at bazel-testlogs/foo/bar/zot/test.xml
+        # TODO: robustness
         pkgNtarget = report_file[len(base)+1:-len("/test.xml")]
 
         # last path component is the target, the rest is package
@@ -53,6 +53,6 @@ def record_tests(client, workspace):
 
     client.path_builder = f
 
-    client.scan(base, '**/test/xml')
+    client.scan(base, '**/test.xml')
 
     client.run()

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -10,7 +10,7 @@ from . import launchable
 def optimize_tests(client, tests):
     # TODO: I think it's better to read tests from stdin
     for t in tests:
-        client.test_path([{ 'type': 'file', 'name': t }])
+        client.test_path(t)
     client.run()
 
 

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -2,14 +2,13 @@
 # The most bare-bone versions of the test runner support
 #
 import click
+import sys
 from . import launchable
 
 
-@click.argument('tests', required=True, nargs=-1)
 @launchable.optimize.tests
-def optimize_tests(client, tests):
-    # TODO: I think it's better to read tests from stdin
-    for t in tests:
+def optimize_tests(client):
+    for t in sys.stdin:
         client.test_path(t)
     client.run()
 

--- a/launchable/test_runners/generic.py
+++ b/launchable/test_runners/generic.py
@@ -8,6 +8,7 @@ from . import launchable
 
 @launchable.optimize.tests
 def optimize_tests(client):
+    # read lines as test file names
     for t in sys.stdin:
         client.test_path(t)
     client.run()
@@ -16,6 +17,9 @@ def optimize_tests(client):
 @click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, reports):
+    # here we are implicitly assuming that test reports we read, combined with the default path builder,
+    # produces test names that aligned with what `optimize_tests` function does above.
+    # TODO: use a custom path builder to ensure this is always the case. This is too fragile.
     for r in reports:
         client.report(r)
     client.run()

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -10,8 +10,8 @@ def optimize_tests(client, source_roots):
         if f.endswith('.java') or f.endswith('.scala') or f.endswith('.kt'):
             f = f[:f.rindex('.')]   # remove extension
             # directory -> package name conversion
-            f = f.replace(os.path.sep, '.')
-            return f
+            cls_name = f.replace(os.path.sep, '.')
+            return [{"type": "class", "name": cls_name}]
         else:
             return None
 

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -1,0 +1,39 @@
+import click
+import os, sys
+from . import launchable
+
+
+@click.argument('files', required=True, nargs=-1)
+@launchable.optimize.tests
+def optimize_tests(client, files):
+    def parse(fname:str):
+        '''
+        Scan a file, directory full of *.rb, or @FILE
+        '''
+        if os.path.isdir(fname):
+            client.scan(fname, '**/*.rb')
+        elif fname=='@-':
+            # read stdin
+            for l in sys.stdin:
+                parse(l)
+        elif fname.startswith('@'):
+            # read response file
+            with open(fname[1:]) as f:
+                for l in f:
+                    parse(l)
+        else:
+            # assume it's a file
+            client.test(fname)
+
+    for f in files:
+        parse(f)
+
+    client.run()
+
+
+@click.argument('report_dirs', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, report_dirs):
+    for root in report_dirs:
+        client.scan(root, "*.xml")
+    client.run()

--- a/launchable/testpath.py
+++ b/launchable/testpath.py
@@ -1,0 +1,10 @@
+from typing import Dict, List
+
+# Path component is a node in a tree.
+# It's the equivalent of a short file/directory name in a file system.
+# In our abstraction, it's represented as arbitrary bag of attributes
+TestPathComponent = Dict[str,str]
+
+# TestPath is a full path to a node in a tree from the root
+# It's the equivalent of an absolute file name in a file system
+TestPath = List[TestPathComponent]


### PR DESCRIPTION
In both `optimize tests` and `record tests`, tests are identified by their test paths.

Introduced an abstraction in the client to build test paths. For `optimize tests`, Optimize still access a string that looks like a file
name and builds a default test path. But this is currently not aligned with what `record tests` do, so something needs to change.

Bazel implementation & Gradle is now complete, and it demonstrates why this change was needed in the first place --- test paths reported by `record tests` should be a sub-path of those used by `optimize tests`

# Other improvements
* Robustness: `optimize tests generic` to read tests from stdin

# Next Steps

- [x] demonstrates Mini Test binding
- [ ] Writing some unit tests. How?
- [x] Update the server side