### PR TITLE
Removing what appears to be the debug status code output.

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -93,7 +93,6 @@ def build(ctx, build_name, source):
         client = LaunchableClient(token)
         res = client.request("post", path, data=json.dumps(
             payload).encode(), headers=headers)
-        print(res.status_code)
         res.raise_for_status()
 
     except Exception as e:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -130,9 +130,6 @@ def tests(context, base_path, session_id: str):
                 res = client.request(
                     "post", "{}/events".format(session_id), data=payload, headers=headers)
                 res.raise_for_status()
-
-                print(res.status_code)
-
             except Exception as e:
                 if os.getenv(REPORT_ERROR_KEY):
                     raise e


### PR DESCRIPTION
If we need/want to keep those to assist debugging, let's have the `--debug` flag.