### PR TITLE
[ST-726] fix handling for test cases result data

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -44,8 +44,13 @@ class CaseEvent:
     def from_case_and_suite(cls, path_builder: TestPathBuilder, case: TestCase, suite: TestSuite, report_file: str, data: Dict = None) -> Dict:
         "Builds a JSON representation of CaseEvent"
 
-        status = CaseEvent.TEST_FAILED if case.result and any(isinstance(case.result, s) for s in (
-            Failure, Error)) else CaseEvent.TEST_SKIPPED if isinstance(case.result, Skipped) else CaseEvent.TEST_PASSED
+        status = CaseEvent.TEST_PASSED
+        for r in case.result:
+            if any(isinstance(r, s) for s in (Failure, Error)):
+                status = CaseEvent.TEST_FAILED
+                break
+            elif isinstance(r, Skipped):
+                status = CaseEvent.TEST_SKIPPED
 
         return {
             "type": cls.EVENT_TYPE,

--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -44,6 +44,7 @@ class CaseEvent:
     def from_case_and_suite(cls, path_builder: TestPathBuilder, case: TestCase, suite: TestSuite, report_file: str, data: Dict = None) -> Dict:
         "Builds a JSON representation of CaseEvent"
 
+        # TODO: reconsider the initial value of the status.
         status = CaseEvent.TEST_PASSED
         for r in case.result:
             if any(isinstance(r, s) for s in (Failure, Error)):

--- a/tests/data/googletest/fail/output.xml
+++ b/tests/data/googletest/fail/output.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="1" disabled="0" errors="0" time="0.001" timestamp="2021-01-26T14:56:53" name="AllTests">
+  <testsuite name="FooTest" tests="3" failures="1" disabled="0" errors="0" time="0.001" timestamp="2021-01-26T14:56:53">
+    <testcase name="Bar" status="run" result="completed" time="0.001" timestamp="2021-01-26T14:56:53" classname="FooTest">
+      <failure message="github.com/launchableinc/rocket-car-googletest/test_a.cpp:21&#x0A;Expected equality of these values:&#x0A;  false&#x0A;  true" type=""><![CDATA[github.com/launchableinc/rocket-car-googletest/test_a.cpp:21
+Expected equality of these values:
+  false
+  true]]></failure>
+    </testcase>
+    <testcase name="Baz" status="run" result="completed" time="0" timestamp="2021-01-26T14:56:53" classname="FooTest" />
+    <testcase name="Foo" status="run" result="completed" time="0" timestamp="2021-01-26T14:56:53" classname="FooTest" />
+  </testsuite>
+</testsuites>

--- a/tests/data/googletest/fail/record_test_result.json
+++ b/tests/data/googletest/fail/record_test_result.json
@@ -1,0 +1,8 @@
+{"events": [
+  {"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Bar", "_lineno": null}], "duration": 0.001, "status": 0, "stdout": "", "stderr": "", "created_at": "2021-01-26T14:56:53", "data": null}
+  ,
+  {"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Baz", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-26T14:56:53", "data": null}
+  ,
+  {"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Foo", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-26T14:56:53", "data": null}
+]}
+

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -35,3 +35,17 @@ class GoogleTestTest(CliTestCase):
             self.test_files_dir.joinpath('record_test_result.json'))
 
         self.assert_json_orderless_equal(expected, payload)
+
+    @responses.activate
+    def test_record_failed_test_googletest(self):
+        # ./test_a --gtest_output=xml:output.xml
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          'googletest', str(self.test_files_dir) + "/fail/")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(
+            b''.join(responses.calls[0].request.body)).decode())
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('fail/record_test_result.json'))
+
+        self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
Even though `junitparser.TestCase.result` is a type of [List](https://github.com/weiwei/junitparser/blob/master/junitparser/junitparser.py#L668-L669), compared TestResult with the result that is a List directly, so always status was a Success status before.

I'm wondering that should we set success status to status's initial value. 
Will you please comment on it?
