### PR TITLE
Surpress print session ID in the subset command

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -26,7 +26,12 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     default=True,
     metavar='SESSION_FILE'
 )
-def session(build_name: str, save_session_file: bool):
+def session(build_name: str, save_session_file: bool, print_session = True: bool):
+    """
+    print_session is for barckward compatibility.
+    If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.
+    If you run this command from the other command such as `subset` and `record tests`, you should set print_session = False because users don't expect to print session ID to the subset output.
+    """
     token, org, workspace = parse_token()
 
     headers = {
@@ -44,9 +49,7 @@ def session(build_name: str, save_session_file: bool):
 
         if save_session_file:
             write_session(build_name, "{}/{}".format(session_path, session_id))
-            # For backward compatibility prior v1.1
-            click.echo("{}/{}".format(session_path, session_id))
-        else:
+        if print_session:
             # what we print here gets captured and passed to `--session` in later commands
             click.echo("{}/{}".format(session_path, session_id))
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -26,7 +26,7 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     default=True,
     metavar='SESSION_FILE'
 )
-def session(build_name: str, save_session_file: bool, print_session = True: bool):
+def session(build_name: str, save_session_file: bool, print_session: bool = True):
     """
     print_session is for barckward compatibility.
     If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -49,7 +49,7 @@ def tests(context, base_path: str, session_id: str, build_name: str):
         if build_name:
             session_id = read_session(build_name)
             if not session_id:
-                res = context.invoke(session, build_name=build_name, save_session_file=True)
+                res = context.invoke(session, build_name=build_name, save_session_file=True, print_session=False)
                 session_id = read_session(build_name)
         else:
             raise click.UsageError(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -56,7 +56,7 @@ def subset(context, target, session_id, base_path: str, build_name: str):
         if build_name:
             session_id = read_session(build_name)
             if not session_id:
-                context.invoke(session, build_name=build_name, save_session_file=True)
+                context.invoke(session, build_name=build_name, save_session_file=True, print_session=False)
                 session_id = read_session(build_name)
         else:
             raise click.UsageError(


### PR DESCRIPTION
In the latest main branch, `subset` command outputs a session ID to STDOUT. As a result, the output is mixed with a session ID and test names. I fixed it by suppressing printing a session ID.
```
$ cat ~/project/test/launchable/subset.txt
/intake/organizations/launchableinc/workspaces/rocket-car-minitest/builds/2717e8ed-e5f6-422d-a65d-4510942fc8c9/test_sessions/2476
test/controllers/user_test.rb
test/models/open_class_user_test.rb
test/models/user_copy_test.rb
test/models/user_test.rb
test/models/admin/user_test.rb
test/channels/application_cable/connection_test.rb
```