### PR TITLE
Add GoogleTest plugin

### DIFF
--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -14,7 +14,8 @@ def make_test_path(cls, case) -> TestPath:
 def subset(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
     for label in sys.stdin:
-        #  -> //foo/bar & zot
+        # handle ctest -N output
+        # Test #1: FooTest.Bar -> (FooTest, Bar)
         result = re.match(r'^ *Test #\d+: ([^ ]+)$', label)
         if result:
             (cls, case) = result.group(1).split('.')

--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -1,0 +1,32 @@
+import sys
+import re
+import click
+
+from . import launchable
+from ..testpath import TestPath
+
+
+def make_test_path(cls, case) -> TestPath:
+    return [{'type': 'class', 'name': cls}, {'type': 'case', 'name': case}]
+
+
+@launchable.subset
+def subset(client):
+    # Read targets from stdin, which generally looks like //foo/bar:zot
+    for label in sys.stdin:
+        #  -> //foo/bar & zot
+        result = re.match(r'^ *Test #\d+: ([^ ]+)$', label)
+        if result:
+            (cls, case) = result.group(1).split('.')
+            client.test_path(make_test_path(cls, case))
+
+    client.formatter = lambda x: x[0]['name'] + "." + x[1]['name']
+    client.run()
+
+
+@click.argument('report_dirs', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, report_dirs):
+    for root in report_dirs:
+        client.scan(root, "*.xml")
+    client.run()

--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -13,12 +13,25 @@ def make_test_path(cls, case) -> TestPath:
 @launchable.subset
 def subset(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
-    for label in sys.stdin:
+    cls = ''
+    for label in map(str.rstrip, sys.stdin):
+        # handle Google Test's --gtest_list_tests output
+        # FooTest.
+        #  Bar
+        #  Baz
+        gtest_class = re.match(r'^([^\.]+)\.', label)
+        if gtest_class:
+            cls = gtest_class.group(1)
+        gtest_case = re.match(r'^  ([^ ]+)', label)
+        if gtest_case and cls:
+            case = gtest_case.group(1)
+            client.test_path(make_test_path(cls, case))
+        
         # handle ctest -N output
         # Test #1: FooTest.Bar -> (FooTest, Bar)
-        result = re.match(r'^ *Test #\d+: ([^ ]+)$', label)
-        if result:
-            (cls, case) = result.group(1).split('.')
+        ctest_result = re.match(r'^  Test #\d+: ([^ ]+)$', label)
+        if ctest_result:
+            (cls, case) = ctest_result.group(1).split('.')
             client.test_path(make_test_path(cls, case))
 
     client.formatter = lambda x: x[0]['name'] + "." + x[1]['name']


### PR DESCRIPTION
This GoogleTest plugin support GoogleTest + CTest output and GoogleTest standalone + `--gtest_list_tests` output as shown below.

## Google Test + CTest output sample
```shell
ctest -N
Test project /Users/ninjin/src/github.com/launchableinc/rocket-car-googletest
  Test #1: FooTest.Bar
  Test #2: FooTest.Baz
  Test #3: FooTest.Foo
  Test #4: */ParameterizedTest.Bar/*

Total Tests: 4
```

CTest sample is here https://github.com/launchableinc/rocket-car-googletest/pull/4

## GoogleTest standalone output sample
```shell
$ ./test_a --gtest_list_tests 
FooTest.
  Bar
  Baz
  Foo
```

