### PR TITLE
Add bazel subset formatter

### DIFF
--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -17,7 +17,7 @@ def optimize_tests(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
     for label in sys.stdin:
         # //foo/bar:zot -> //foo/bar & zot
-        pkg,target = label.split(':')
+        pkg,target = label.rstrip('\n').split(':')
         # TODO: error checks and more robustness
 
         client.test_path(make_test_path(pkg, target))

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -17,10 +17,10 @@ def optimize_tests(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
     for label in sys.stdin:
         # //foo/bar:zot -> //foo/bar & zot
-        pkg,target = label.rstrip('\n').split(':')
-        # TODO: error checks and more robustness
-
-        client.test_path(make_test_path(pkg, target))
+        if label.startswith('//'):
+            pkg,target = label.rstrip('\n').split(':')
+            # TODO: error checks and more robustness
+            client.test_path(make_test_path(pkg, target))
 
     client.formatter = lambda x: x[0]['name'] + ":" + x[1]['name']
     client.run()

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -22,6 +22,7 @@ def optimize_tests(client):
 
         client.test_path(make_test_path(pkg, target))
 
+    client.formatter = lambda x: x[0]['name'] + ":" + x[1]['name']
     client.run()
 
 


### PR DESCRIPTION
On Bazel request, subsetting API returns a package and a target such as  ` [{"type":"package","name":"//src/test/java/com/ninjinkun"},{"type":"target","name":"mylib_test2\n"}]`. We need to format them to `/src/test/java/com/ninjinkun:mylib_test2`.