### PR TITLE
Replace nose with unittest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,6 @@ jobs:
         pipenv run lint
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         pipenv run lint-warn
-    - name: Test with nosetests
+    - name: Test with unittest
       run: |
         pipenv run test

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ setuptools = ">=30.3.0"
 setuptools-scm = "*"
 wheel = "*"
 autopep8 = "*"
-nose = "*"
 importlib-metadata = "*"
 responses = "*"
 
@@ -19,7 +18,7 @@ launchable = {editable = true,path = "."}
 [scripts]
 build = "python setup.py sdist bdist_wheel"
 install = "pip install -U ."
-test = "python -m nose tests"
+test = "python -m unittest"
 lint = "flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics"
 lint-warn = "flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics"
 format = "autopep8 -ivr ."

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ install_requires =
     requests
     junitparser>=1.6.3
     setuptools
-tests_requires =
-    nose
 python_requires = >=3.4
 
 [options.entry_points]
@@ -30,7 +28,3 @@ console_scripts = launchable = launchable.__main__:main
 
 [options.package_data]
 launchable = jar/exe_deploy.jar
-
-[nosetests]
-exe = True
-tests = tests

--- a/tests/commands/test_verify.py
+++ b/tests/commands/test_verify.py
@@ -1,36 +1,38 @@
-from nose.tools import eq_
+from unittest import TestCase
 from launchable.commands.verify import *
 
-def test_compare_version():
-    def sign(x):
-        if x<0:
-            return -1
-        if x>0:
-            return 1
-        return 0
 
-    def f(expected, a,b):
-        """Ensure symmetry on two sides"""
-        eq_(sign(compare_version(a,b)), expected)
-        eq_(sign(compare_version(b,a)), -expected)
+class VersionTest(TestCase):
+    def test_compare_version(self):
+        def sign(x):
+            if x<0:
+                return -1
+            if x>0:
+                return 1
+            return 0
 
-    f(0, [1, 1, 0], [1, 1])     # 1.1.0 = 1.1
-    f(1, [1, 1], [1, 0])        # 1.1 > 1.0
-    f(1, [1, 0, 1], [1])        # 1.0.1 > 1
+        def f(expected, a,b):
+            """Ensure symmetry on two sides"""
+            self.assertEqual(sign(compare_version(a,b)), expected)
+            self.assertEqual(sign(compare_version(b,a)), -expected)
 
-def test_java_version():
-    assert compare_java_version(
-"""
-java version "1.8.0_144"
-Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
-Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)
-"""
-    ) >= 0
+        f(0, [1, 1, 0], [1, 1])     # 1.1.0 = 1.1
+        f(1, [1, 1], [1, 0])        # 1.1 > 1.0
+        f(1, [1, 0, 1], [1])        # 1.0.1 > 1
 
-    assert compare_java_version(
-"""
-java version "1.5.0_22"
-Java(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)
-Java HotSpot(TM) 64-Bit Server VM (build 1.5.0_22-b03, mixed mode)
-"""
-    ) < 0
+    def test_java_version(self):
+        self.assertTrue(compare_java_version(
+    """
+    java version "1.8.0_144"
+    Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
+    Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)
+    """
+        ) >= 0)
+
+        self.assertTrue(compare_java_version(
+    """
+    java version "1.5.0_22"
+    Java(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)
+    Java HotSpot(TM) 64-Bit Server VM (build 1.5.0_22-b03, mixed mode)
+    """
+        ) < 0)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,11 +1,12 @@
 from click.testing import CliRunner
 from launchable.__main__ import main
 from launchable.version import __version__
-from nose.tools import eq_
+from unittest import TestCase
 
 
-def test_version():
-    runner = CliRunner()
-    result = runner.invoke(main, ['--version'])
-    eq_(result.exit_code, 0)
-    eq_(result.output, 'launchable-cli, version {}\n'.format(__version__))
+class VersionTest(TestCase):
+    def test_version(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['--version'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, 'launchable-cli, version {}\n'.format(__version__))

--- a/tests/utils/test_gzipgen.py
+++ b/tests/utils/test_gzipgen.py
@@ -1,10 +1,11 @@
 from launchable.utils.gzipgen import compress
-from nose.tools import eq_
 import gzip
+from unittest import TestCase
 
-def test_compress():
-    """Basic sanity test of """
-    encoded=b''.join(compress([b'Hello',b' ',b'world']))
-    msg = gzip.decompress(encoded)
-    print(msg)
-    eq_(msg,b'Hello world')
+class GzippenTest(TestCase):
+    def test_compress(self):
+        """Basic sanity test of """
+        encoded=b''.join(compress([b'Hello',b' ',b'world']))
+        msg = gzip.decompress(encoded)
+        print(msg)
+        self.assertEqual(msg, b'Hello world')


### PR DESCRIPTION
We decided to use unittest as this CLI's test framework. I removed nose dependencies and add some unittest codes.