### PR TITLE
Improving the error handling.

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -1,15 +1,17 @@
-import click
+import glob
 import json
 import os
-import glob
+import traceback
+
+import click
 from junitparser import JUnitXml, TestSuite
 
 from .case_event import CaseEvent
-from ...utils.http_client import LaunchableClient
-from ...utils.gzipgen import compress
-from ...utils.token import parse_token
-from ...utils.env_keys import REPORT_ERROR_KEY
 from ...testpath import TestPathComponent
+from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.gzipgen import compress
+from ...utils.http_client import LaunchableClient
+from ...utils.token import parse_token
 
 
 @click.group()
@@ -135,6 +137,6 @@ def tests(context, base_path, session_id: str):
                 if os.getenv(REPORT_ERROR_KEY):
                     raise e
                 else:
-                    print(e)
+                    traceback.print_exc()
 
     context.obj = RecordTests()

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -20,7 +20,11 @@ class LaunchableClient:
 
     def request(self, method, path, **kwargs):
         headers = kwargs.pop("headers")
-        return self.http.request(method, self.base_url + path, headers={**headers, **self._headers()}, **kwargs)
+        url = self.base_url + path
+        try:
+            return self.http.request(method, url, headers={**headers, **self._headers()}, **kwargs)
+        except Exception as e:
+            raise Exception("unable to post to %s" % url) from e
 
     def _headers(self):
         return {


### PR DESCRIPTION
My design goals here is to provide as much details as possible, given that our users are developers themselves.

Previously, the error message printed was:

```
<urllib3.connection.HTTPSConnection object at 0x7fbfc37eff70>: Failed to establish a new connection: [Errno -2] Name or service not known
```

which doesn't tell me what name failed to resolve. With this, the error is now:
```
Traceback (most recent call last):
  File "/home/kohsuke/.local/lib/python3.8/site-packages/urllib3/connection.py", line 159, in _new_conn
    conn = connection.create_connection(
  File "/home/kohsuke/.local/lib/python3.8/site-packages/urllib3/util/connection.py", line 61, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kohsuke/ws/launchable/cli/launchable/utils/http_client.py", line 25, in request
    return self.http.request(method, url, headers={**headers, **self._headers()}, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/requests-2.24.0-py3.8.egg/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/requests-2.24.0-py3.8.egg/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/requests-2.24.0-py3.8.egg/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/requests-2.24.0-py3.8.egg/requests/adapters.py", line 467, in send
    low_conn.endheaders()
  File "/usr/lib/python3.8/http/client.py", line 1250, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1010, in _send_output
    self.send(msg)
  File "/usr/lib/python3.8/http/client.py", line 950, in send
    self.connect()
  File "/home/kohsuke/.local/lib/python3.8/site-packages/urllib3/connection.py", line 309, in connect
    conn = self._new_conn()
  File "/home/kohsuke/.local/lib/python3.8/site-packages/urllib3/connection.py", line 171, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x7f7f4b411e50>: Failed to establish a new connection: [Errno -2] Name or service not known

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/kohsuke/ws/launchable/cli/launchable/commands/record/tests.py", line 130, in run
    res = client.request(
  File "/home/kohsuke/ws/launchable/cli/launchable/utils/http_client.py", line 27, in request
    raise Exception("unable to post to %s" % url) from e
Exception: unable to post to https://api.mercury.launchableinc.comfoo/events
```

So I can now tell what it is that's really failing.

Also see "design considerations" under [CLI Error Handling Design Principles](https://launchableinc.atlassian.net/wiki/spaces/PRODUCT/pages/761331921/CLI+Error+Handling+Design+Principles)