### PR TITLE
[ST-696] Accept XML file names, not just diirectories

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -3,6 +3,7 @@ import json
 import os
 from os.path import *
 import glob
+import gzip
 from typing import Callable, Union
 from ..utils.click import PERCENTAGE
 from ..utils.env_keys import REPORT_ERROR_KEY
@@ -141,6 +142,7 @@ def subset(context, target, session_id, base_path):
                 try:
                     headers = {
                         "Content-Type": "application/json",
+                        "Content-Encoding": "gzip",
                     }
 
                     payload = {
@@ -156,8 +158,8 @@ def subset(context, target, session_id, base_path):
                         org, workspace)
 
                     client = LaunchableClient(token)
-                    res = client.request("post", path, data=json.dumps(
-                        payload).encode(), headers=headers)
+                    res = client.request("post", path, data=gzip.compress(json.dumps(
+                        payload).encode()), headers=headers)
                     res.raise_for_status()
 
                     output = res.json()["testPaths"]

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -14,9 +14,4 @@ def subset(client):
     client.run()
 
 
-@click.argument('source_roots', required=True, nargs=-1)
-@launchable.record.tests
-def record_tests(client, source_roots):
-    for root in source_roots:
-        client.scan(root, "*.xml")
-    client.run()
+record_tests = launchable.CommonRecordTestImpls(__name__).report_files()

--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -37,9 +37,4 @@ def subset(client):
     client.run()
 
 
-@click.argument('report_dirs', required=True, nargs=-1)
-@launchable.record.tests
-def record_tests(client, report_dirs):
-    for root in report_dirs:
-        client.scan(root, "*.xml")
-    client.run()
+record_tests = launchable.CommonRecordTestImpls(__name__).report_files()

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,6 +1,7 @@
-import click
 import os
-import glob
+
+import click
+
 from . import launchable
 
 
@@ -22,28 +23,4 @@ def subset(client, source_roots):
     client.run()
 
 
-@click.argument('source_roots', required=True, nargs=-1)
-@launchable.record.tests
-def record_tests(client, source_roots):
-    # Accept both file names and GLOB patterns
-    # Simple globs like '*.xml' can be dealt with by shell, but
-    # not all shells consistently deal with advanced GLOBS like '**'
-    # so it's worth supporting it here.
-    for root in source_roots:
-        match = False
-        for t in glob.iglob(root, recursive=True):
-            match = True
-            if os.path.isdir(t):
-                client.scan(t, "*.xml")
-            else:
-                client.report(t)
-
-        if not match:
-            # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
-            # raise it as an error. Note this can happen for reasons other than a configuration error.
-            # For example, if a build catastrophically failed and no tests got run.
-            click.echo("No matches found: " % root, err=True)
-            # intentionally exiting with zero
-            return
-
-    client.run()
+record_tests = launchable.CommonRecordTestImpls(__name__).report_files()

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,5 +1,6 @@
 import click
 import os
+import glob
 from . import launchable
 
 
@@ -24,6 +25,25 @@ def subset(client, source_roots):
 @click.argument('source_roots', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, source_roots):
+    # Accept both file names and GLOB patterns
+    # Simple globs like '*.xml' can be dealt with by shell, but
+    # not all shells consistently deal with advanced GLOBS like '**'
+    # so it's worth supporting it here.
     for root in source_roots:
-        client.scan(root, "*.xml")
+        match = False
+        for t in glob.iglob(root, recursive=True):
+            match = True
+            if os.path.isdir(t):
+                client.scan(t, "*.xml")
+            else:
+                client.report(t)
+
+        if not match:
+            # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
+            # raise it as an error. Note this can happen for reasons other than a configuration error.
+            # For example, if a build catastrophically failed and no tests got run.
+            click.echo("No matches found: " % root, err=True)
+            # intentionally exiting with zero
+            return
+
     client.run()

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -1,24 +1,25 @@
-import click
-import types
+import click, types, glob, os
 from launchable.commands.subset import subset as subset_cmd
 from launchable.commands.record.tests import tests as record_tests_cmd
 
 
-def cmdname(f):
+def cmdname(m):
     """figure out the sub-command name from a test runner function"""
 
     # a.b.cde -> cde
-    m = f.__module__
-    return m[m.rindex('.')+1:]
+    # xyz -> xyz
+    return m[m.rfind('.')+1:]
 
 
-def wrap(f, group):
+def wrap(f, group, name=None):
     """
     Wraps a 'plugin' function into a click command and registers it to the given group.
 
     a plugin function receives the scanner object in its first argument
     """
-    d = click.command(name=cmdname(f))
+    if not name:
+        name = cmdname(f.__module__)
+    d = click.command(name=name)
     cmd = d(click.pass_obj(f))
     group.add_command(cmd)
     return cmd
@@ -29,3 +30,46 @@ def subset(f): return wrap(f, subset_cmd)
 
 record = types.SimpleNamespace()
 record.tests = lambda f: wrap(f, record_tests_cmd)
+
+
+class CommonRecordTestImpls:
+    """
+    Typical 'record tests' implementations that are reusable.
+    """
+
+    def __init__(self, module_name):
+        self.cmdname = cmdname(module_name)
+
+    def report_files(self):
+        """
+        Suitable for test runners that create a directory full of JUnit report files.
+
+        'record tests' expect JUnit report/XML file names.
+        """
+
+        @click.argument('source_roots', required=True, nargs=-1)
+        def record_tests(client, source_roots):
+            # Accept both file names and GLOB patterns
+            # Simple globs like '*.xml' can be dealt with by shell, but
+            # not all shells consistently deal with advanced GLOBS like '**'
+            # so it's worth supporting it here.
+            for root in source_roots:
+                match = False
+                for t in glob.iglob(root, recursive=True):
+                    match = True
+                    if os.path.isdir(t):
+                        client.scan(t, "*.xml")
+                    else:
+                        client.report(t)
+
+                if not match:
+                    # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
+                    # raise it as an error. Note this can happen for reasons other than a configuration error.
+                    # For example, if a build catastrophically failed and no tests got run.
+                    click.echo("No matches found: " % root, err=True)
+                    # intentionally exiting with zero
+                    return
+
+            client.run()
+
+        return wrap(record_tests, record_tests_cmd, self.cmdname)

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -32,13 +32,4 @@ def subset(client, files):
     client.run()
 
 
-@click.argument('report_dirs', required=True, nargs=-1)
-@launchable.record.tests
-def record_tests(client, report_dirs):
-    for root in report_dirs:
-        if os.path.isdir(root):
-            client.scan(root, "*.xml")
-        else:
-            client.report(root)
-
-    client.run()
+record_tests = launchable.CommonRecordTestImpls(__name__).report_files()

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -12,7 +12,7 @@ from launchable.__main__ import main
 
 class CliTestCase(unittest.TestCase):
     """
-    Base class for seting up test to invoke CLI
+    Base class for setting up test to invoke CLI
     """
     launchable_token = 'v1:launchableinc/mothership:auth-token-sample'
     session = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/16'
@@ -32,6 +32,9 @@ class CliTestCase(unittest.TestCase):
             return json.load(json_file)
 
     def payload(self, mock_post):
+        """
+        Given a mock request object, capture the payload sent to the server
+        """
         for (args, kwargs) in mock_post.call_args_list:
             if kwargs['data']:
                 data = kwargs['data']

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -1,0 +1,63 @@
+import gzip
+import json
+import os
+import unittest
+import types
+
+import click.testing
+from click.testing import CliRunner
+
+from launchable.__main__ import main
+
+
+class CliTestCase(unittest.TestCase):
+    """
+    Base class for seting up test to invoke CLI
+    """
+    launchable_token = 'v1:launchableinc/mothership:auth-token-sample'
+    session = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/16'
+
+    def setUp(self):
+        self.maxDiff = None
+        os.environ['LAUNCHABLE_TOKEN'] = self.launchable_token
+
+    def cli(self, *args, **kwargs) -> click.testing.Result:
+        """
+        Invoke CLI command and returns its result
+        """
+        return CliRunner().invoke(main, args, **kwargs)
+
+    def load_json_from_file(self, file):
+        with file.open() as json_file:
+            return json.load(json_file)
+
+    def payload(self, mock_post):
+        for (args, kwargs) in mock_post.call_args_list:
+            if kwargs['data']:
+                data = kwargs['data']
+                if isinstance(data, types.GeneratorType):
+                    data = b''.join(data)
+                return data
+
+        raise Exception("No data posted")
+
+    def gzipped_json_payload(self, mock_post):
+        return json.loads(gzip.decompress(self.payload(mock_post)).decode())
+
+    def json_payload(self, mock_post):
+        return json.loads(self.payload(mock_post))
+
+    def assert_json_orderless_equal(self, a, b):
+        """
+        Compare two JSON trees ignoring orders of items in list & dict
+        """
+
+        def tree_sorted(obj):
+            if isinstance(obj, dict):
+                return sorted((k, tree_sorted(v)) for k, v in obj.items())
+            if isinstance(obj, list):
+                return sorted(tree_sorted(x) for x in obj)
+            else:
+                return obj
+
+        self.assertEqual(tree_sorted(a), tree_sorted(b))

--- a/tests/commands/test_record_tests_go_test.py
+++ b/tests/commands/test_record_tests_go_test.py
@@ -1,72 +1,30 @@
-from unittest import TestCase, mock
-from nose.tools import eq_, ok_
-from click.testing import CliRunner
-from test.support import captured_stdin
-
-import os
-import json
 from pathlib import Path
-import gzip
+from unittest import mock
 
-from launchable.__main__ import main
+from tests.cli_test_case import CliTestCase
 
-
-class GoTestTest(TestCase):
-    launchable_token = 'v1:launchableinc/mothership:auth-token-sample'
-    session = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/16'
-    test_files_dir = Path(__file__).parent.joinpath(
-        '../data/go_test/').resolve()
-
-    def setUp(self):
-        self.maxDiff = None
-        os.environ['LAUNCHABLE_TOKEN'] = self.launchable_token
+class GoTestTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/go_test/').resolve()
 
     @mock.patch('requests.request')
     def test_subset(self, mock_post):
-        runner = CliRunner()
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\nok      github.com/launchableinc/rocket-car-gotest      0.268s"
-        result = runner.invoke(main, [
-                               'subset', '--target', '10%', '--session', self.session, 'go_test'], input=pipe)
-
+        result=self.cli('subset', '--target', '10%', '--session', self.session, 'go_test', input=pipe)
         self.assertEqual(result.exit_code, 0)
 
-        for (args, kwargs) in mock_post.call_args_list:
-            if kwargs['data']:
-                data = kwargs['data']
-
-        result_file_path = self.test_files_dir.joinpath('subset_result.json')
-        with result_file_path.open() as json_file:
-            expected = json.load(json_file)
-            self.assertDictEqual(json.loads(data.decode()), expected)
+        payload = self.gzipped_json_payload(mock_post)
+        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
+        self.assert_json_orderless_equal(expected, payload)
 
     @mock.patch('requests.request')
     def test_record_tests(self, mock_post):
-        runner = CliRunner()
-        result = runner.invoke(main, ['record', 'tests',  '--session',
-                                      self.session, 'go_test', str(self.test_files_dir) + "/"])
+        result=self.cli('record', 'tests',  '--session', self.session, 'go_test', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
-        for (args, kwargs) in mock_post.call_args_list:
-            if kwargs['data']:
-                data = kwargs['data']
-        zipped_payload = b''.join(data)
-        payload = json.loads(gzip.decompress(zipped_payload).decode())
+        payload = self.gzipped_json_payload(mock_post)
+        # Remove timestamp because it depends on the machine clock
+        for c in payload['events']:
+            del c['created_at']
 
-        result_file_path = self.test_files_dir.joinpath(
-            'record_test_result.json')
-        with result_file_path.open() as json_file:
-            expected = json.load(json_file)
-
-            # Normalize events order that depends on shell glob implementation
-            payload['events'] = sorted(
-                payload['events'], key=lambda c: c['testPath'][0]['name'])
-            expected['events'] = sorted(
-                expected['events'], key=lambda c: c['testPath'][0]['name'])
-
-            # Remove timestamp because it depends on the machine clock
-            for c in payload['events']:
-                del c['created_at']
-            for c in expected['events']:
-                del c['created_at']
-
-            self.assertDictEqual(payload, expected)
+        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
+        self.assert_json_orderless_equal(expected, payload)

--- a/tests/commands/test_record_tests_minitest.py
+++ b/tests/commands/test_record_tests_minitest.py
@@ -1,40 +1,18 @@
-from unittest import TestCase, mock
-from nose.tools import eq_, ok_
-from click.testing import CliRunner
-
-import os
-import json
 from pathlib import Path
-import gzip
+from unittest import mock
 
-from launchable.__main__ import main
-from launchable.utils.gzipgen import compress
+from tests.cli_test_case import CliTestCase
 
-class MinitestTest(TestCase):
-    launchable_token='v1:launchableinc/mothership:auth-token-sample'
-    session = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/16'
+
+class MinitestTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/minitest/').resolve()
     result_file_path = test_files_dir.joinpath('record_test_result.json')
 
-    def setUp(self):
-        self.maxDiff = None
-        os.environ['LAUNCHABLE_TOKEN'] = self.launchable_token
-
     @mock.patch('requests.request')
     def test_record_test_minitest(self, mock_post):
-        runner = CliRunner()
-        result = runner.invoke(main, ['record', 'tests',  '--session', self.session, 'minitest', str(self.test_files_dir) + "/"])
+        result = self.cli('record', 'tests',  '--session', self.session, 'minitest', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
-        for (args, kwargs) in mock_post.call_args_list:
-            if kwargs['data']:
-                data = kwargs['data']
-        zipped_payload = b''.join(data)
-        payload = json.loads(gzip.decompress(zipped_payload).decode())
-        with self.result_file_path.open() as json_file:
-            expected = json.load(json_file)
 
-            # Normalize events order that depends on shell glob implementation
-            payload['events'] = sorted(payload['events'], key=lambda c: c['testPath'][0]['name'] + c['testPath'][1]['name'])
-            expected['events'] = sorted(expected['events'], key=lambda c: c['testPath'][0]['name'] + c['testPath'][1]['name'])
-
-            self.assertDictEqual(payload, expected)
+        payload = self.gzipped_json_payload(mock_post)
+        expected = self.load_json_from_file(self.result_file_path)
+        self.assert_json_orderless_equal(expected, payload)

--- a/tests/data/go_test/record_test_result.json
+++ b/tests/data/go_test/record_test_result.json
@@ -1,6 +1,6 @@
 {"events": [
-  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample1", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410391+00:00", "data": null},
-  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample2", "_lineno": null}], "duration": 3.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410811+00:00", "data": null},
-  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample3", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410874+00:00", "data": null},
-  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample4", "_lineno": null}], "duration": 2.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-12T13:12:33.410917+00:00", "data": null}
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample1", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample2", "_lineno": null}], "duration": 3.0, "status": 1, "stdout": "", "stderr": "", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample3", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "data": null},
+  {"type": "case", "testPath": [{"type": "class", "name": "rocket-car-gotest"}, {"type": "testcase", "name": "TestExample4", "_lineno": null}], "duration": 2.0, "status": 1, "stdout": "", "stderr": "", "data": null}
 ]}

--- a/tests/data/gradle/recursion/expected.json
+++ b/tests/data/gradle/recursion/expected.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "com.launchableinc.rocket_car_gradle.AppTest"
+        },
+        {
+          "type": "testcase",
+          "name": "testAppHasAGreeting",
+          "_lineno": null
+        }
+      ],
+      "duration": 0.002,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2020-11-18T13:17:18",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "com.launchableinc.rocket_car_gradle.AppTest"
+        },
+        {
+          "type": "testcase",
+          "name": "testAppHasAGreeting2",
+          "_lineno": null
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2020-11-18T13:17:18",
+      "data": null
+    }
+  ]
+}

--- a/tests/data/gradle/recursion/foo/bar/reports/1.xml
+++ b/tests/data/gradle/recursion/foo/bar/reports/1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.launchableinc.rocket_car_gradle.AppTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2020-11-18T13:17:18" hostname="YoshiorinoMacBook-Pro.local" time="0.002">
+  <properties/>
+  <testcase name="testAppHasAGreeting" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.002"/>
+  <testcase name="testAppHasAGreeting2" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.0"/>
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from unittest import mock
+
+from tests.cli_test_case import CliTestCase
+
+
+class GradleTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/gradle/recursion').resolve()
+    result_file_path = test_files_dir.joinpath('expected.json')
+
+    @mock.patch('requests.request')
+    def test_record_test_minitest(self, mock_post):
+        result = self.cli('record', 'tests',  '--session', self.session, 'gradle', str(self.test_files_dir) + "/**/reports")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = self.gzipped_json_payload(mock_post)
+        expected = self.load_json_from_file(self.result_file_path)
+
+        self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
Also in this change,
* Make test code more DRY by introducing reusable base class `CliTestCase`
* Promote consistency across test runners by creating reusable `record tests` support
