### PR TITLE
Fixing up what I broke in PR #70

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -18,7 +18,7 @@ from ..testpath import TestPath
     help='subsetting target from 0% to 100%',
     required=True,
     type=PERCENTAGE,
-    default=0.8,
+    default='80%',
 )
 @click.option(
     '--session',


### PR DESCRIPTION
Turns out the default gets processed through the conversion code, instead of getting passed as-is.