### PR TITLE
[ST-704] add cypress test runner

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -15,18 +15,6 @@ from ...utils.http_client import LaunchableClient
 from ...utils.token import parse_token
 
 
-def testsuites(xml) -> [TestSuite]:
-    if isinstance(xml, JUnitXml):
-        testsuites = [suite for suite in xml]
-    elif isinstance(xml, TestSuite):
-        testsuites = [xml]
-    else:
-        # TODO: what is a Pythonesque way to do this?
-        assert False
-
-    return testsuites
-
-
 @click.group()
 @click.option(
     '--base',
@@ -58,6 +46,18 @@ def tests(context, base_path, session_id: str):
         # some libraries output invalid  incorrectly format then have to fix them.
         TestSuites = Callable[[JUnitXml], List[TestSuite]]
 
+        @staticmethod
+        def default_testsuites(xml) -> [TestSuite]:
+            if isinstance(xml, JUnitXml):
+                testsuites = [suite for suite in xml]
+            elif isinstance(xml, TestSuite):
+                testsuites = [xml]
+            else:
+                # TODO: what is a Pythonesque way to do this?
+                assert False
+
+            return testsuites
+
         @property
         def path_builder(self) -> CaseEvent.TestPathBuilder:
             """
@@ -81,7 +81,7 @@ def tests(context, base_path, session_id: str):
         def __init__(self):
             self.reports = []
             self.path_builder = CaseEvent.default_path_builder(base_path)
-            self.testsuites = testsuites
+            self.testsuites = RecordTests.default_testsuites
 
         def make_file_path_component(self, filepath) -> TestPathComponent:
             """Create a single TestPathComponent from the given file path"""

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -5,6 +5,7 @@ import traceback
 
 import click
 from junitparser import JUnitXml, TestSuite
+from typing import Callable, List
 
 from .case_event import CaseEvent
 from ...testpath import TestPathComponent
@@ -53,6 +54,10 @@ def tests(context, base_path, session_id: str):
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class
     class RecordTests:
+        # function that returns junitparser.TestCase
+        # some libraries output invalid  incorrectly format then have to fix them.
+        TestSuites = Callable[[JUnitXml], List[TestSuite]]
+
         @property
         def path_builder(self) -> CaseEvent.TestPathBuilder:
             """
@@ -70,7 +75,7 @@ def tests(context, base_path, session_id: str):
             return self._testsuites
 
         @testsuites.setter
-        def testsuites(self, v):
+        def testsuites(self, v: TestSuites):
             self._testsuites = v
 
         def __init__(self):

--- a/launchable/test_runners/cypress.py
+++ b/launchable/test_runners/cypress.py
@@ -1,5 +1,6 @@
 import click
 import os
+import sys
 from . import launchable
 from junitparser import TestSuite, JUnitXml
 
@@ -25,4 +26,14 @@ def record_tests(client, reports):
         return testsuites
 
     client.testsuites = testsuites
+    client.run()
+
+
+@launchable.subset
+def subset(client):
+    # read lines as test file names
+    for t in sys.stdin:
+        client.test_path(t.rstrip("\n"))
+
+    client.separator = ','
     client.run()

--- a/launchable/test_runners/cypress.py
+++ b/launchable/test_runners/cypress.py
@@ -1,0 +1,12 @@
+import click
+import os
+from . import launchable
+
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    for r in reports:
+        client.report(r)
+
+    client.run()

--- a/launchable/test_runners/cypress.py
+++ b/launchable/test_runners/cypress.py
@@ -13,14 +13,12 @@ def record_tests(client, reports):
     def testsuites(xml) -> [TestSuite]:
         testsuites = []
         if isinstance(xml, JUnitXml):
+            filepath = xml._elem.find(
+                './/testsuite[@name="Root Suite"]').get("file")
             for suite in xml:
-                if suite.name == "Root Suite":
-                    filepath = suite._elem.attrib.get("file")
-                    continue
-                if filepath:
-                    suite._elem.attrib.update(
-                        {"filepath": filepath})
-                    testsuites.append(suite)
+                suite._elem.attrib.update(
+                    {"filepath": filepath})
+                testsuites.append(suite)
         else:
             # TODO: what is a Pythonesque way to do this?
             assert False

--- a/launchable/test_runners/cypress.py
+++ b/launchable/test_runners/cypress.py
@@ -1,6 +1,7 @@
 import click
 import os
 from . import launchable
+from junitparser import TestSuite, JUnitXml
 
 
 @click.argument('reports', required=True, nargs=-1)
@@ -9,4 +10,21 @@ def record_tests(client, reports):
     for r in reports:
         client.report(r)
 
+    def testsuites(xml) -> [TestSuite]:
+        testsuites = []
+        if isinstance(xml, JUnitXml):
+            for suite in xml:
+                if suite.name == "Root Suite":
+                    filepath = suite._elem.attrib.get("file")
+                    continue
+                if filepath:
+                    suite._elem.attrib.update(
+                        {"filepath": filepath})
+                    testsuites.append(suite)
+        else:
+            # TODO: what is a Pythonesque way to do this?
+            assert False
+        return testsuites
+
+    client.testsuites = testsuites
     client.run()

--- a/tests/data/cypress/record_test_result.json
+++ b/tests/data/cypress/record_test_result.json
@@ -1,0 +1,7 @@
+{"events": [
+  {"type": "case", "testPath": [{"type": "class", "name": "cy.window() - get the global window object"}, {"type": "file", "name": "cypress/integration/examples/window.spec.js"}, {"type": "testcase", "name": "Window cy.window() - get the global window object", "_lineno": null}], "duration": 0.149, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-20T08:49:02", "data": null}
+  ,
+  {"type": "case", "testPath": [{"type": "class", "name": "cy.document() - get the document object"}, {"type": "file", "name": "cypress/integration/examples/window.spec.js"}, {"type": "testcase", "name": "Window cy.document() - get the document object", "_lineno": null}], "duration": 0.078, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-20T08:49:02", "data": null}
+  ,
+  {"type": "case", "testPath": [{"type": "class", "name": "cy.title() - get the title"}, {"type": "file", "name": "cypress/integration/examples/window.spec.js"}, {"type": "testcase", "name": "Window cy.title() - get the title", "_lineno": null}], "duration": 0.088, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-20T08:49:02", "data": null}
+  ]}

--- a/tests/data/cypress/subset_result.json
+++ b/tests/data/cypress/subset_result.json
@@ -1,0 +1,14 @@
+{
+  "session": {
+    "id": "16"
+  },
+  "target": 0.1,
+  "testPaths": [
+    [
+      {
+        "name": "cypress/integration/examples/window.spec.js",
+        "type": "file"
+      }
+    ]
+  ]
+}

--- a/tests/data/cypress/test-result.xml
+++ b/tests/data/cypress/test-result.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="1.1780" tests="6" failures="0">
+  <testsuite name="Root Suite" timestamp="2021-01-20T08:49:02" tests="0" file="cypress/integration/examples/window.spec.js" time="0.0000" failures="0">
+  </testsuite>
+  <testsuite name="Window" timestamp="2021-01-20T08:49:02" tests="3" time="0.3150" failures="0">
+    <testcase name="Window cy.window() - get the global window object" time="0.1490" classname="cy.window() - get the global window object">
+    </testcase>
+    <testcase name="Window cy.document() - get the document object" time="0.0780" classname="cy.document() - get the document object">
+    </testcase>
+    <testcase name="Window cy.title() - get the title" time="0.0880" classname="cy.title() - get the title">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -24,6 +24,7 @@ class CypressTest(CliTestCase):
 
     @mock.patch('requests.request')
     def test_subset_cypress(self, mock_post):
+        # test-report.xml is outputed from cypress/integration/examples/window.spec.js, so set it
         pipe = "cypress/integration/examples/window.spec.js"
         result = self.cli('subset', '--target', '10%',
                           '--session', self.session, 'cypress', input=pipe)

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest import mock
+
+from tests.cli_test_case import CliTestCase
+
+
+class CypressTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath(
+        '../data/cypress/').resolve()
+
+    @mock.patch('requests.request')
+    def test_record_test_cypress(self, mock_post):
+        # report.xml was generated used to cypress-io/cypress-example-kitchensink
+        # cypress run --reporter junit report.xml
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          'cypress', str(self.test_files_dir) + "/test-result.xml")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = self.gzipped_json_payload(mock_post)
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('record_test_result.json'))
+
+        self.assert_json_orderless_equal(expected, payload)

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -10,7 +10,7 @@ class CypressTest(CliTestCase):
 
     @mock.patch('requests.request')
     def test_record_test_cypress(self, mock_post):
-        # report.xml was generated used to cypress-io/cypress-example-kitchensink
+        # test-result.xml was generated used to cypress-io/cypress-example-kitchensink
         # cypress run --reporter junit report.xml
         result = self.cli('record', 'tests',  '--session', self.session,
                           'cypress', str(self.test_files_dir) + "/test-result.xml")
@@ -20,4 +20,18 @@ class CypressTest(CliTestCase):
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
+        self.assert_json_orderless_equal(expected, payload)
+
+    @mock.patch('requests.request')
+    def test_subset_cypress(self, mock_post):
+        pipe = "cypress/integration/examples/window.spec.js"
+        result = self.cli('subset', '--target', '10%',
+                          '--session', self.session, 'cypress', input=pipe)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = self.gzipped_json_payload(mock_post)
+        print("fooo")
+        print(payload)
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('subset_result.json'))
         self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
cypress JUnit reporter outputs incorrect format(https://github.com/cypress-io/cypress/issues/8237), so we can't use file command.
I create a cypress plugin for that.

I need some testsuites elements to get the test file name that use to report, so I define testsuites method that can overwrite.
And I prepare custom testsuites method for cypress.

outputed XML: https://github.com/launchableinc/cli/pull/101/files#diff-57f8b2c67ad176f3307742a51acc476264050670ebe13c6492441fd17596f971
