### PR TITLE
Add trap command lines to documents

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   * [Nose \(Python\)](integrations/nose-python.md)
   * [Generic file based test runner](integrations/file.md)
   * [Dealing with custom test report format](integrations/convert-to-junit.md)
+  * [Always record tests](integrations/always-run.md)
 * [Security](security/README.md)
   * [Data Privacy and Protection](security/data-privacy-and-protection.md)
   * [Security Policies](security/information-security.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -155,7 +155,7 @@ launchable record tests [OPTIONS] TESTRUNNER ...
 | `--session SESSIONID` | ID of the test session \(see `record session`\) | One of `--build` or `--session` is required |
 | `--base DIR` | See the discussion of `launchable subset --base` option. | No |
 
-This command reads JUnit XML report files produced by test runners and sends them to Launchable. This command require to run either tests succeed / failed
+This command reads JUnit XML report files produced by test runners and sends them to Launchable.
 
 Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`, see [Integrations](integrations/)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -155,7 +155,7 @@ launchable record tests [OPTIONS] TESTRUNNER ...
 | `--session SESSIONID` | ID of the test session \(see `record session`\) | One of `--build` or `--session` is required |
 | `--base DIR` | See the discussion of `launchable subset --base` option. | No |
 
-This command reads JUnit XML report files produced by test runners and sends them to Launchable.
+This command reads JUnit XML report files produced by test runners and sends them to Launchable. This command require to run either tests succeed / failed
 
 Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`, see [Integrations](integrations/)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,15 +24,13 @@ bundle install
 # ask Launchable which tests to run for this build
 launchable subset --build <BUILD NAME> [OPTIONS] > tests.txt
 
-# set trap to send test results to Launchable for this build either tests succeed/fail
-trap "launchable record tests <BUILD NAME> [OPTIONS]" 0 1
-
 # run those tests, for example:
 bundle exec rails test -v $(cat tests.txt)
 
-# remove trap
-trap -
-
+# send test results to Launchable for this build
+# Note: You need to configure the line to always run wheather test run succeeds/fails.
+#       See each integration page.
+launchable record tests <BUILD NAME> [OPTIONS]
 ```
 
 ### Data model
@@ -105,14 +103,13 @@ bundle install
 
 ## test step
 
-# set trap to send test results to Launchable for this build either tests succeed/fail
-trap "launchable record tests <BUILD NAME> [OPTIONS]" 0 1
-
 # run tests
 bundle exec rails test
 
-# remove trap
-trap -
+# send test results to Launchable for this build
+# Note: You need to configure the line to always run wheather test run succeeds/fails.
+#       See each integration page.
+launchable record tests <BUILD NAME> [OPTIONS]
 ```
 
 Keen eyes will notice that this is everything from the previous example **except** `launchable subset`, which we don't want to add until we're ready to actually subset tests.
@@ -257,16 +254,15 @@ launchable subset \
     > launchable-subset.txt
 
 # set trap to send test results to Launchable for this build either tests succeed/fail
-trap "launchable record tests \
-    --build <BUILD NAME> \
-    minitest ./test/reports" 0 1
+function record() { \
+    launchable record tests \
+        --build <BUILD NAME> \
+        minitest ./test/reports \
+}
+trap record EXIT SIGHUP
 
 # run the subset
 bundle exec rails test -v $(cat launchable-subset.txt)
-
-# remove trap
-trap -
-
 ```
 
 ## Troubleshooting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,11 +24,15 @@ bundle install
 # ask Launchable which tests to run for this build
 launchable subset --build <BUILD NAME> [OPTIONS] > tests.txt
 
+# set trap to send test results to Launchable for this build either tests succeed/fail
+trap "launchable record tests <BUILD NAME> [OPTIONS]" 0 1
+
 # run those tests, for example:
 bundle exec rails test -v $(cat tests.txt)
 
-# send test results to Launchable for this build
-launchable record tests <BUILD NAME> [OPTIONS]
+# remove trap
+trap -
+
 ```
 
 ### Data model
@@ -101,11 +105,14 @@ bundle install
 
 ## test step
 
+# set trap to send test results to Launchable for this build either tests succeed/fail
+trap "launchable record tests <BUILD NAME> [OPTIONS]" 0 1
+
 # run tests
 bundle exec rails test
 
-# send test results to Launchable for this build
-launchable record tests <BUILD NAME> [OPTIONS]
+# remove trap
+trap -
 ```
 
 Keen eyes will notice that this is everything from the previous example **except** `launchable subset`, which we don't want to add until we're ready to actually subset tests.
@@ -249,13 +256,17 @@ launchable subset \
     minitest ./test \
     > launchable-subset.txt
 
+# set trap to send test results to Launchable for this build either tests succeed/fail
+trap "launchable record tests \
+    --build <BUILD NAME> \
+    minitest ./test/reports" 0 1
+
 # run the subset
 bundle exec rails test -v $(cat launchable-subset.txt)
 
-# send test reports
-launchable record tests \
-    --build <BUILD NAME> \
-    minitest ./test/reports
+# remove trap
+trap -
+
 ```
 
 ## Troubleshooting

--- a/docs/integrations/always-run.md
+++ b/docs/integrations/always-run.md
@@ -8,11 +8,11 @@ Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline
 ```gradle
 pipeline {
   ...
-  bundle exec rails test -v $(cat launchable-subset.txt)
+  sh 'bundle exec rails test -v $(cat launchable-subset.txt)'
   ...
   post {
     always {
-      launchable record tests <BUILD NAME> [OPTIONS]
+      sh 'launchable record tests <BUILD NAME> [OPTIONS]'
     }
   }
 }

--- a/docs/integrations/always-run.md
+++ b/docs/integrations/always-run.md
@@ -1,0 +1,61 @@
+# Always run the command
+
+`launchable record tests` requires always run whether test run succeeds or fails. The way depends on your CI environment. 
+
+### Jenkins
+Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline/syntax/#post) option:
+
+```gradle
+pipeline {
+  ...
+  bundle exec rails test -v $(cat launchable-subset.txt)
+  ...
+  post {
+    always {
+      launchable record tests <BUILD NAME> [OPTIONS]
+    }
+  }
+}
+```
+
+### CircleCI
+CircleCI has [`when: always`](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute) option:
+```yaml
+- jobs:
+  - test:
+    ...
+    - run:
+      name: Run tests
+      command: bundle exec rails test -v $(cat launchable-subset.txt)
+    - run:
+      name: Record test results
+      command: launchable record tests <BUILD NAME> [OPTIONS]
+      when: always
+
+```
+### Github Actions
+GithubAction has [`if: ${{ always() }}`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always) option:
+
+```yaml
+jobs:
+  test:
+    steps:
+      ...
+      - name: Run tests
+        run: bundle exec rails test -v $(cat launchable-subset.txt)
+      - name: Record test result
+        run: launchable record tests <BUILD NAME> [OPTIONS]
+        if: always()
+```
+
+### Bash
+If you run tests on your local or other CI, you can use `trap`:
+```bash
+function record() {
+  launchable record tests <BUILD NAME> [OPTIONS]
+}
+# set a trap to send test results to Launchable for this build either tests succeed/fail
+trap record EXIT SIGHUP
+
+bundle exec rails test -v $(cat launchable-subset.txt)
+```

--- a/docs/integrations/bazel.md
+++ b/docs/integrations/bazel.md
@@ -10,70 +10,9 @@ bazel test //...
 
 launchable record tests --build <BUILD NAME> bazel .
 ```
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 For more information and advanced options, run `launchable record tests bazel --help`
-
-
-### Always run the command
-
-`launchable record tests` requires always run whether test run succeeds or fails. The way depends on your CI environment. 
-
-#### Jenkins
-Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline/syntax/#post) option:
-
-```gradle
-pipeline {
-  ...
-  bazel test //...
-  ...
-  post { 
-    always {
-      launchable record tests --build <BUILD NAME> bazel .
-    }
-  }
-}
-```
-
-#### CircleCI
-CircleCI has [`when: always`](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute) option:
-```yaml
-- jobs:
-  - test:
-    ...
-    - run:
-      name: Run tests
-      command: bazel test //...
-    - run:
-      name: Record test results
-      command: launchable record tests --build <BUILD NAME> bazel .
-      when: always
-
-```
-#### Github Actions
-GithubAction has [`if: ${{ always() }}`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always) option:
-
-```yaml
-jobs:
-  test:
-    steps:
-      ...
-      - name: Run tests
-        run: bazel test //...
-      - name: Record test result
-        run: launchable record tests --build <BUILD NAME> bazel .
-        if: always()
-```
-
-#### Bash
-If you run tests on your local or other CI, you can use `trap`:
-```bash
-function record() {
-  launchable record tests --build <BUILD NAME> bazel .
-}
-# set a trap to send test results to Launchable for this build either tests succeed/fail
-trap record EXIT SIGHUP
-
-bazel test //...
-```
 
 ## Subsetting test execution
 

--- a/docs/integrations/bazel.md
+++ b/docs/integrations/bazel.md
@@ -10,8 +10,70 @@ bazel test //...
 
 launchable record tests --build <BUILD NAME> bazel .
 ```
-
 For more information and advanced options, run `launchable record tests bazel --help`
+
+
+### Always run the command
+
+`launchable record tests` requires always run whether test run succeeds or fails. The way depends on your CI environment. 
+
+#### Jenkins
+Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline/syntax/#post) option:
+
+```gradle
+pipeline {
+  ...
+  bazel test //...
+  ...
+  post { 
+    always {
+      launchable record tests --build <BUILD NAME> bazel .
+    }
+  }
+}
+```
+
+#### CircleCI
+CircleCI has [`when: always`](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute) option:
+```yaml
+- jobs:
+  - test:
+    ...
+    - run:
+      name: Run tests
+      command: bazel test //...
+    - run:
+      name: Record test results
+      command: launchable record tests --build <BUILD NAME> bazel .
+      when: always
+
+```
+#### Github Actions
+GithubAction has [`if: ${{ always() }}`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always) option:
+
+```yaml
+jobs:
+  test:
+    steps:
+      ...
+      - name: Run tests
+        run: bazel test //...
+      - name: Record test result
+        run: launchable record tests --build <BUILD NAME> bazel .
+        if: always()
+```
+
+#### Bash
+If you run tests on your local or other CI, you can use `trap`:
+```bash
+function record() {
+  launchable record tests --build <BUILD NAME> bazel .
+}
+# set a trap to send test results to Launchable for this build either tests succeed/fail
+trap record EXIT SIGHUP
+
+bazel test //...
+```
 
 ## Subsetting test execution
 

--- a/docs/integrations/cypress.md
+++ b/docs/integrations/cypress.md
@@ -13,6 +13,8 @@ cypress run --reporter junit --reporter-options "mochaFile=report/test-output-[h
 launchable record tests --build <BUILD NAME> cypress ./report/*.xml
 ```
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](integrations/always-run.md).
+
 For more information and advanced options, run `launchable record tests cypress --help`
 
 ## Subsetting test execution

--- a/docs/integrations/file.md
+++ b/docs/integrations/file.md
@@ -62,6 +62,8 @@ launchable record tests \
 
 When test reports contain absolute path names of test files, it prevents Launchable from seeing that `/home/kohsuke/ws/foo.js` from one test execution and `/home/john/src/foo.js` from another execution are actually the same test, so the `--base` option is used to relativize the test file names.
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 ## Subsetting test execution
 
 To obtain the appropriate subset of tests to run, start by enumerating test files that are considered for execution, then pipe that to `stdin` of `launchable subset` command.

--- a/docs/integrations/go-test.md
+++ b/docs/integrations/go-test.md
@@ -16,6 +16,8 @@ go test -v ./... | go-junit-report > report.xml
 launchable record tests ... go-test .
 ```
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 For more information and advanced options, run `launchable record tests go-test --help`
 
 ## Subsetting test execution

--- a/docs/integrations/googletest.md
+++ b/docs/integrations/googletest.md
@@ -13,6 +13,8 @@ After running tests, point to the directory that contains all the generated test
 launchable record tests --build <BUILD NAME> googletest ./report
 ```
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 For more information and advanced options, run `launchable record tests googletest --help`
 
 ## Subsetting test execution

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -13,6 +13,8 @@ gradle test ...
 launchable record tests --build <BUILD NAME> gradle ./build/test-results/test/
 ```
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 For a large project, a dedicated Gradle task to list up all report directories might be convenient. See [the upstream documentation](https://docs.gradle.org/current/userguide/java_testing.html#test_reporting) for more details and insights.
 
 Alternatively, you can specify a glob pattern for directories or individual test report files \(this pattern might already be specified in your pipeline script\):

--- a/docs/integrations/minitest.md
+++ b/docs/integrations/minitest.md
@@ -13,6 +13,8 @@ bundle exec rails test
 launchable record tests --build <BUILD NAME> minitest "$CIRCLE_TEST_REPORTS/reports"
 ```
 
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](always-run.md).
+
 For more information and advanced options, run `launchable record tests minitest --help`
 
 ## Subsetting test execution


### PR DESCRIPTION
I found an issue. Most of CI system exits its run process when a test is failed. It means `record tests` after the test run doesn't run that time. To avoid this problem, customers must configure to run `record tests` after the test failed.

I propose the following setting. `trap` handles shell command signal. `0 1` are normal exit 0 and failure 1 (I think we can expect all test frameworks use this signal). 

```bash
trap "launchable record tests <BUILD NAME> [OPTIONS]" 0 1
bundle exec rails test -v $(cat tests.txt)
trap -
```

I want to add these instructions to the documents. I added some lines on this PR, but I think it's not enough. Please give me some idea about the following discussion point. 

# Discussions
## Other methods
There are other always run commands that depend on CI system. For example, Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline/syntax/#post), GithubAction has [`if: ${{ always() }}`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always), CircleCI has [`when: always`](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute). Do we introduce those solutions in the doc? If do this, what page do we edit?

## Other pages
I added some lines to `getting-started.md`. Do we need to add those lines to other pages? I think we should add lines to integration pages and `cli-reference.md`, but I'm not sure how I write those pages. Any idea is welcome.