### PR TITLE
Remove tailing newlines from file plugin

### DIFF
--- a/launchable/test_runners/file.py
+++ b/launchable/test_runners/file.py
@@ -12,7 +12,7 @@ from ..testpath import TestPath
 def subset(client):
     # read lines as test file names
     for t in sys.stdin:
-        client.test_path(t)
+        client.test_path(t.rstrip("\n"))
     client.run()
 
 


### PR DESCRIPTION
When I testing the file plugin, I noticed test_path contains a tailing new line like the one below:

```
testPaths: [[{"type":"file","name":"tests/dir1/test1.py\n"}], [{"type":"file","name":"tests/dir1/test2.py\n"}], [{"type":"file","name":"tests/dir2/test1.py\n"}], [{"type":"file","name":"tests/dir2/test2.py\n"}], [{"type":"file","name":"tests/dir3/test1.py"}]]
```

That is because the plugin takes the input as it is so I remove the tailing newline from it.