### PR TITLE
Run the release process when a release is published, not when it's cr…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
…eated

The 'create' trigger appears to kick in only when a release is created
from GitHub UI, and not when I create a tag locally and git-push it.

I believe this will change the workflow to trigger when the publish
button is pressed.

Reference: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release