### PR TITLE
Be more lax about the version of Click

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,13 @@ You can use Python's `-m` option to launch module directly.
 ```shell
 python3 -m launchable record commit
 ```
+
+# Design Philosophy
+- **Dependencies**: Launchable needs to run with varying environments of users. So when we need to
+  reduce dependencies to other packages or tools installed on the system. For example, Python packages
+  we depend on and their version constraints might conflict with what other Python packages specifies.
+  Some libraries have native components, which need to be built during `pip install` and that adds to
+  the burden, too.
+- **Extensibility**: Test runners people use are all over the map. To provide 1st class support for those
+  while keeping the code DRY, CLI has two layers. The core layer that defines a properly abstracted
+  generic logic, and tool specific "integration" layers that glue the core layer and different tools.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 setup_requires =
     setuptools_scm
 install_requires =
-    click>=7.1.2
+    click>=7.0
     requests
     junitparser>=1.6.3
     setuptools


### PR DESCRIPTION
If users already use Python and have some libraries depend on Click, us needing the very latest could cause some pain.

Let's see if we can live with a little older Click 7.