### PR TITLE
Capture the whole session path and remove the need for separate --name option

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -31,7 +31,8 @@ def session(build_name):
         res.raise_for_status()
         session_id = res.json()['id']
 
-        click.echo(session_id)
+        # what we print here gets captured and passed to `--session` in later commands
+        click.echo("{}/{}".format(session_path, session_id))
         return session_id
 
     except Exception as e:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -2,7 +2,6 @@ import click
 import json
 import os
 import glob
-from typing import List
 from junitparser import JUnitXml, TestSuite
 
 from .case_event import CaseEvent
@@ -13,14 +12,6 @@ from ...utils.env_keys import REPORT_ERROR_KEY
 
 
 @click.group()
-@click.option(
-    '--name',
-    'build_name',
-    help='build identifier',
-    required=True,
-    type=str,
-    metavar='BUILD_ID'
-)
 @click.option(
     '--source',
     help='repository district'
@@ -33,10 +24,10 @@ from ...utils.env_keys import REPORT_ERROR_KEY
     'session_id',
     help='Test session ID',
     required=os.getenv(REPORT_ERROR_KEY), # validate session_id under debug mode,
-    type=int,
+    type=str,
 )
 @click.pass_context
-def tests(context, build_name, source, session_id):
+def tests(context, source, session_id: str):
     if not session_id:
         click.echo("Session ID in --session is missing. It might be caused by Launchable API errors.", err=True)
         # intentionally exiting with zero
@@ -125,10 +116,8 @@ def tests(context, build_name, source, session_id):
             client = LaunchableClient(token)
 
             try:
-                case_path = "/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/events".format(
-                    org, workspace, build_name, session_id)
                 res = client.request(
-                    "post", case_path, data=payload, headers=headers)
+                    "post", "{}/events".format(session_id), data=payload, headers=headers)
                 res.raise_for_status()
 
                 print(res.status_code)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -23,7 +23,7 @@ from ..testpath import TestPath
     '--session',
     'session_id',
     help='Test session ID',
-    type=int,
+    type=str,
     required=os.getenv(REPORT_ERROR_KEY),  # validate session_id under debug mode
 )
 @click.option(
@@ -32,16 +32,8 @@ from ..testpath import TestPath
          'REPO_DIST like --source . ',
     metavar="REPO_NAME",
 )
-@click.option(
-    '--name',
-    'build_name',
-    help='build identifier',
-    required=True,
-    type=str,
-    metavar='BUILD_ID'
-)
 @click.pass_context
-def subset(context, target, session_id, source, build_name):
+def subset(context, target, session_id, source):
     token, org, workspace = parse_token()
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
@@ -120,7 +112,7 @@ def subset(context, target, session_id, source, build_name):
                         "testPaths": self.test_paths,
                         "target": target,
                         "session": {
-                            "id": session_id
+                            "id": os.path.basename(session_id)  # expecting just the last component, not the whole path
                         }
                     }
 


### PR DESCRIPTION
session ID is no longer a number, which was unnnecessary assumption anyway.