### PR TITLE
go_test -> go-test

### DIFF
--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -8,8 +8,11 @@ def cmdname(f):
     """figure out the sub-command name from a test runner function"""
 
     # a.b.cde -> cde
+    #
+    # In python module name the conventional separator is '_' but in command name,
+    # it is '-', so we do replace that
     m = f.__module__
-    return m[m.rindex('.')+1:]
+    return m[m.rindex('.')+1:].replace('_','-')
 
 
 def wrap(f, group):

--- a/tests/commands/test_record_tests_go_test.py
+++ b/tests/commands/test_record_tests_go_test.py
@@ -26,7 +26,7 @@ class GoTestTest(TestCase):
         runner = CliRunner()
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\nok      github.com/launchableinc/rocket-car-gotest      0.268s"
         result = runner.invoke(main, [
-                               'subset', '--target', '10%', '--session', self.session, 'go_test'], input=pipe)
+                               'subset', '--target', '10%', '--session', self.session, 'go-test'], input=pipe)
 
         self.assertEqual(result.exit_code, 0)
 
@@ -43,7 +43,7 @@ class GoTestTest(TestCase):
     def test_record_tests(self, mock_post):
         runner = CliRunner()
         result = runner.invoke(main, ['record', 'tests',  '--session',
-                                      self.session, 'go_test', str(self.test_files_dir) + "/"])
+                                      self.session, 'go-test', str(self.test_files_dir) + "/"])
         self.assertEqual(result.exit_code, 0)
 
         for (args, kwargs) in mock_post.call_args_list:


### PR DESCRIPTION
After discussing with @awilkes , we came to the agreement that more conventional command name is probably `go-test`.

While this is technically a breaking change, we haven't really announced the Go test support yet, so I think it's OK to sneak this in and call it v1.1.2