### PR TITLE
Move setup.py to setup.cfg

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose setuptools>=30.3.0 setuptools_scm wheel
+        pip install flake8 nose setuptools>=45.0.0 setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose setuptools>=45.0.0 setuptools_scm wheel
+        pip install flake8 nose 'setuptools>=45.0.0' setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose setuptools>=v30.3.0 setuptools_scm wheel
+        pip install flake8 nose setuptools>=30.3.0 setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose 'setuptools>=45.0.0' setuptools_scm wheel
+        pip install flake8 nose 'setuptools>=30.3.0' setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose setuptools setuptools_scm wheel
+        pip install flake8 nose setuptools>=v30.3.0 setuptools_scm wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-click==7.1.2
-requests==2.24.0
-junitparser==1.6.3
-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ setup_requires =
 install_requires =
     click>=7.1.2
     requests
-    junitparser
+    junitparser>=1.6.3
     setuptools
 python_requires = >=3.4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = launchable
+author = Launchable, Inc.
+author_email = info@launchableinc.com
+license = Apache Software License v2
+description = Launchable CLI
+url = https://launchableinc.com/
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+setup_requires =
+    setuptools_scm
+install_requires =
+    click>=7.1.2
+    requests
+    junitparser
+    setuptools
+python_requires = >=3.4
+
+[options.entry_points]
+console_scripts = launchable = launchable.__main__:main
+
+[options.package_data]
+launchable = jar/exe_deploy.jar

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,5 @@
-from setuptools import setup, find_packages
-
-from os import path
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-
-def _requirements(file):
-    return open(file).read().splitlines()
-
+from setuptools import setup
 
 setup(
-    name='launchable',
-    license='Apache Software License v2',
-    author='Launchable, Inc.',
-    url='https://launchableinc.com/',
-    author_email='info@launchableinc.com',
-    description='Launchable CLI',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    install_requires=_requirements('requirements.txt'),
-    packages=find_packages(),
-    package_data={'launchable': ['jar/exe_deploy.jar']},
-    setup_require=['setuptools_scm'],
     use_scm_version=True,
-    entry_points={
-        'console_scripts': [
-            'launchable = launchable.__main__:main',
-        ]
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires='>=3.4',
 )


### PR DESCRIPTION
I heard modern Python projects use `setup.cfg` instead of `setup.py` https://www.python.org/dev/peps/pep-0390/. Following this way, we can remove requirements.txt and some lines. According to my research, it is compatible for Python 3.4 or later under using setuptools 30.3.0 or later.