### PR TITLE
Revive base path

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -97,6 +97,7 @@ def subset(context, target, session_id, source, build_name):
                 - if a TestPath is returned, that's added as is
             """
             for t in glob.iglob(os.path.join(base, pattern), recursive=True):
+                t = os.path.normpath(os.path.relpath(t, start=source)) if source else t
                 t = path_builder(t)
                 if t:
                     self.test_paths.append(self.to_test_path(t))

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -97,7 +97,6 @@ def subset(context, target, session_id, source, build_name):
                 - if a TestPath is returned, that's added as is
             """
             for t in glob.iglob(os.path.join(base, pattern), recursive=True):
-                t = t[len(base) + 1:]  # drop the base portion
                 t = path_builder(t)
                 if t:
                     self.test_paths.append(self.to_test_path(t))

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -1,6 +1,7 @@
 import click
 import json
 import os
+from os.path import *
 import glob
 from typing import Callable, Union
 from ..utils.click import PERCENTAGE
@@ -28,10 +29,10 @@ from ..testpath import TestPath
     required=os.getenv(REPORT_ERROR_KEY),  # validate session_id under debug mode
 )
 @click.option(
-    '--source',
-    help='repository district'
-         'REPO_DIST like --source . ',
-    metavar="REPO_NAME",
+    '--base',
+    'base_path',
+    help='(Advanced) base directory to make test names portable',
+    metavar="PATH",
 )
 @click.option(
     '--name',
@@ -42,7 +43,7 @@ from ..testpath import TestPath
     metavar='BUILD_ID'
 )
 @click.pass_context
-def subset(context, target, session_id, source, build_name):
+def subset(context, target, session_id, base_path, build_name):
     token, org, workspace = parse_token()
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
@@ -55,9 +56,17 @@ def subset(context, target, session_id, source, build_name):
 
         def __init__(self):
             self.test_paths = []
-            # default formatter t hat's in line with to_test_path(str)
             # TODO: robustness improvement.
-            self._formatter = lambda x: x[0]['name']
+            self._formatter = Optimize.default_formatter
+
+        @staticmethod
+        def default_formatter(x: TestPath):
+            """default formatter that's in line with to_test_path(str)"""
+            file_name = x[0]['name']
+            if base_path:
+                # default behavior consistent with default_path_builder's relative path handling
+                file_name = join(base_path, file_name)
+            return file_name
 
         @property
         def formatter(self) -> Callable[[TestPath], str]:
@@ -84,21 +93,34 @@ def subset(context, target, session_id, source, build_name):
             else:
                 return x
 
-        def scan(self, base: str, pattern: str, path_builder: Callable[[str], Union[TestPath, str, None]] = lambda x:x):
+        def scan(self, base: str, pattern: str, path_builder: Callable[[str], Union[TestPath, str, None]] = None):
             """
             Starting at the 'base' path, recursively add everything that matches the given GLOB pattern
 
             scan('src/test/java', '**/*.java')
 
-            'path_builder' argument is used to map file name into a custom test path:
+            'path_builder' is a function used to map file name into a custom test path.
+            It takes a single string argument that represents the portion matched to the glob pattern,
+            and its return value controls what happens to that file:
                 - skip a file by returning a False-like object
                 - if a str is returned, that's interpreted as a path name and
-                  converted to the default test path representation
+                  converted to the default test path representation. Typically, `os.path.join(base,file_name)
                 - if a TestPath is returned, that's added as is
             """
-            for t in glob.iglob(os.path.join(base, pattern), recursive=True):
-                t = os.path.normpath(os.path.relpath(t, start=source)) if source else t
-                t = path_builder(t)
+
+            if path_builder==None:
+                # default implementation of path_builder creates a file name relative to `source` so as not
+                # to be affected by the path
+                def default_path_builder(file_name):
+                    file_name = join(base, file_name)
+                    if base_path:
+                        # relativize against `base_path` to make the path name portable
+                        file_name = normpath(relpath(file_name, start=base_path))
+                    return file_name
+                path_builder = default_path_builder
+
+            for t in glob.iglob(join(base, pattern), recursive=True):
+                t = path_builder(t[len(base)+1:])
                 if t:
                     self.test_paths.append(self.to_test_path(t))
 


### PR DESCRIPTION
Current implementation drops the base file path. For example, if you specify `launchable optimize minitest tests`, the command outputs `models/open_class_user_test.rb` without `test` directory.  However, minitest needs full path such as `test/models/open_class_user_test.rb` to test run.  That is why I deleted the line removing a base path component. Instead of the line, I added file path normalization with`sourc option.