### PR TITLE
Fix TypeError when file/glob does not match any file

### DIFF
--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -69,7 +69,7 @@ class CommonRecordTestImpls:
                     # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
                     # raise it as an error. Note this can happen for reasons other than a configuration error.
                     # For example, if a build catastrophically failed and no tests got run.
-                    click.echo("No matches found: " % root, err=True)
+                    click.echo("No matches found: {}".format(root), err=True)
                     # intentionally exiting with zero
                     return
 

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -49,3 +49,12 @@ class GoogleTestTest(CliTestCase):
             self.test_files_dir.joinpath('fail/record_test_result.json'))
 
         self.assert_json_orderless_equal(expected, payload)
+
+    @responses.activate
+    def test_record_empty_dir(self):
+        path = 'latest/gtest_*_results.xml'
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          'googletest', path)
+        self.assertEqual(result.output.rstrip(
+            '\n'), "No matches found: {}".format(path))
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
https://github.com/launchableinc/cli/issues/103

Python's `"some_format" % some_string` needs `%s` in the format template such as `"some_format: %s" % some_string`. This is what caused #103 error.
