### PR TITLE
Add Go test plugin

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -52,6 +52,7 @@ def subset(context, target, session_id, base_path):
             self.test_paths = []
             # TODO: robustness improvement.
             self._formatter = Optimize.default_formatter
+            self._separator = "\n"
 
         @staticmethod
         def default_formatter(x: TestPath):
@@ -73,6 +74,14 @@ def subset(context, target, session_id, base_path):
         @formatter.setter
         def formatter(self, v: Callable[[TestPath], str]):
             self._formatter = v
+
+        @property
+        def separator(self) -> str:
+            return self._separator
+
+        @separator.setter
+        def separator(self, s: str):
+            self._separator = s
 
         def test_path(self, path: TestPathLike):
             """register one test"""
@@ -160,7 +169,6 @@ def subset(context, target, session_id, base_path):
 
             # regardless of whether we managed to talk to the service
             # we produce test names
-            for t in output:
-                click.echo(self.formatter(t))
+            click.echo(self.separator.join(self.formatter(t) for t in output))
 
     context.obj = Optimize()

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -2,13 +2,14 @@ import sys
 import click
 from . import launchable
 
-
 @launchable.subset
 def subset(client):
     for case in sys.stdin:
         # Avoid last line such as `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
         if not ' ' in case:
             client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
+
+    client.formatter = lambda t: "^{}$|".format(t)
     client.run()
 
 

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -9,7 +9,8 @@ def subset(client):
         if not ' ' in case:
             client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
 
-    client.formatter = lambda t: "^{}$|".format(t)
+    client.formatter = lambda t: "^{}$".format(t)
+    client.separator = '|'
     client.run()
 
 

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -1,0 +1,12 @@
+from junitparser import TestCase, TestSuite
+import sys
+from . import launchable
+
+
+@launchable.subset
+def subset(client):
+    for case in sys.stdin:
+        # Aboid last line such s `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
+        if not ' ' in case:
+            client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
+    client.run()

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -6,7 +6,7 @@ from . import launchable
 @launchable.subset
 def subset(client):
     for case in sys.stdin:
-        # Aboid last line such s `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
+        # Avoid last line such as `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
         if not ' ' in case:
             client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
     client.run()

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -1,5 +1,5 @@
-from junitparser import TestCase, TestSuite
 import sys
+import click
 from . import launchable
 
 
@@ -9,4 +9,12 @@ def subset(client):
         # Aboid last line such s `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
         if not ' ' in case:
             client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
+    client.run()
+
+
+@click.argument('source_roots', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, source_roots):
+    for root in source_roots:
+        client.scan(root, "*.xml")
     client.run()

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -7,9 +7,9 @@ def subset(client):
     for case in sys.stdin:
         # Avoid last line such as `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
         if not ' ' in case:
-            client.test_path({'type': 'testcase', 'name': case.rstrip('\n')})
+            client.test_path([{'type': 'testcase', 'name': case.rstrip('\n')}])
 
-    client.formatter = lambda t: "^{}$".format(t)
+    client.formatter = lambda x: "^{}$".format(x[0]['name'])
     client.separator = '|'
     client.run()
 

--- a/tests/commands/test_record_tests_go_test.py
+++ b/tests/commands/test_record_tests_go_test.py
@@ -37,7 +37,7 @@ class GoTestTest(TestCase):
         result_file_path = self.test_files_dir.joinpath('subset_result.json')
         with result_file_path.open() as json_file:
             expected = json.load(json_file)
-            self.assertDictEqual(json.loads(data), expected)
+            self.assertDictEqual(json.loads(data.decode()), expected)
 
     @mock.patch('requests.request')
     def test_record_tests(self, mock_post):

--- a/tests/commands/test_record_tests_go_test.py
+++ b/tests/commands/test_record_tests_go_test.py
@@ -1,0 +1,59 @@
+from unittest import TestCase, mock
+from nose.tools import eq_, ok_
+from click.testing import CliRunner
+from test.support import captured_stdin
+
+import os
+import json
+from pathlib import Path
+import gzip
+
+from launchable.__main__ import main
+
+
+class GoTestTest(TestCase):
+    launchable_token = 'v1:launchableinc/mothership:auth-token-sample'
+    session = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/16'
+    test_files_dir = Path(__file__).parent.joinpath(
+        '../data/go_test/').resolve()
+
+    def setUp(self):
+        self.maxDiff = None
+        os.environ['LAUNCHABLE_TOKEN'] = self.launchable_token
+
+    @mock.patch('requests.request')
+    def test_subset(self, mock_post):
+        runner = CliRunner()
+        pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\nok      github.com/launchableinc/rocket-car-gotest      0.268s"
+        result = runner.invoke(main, [
+                               'subset', '--target', '10%', '--session', self.session, 'go_test'], input=pipe)
+
+        self.assertEqual(result.exit_code, 0)
+
+        for (args, kwargs) in mock_post.call_args_list:
+            if kwargs['data']:
+                data = kwargs['data']
+
+        result_file_path = self.test_files_dir.joinpath('subset_result.json')
+        with result_file_path.open() as json_file:
+            expected = json.load(json_file)
+            self.assertDictEqual(json.loads(data), expected)
+
+    # @mock.patch('requests.request')
+    # def test_record_test_minitest(self, mock_post):
+    #     runner = CliRunner()
+    #     result = runner.invoke(main, ['record', 'tests',  '--session', self.session, 'go_test', str(self.test_files_dir) + "/"])
+    #     self.assertEqual(result.exit_code, 0)
+    #     for (args, kwargs) in mock_post.call_args_list:
+    #         if kwargs['data']:
+    #             data = kwargs['data']
+    #     zipped_payload = b''.join(data)
+    #     payload = json.loads(gzip.decompress(zipped_payload).decode())
+    #     with self.result_file_path.open() as json_file:
+    #         expected = json.load(json_file)
+
+    #         # Normalize events order that depends on shell glob implementation
+    #         payload['events'] = sorted(payload['events'], key=lambda c: c['testPath'][0]['name'] + c['testPath'][1]['name'])
+    #         expected['events'] = sorted(expected['events'], key=lambda c: c['testPath'][0]['name'] + c['testPath'][1]['name'])
+
+    #         self.assertDictEqual(payload, expected)

--- a/tests/data/go_test/record_test_result.json
+++ b/tests/data/go_test/record_test_result.json
@@ -1,0 +1,6 @@
+{"events": [
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample1", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410391+00:00", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample2", "_lineno": null}], "duration": 3.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410811+00:00", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample3", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410874+00:00", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample4", "_lineno": null}], "duration": 2.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410917+00:00", "data": null}
+]}

--- a/tests/data/go_test/report.xml
+++ b/tests/data/go_test/report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="4" failures="0" time="5.262" name="github.com/launchableinc/rocket-car-gotest">
+		<properties>
+			<property name="go.version" value="go1.15.5"></property>
+		</properties>
+		<testcase classname="rocket-car-gotest" name="TestExample1" time="0.000"></testcase>
+		<testcase classname="rocket-car-gotest" name="TestExample2" time="3.000"></testcase>
+		<testcase classname="rocket-car-gotest" name="TestExample3" time="0.000"></testcase>
+		<testcase classname="rocket-car-gotest" name="TestExample4" time="2.000"></testcase>
+	</testsuite>
+</testsuites>

--- a/tests/data/go_test/subset_result.json
+++ b/tests/data/go_test/subset_result.json
@@ -1,6 +1,6 @@
 {"session": {"id": "16"},
   "target": 0.1,
-  "testPaths": [{"name": "TestExample1", "type": "testcase"},
-                {"name": "TestExample2", "type": "testcase"},
-                {"name": "TestExample3", "type": "testcase"},
-                {"name": "TestExample4", "type": "testcase"}]}
+  "testPaths": [[{"name": "TestExample1", "type": "testcase"}],
+                [{"name": "TestExample2", "type": "testcase"}],
+                [{"name": "TestExample3", "type": "testcase"}],
+                [{"name": "TestExample4", "type": "testcase"}]]}

--- a/tests/data/go_test/subset_result.json
+++ b/tests/data/go_test/subset_result.json
@@ -1,0 +1,6 @@
+{"session": {"id": "16"},
+  "target": 0.1,
+  "testPaths": [{"name": "TestExample1", "type": "testcase"},
+                {"name": "TestExample2", "type": "testcase"},
+                {"name": "TestExample3", "type": "testcase"},
+                {"name": "TestExample4", "type": "testcase"}]}


### PR DESCRIPTION
# Usage
## subset
`subset` command receives test names from stdin
```shell
go test -list . | launchable subset --name '#123' go_test > subset.txt
go test -run $(cat subset.txt | perl -anle 'print(join q{|}, map { q{^} . quotemeta . q{$} } @F)')
```

## record tests
`record tests` command read JUnit XML files.

```shell
go test -v 2>&1 | go-junit-report >  report.xml # convert output via go-junit-report 
launchable record tests --name '#123' go_test .
```

# Disucussion
Should the plugin command name be `go_test` or `go-test`?
