### PR TITLE
Remove CTest support from GoogleTest plugin

### DIFF
--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -25,13 +25,6 @@ def subset(client):
         if gtest_case and cls:
             case = gtest_case.group(1)
             client.test_path(make_test_path(cls, case))
-        
-        # handle ctest -N output
-        # Test #1: FooTest.Bar -> (FooTest, Bar)
-        ctest_result = re.match(r'^  Test #\d+: ([^ ]+)$', label)
-        if ctest_result:
-            (cls, case) = ctest_result.group(1).split('.')
-            client.test_path(make_test_path(cls, case))
 
     client.formatter = lambda x: x[0]['name'] + "." + x[1]['name']
     client.run()

--- a/tests/data/googletest/subset_result.json
+++ b/tests/data/googletest/subset_result.json
@@ -1,88 +1,18 @@
 {
-  "session": {
-    "id": "16"
-  },
-  "target": 0.1,
   "testPaths": [
     [
-      {
-        "name": "  Test #1: FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Test",
-        "type": "testcase"
-      }
+      { "type": "class", "name": "FooTest" },
+      { "type": "testcase", "name": "Bar" }
     ],
     [
-      {
-        "name": "FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Bar",
-        "type": "testcase"
-      }
+      { "type": "class", "name": "FooTest" },
+      { "type": "testcase", "name": "Baz" }
     ],
     [
-      {
-        "name": "  Test #2: FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Test",
-        "type": "testcase"
-      }
-    ],
-    [
-      {
-        "name": "FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Baz",
-        "type": "testcase"
-      }
-    ],
-    [
-      {
-        "name": "  Test #3: FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Test",
-        "type": "testcase"
-      }
-    ],
-    [
-      {
-        "name": "FooTest",
-        "type": "class"
-      },
-      {
-        "name": "Foo",
-        "type": "testcase"
-      }
-    ],
-    [
-      {
-        "name": "  Test #4: */ParameterizedTest",
-        "type": "class"
-      },
-      {
-        "name": "Test",
-        "type": "testcase"
-      }
-    ],
-    [
-      {
-        "name": "*/ParameterizedTest",
-        "type": "class"
-      },
-      {
-        "name": "Bar/*",
-        "type": "testcase"
-      }
+      { "type": "class", "name": "FooTest" },
+      { "type": "testcase", "name": "Foo" }
     ]
-  ]
+  ],
+  "target": 0.1,
+  "session": { "id": "16" }
 }

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -12,7 +12,11 @@ class GoogleTestTest(CliTestCase):
     @responses.activate
     def test_subset(self):
         # I use "ctest -N" to get this list.
-        pipe = "Test project github.com/launchableinc/rocket-car-googletest\n  Test #1: FooTest.Bar\n  Test #2: FooTest.Baz\n  Test #3: FooTest.Foo\n  Test #4: */ParameterizedTest.Bar/*\n\nTotal Tests: 4"
+        pipe = """FooTest.
+  Bar
+  Baz
+  Foo
+        """
         result = self.cli('subset', '--target', '10%',
                           '--session', self.session, 'googletest', input=pipe)
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
We have the new CTest plugin. To avoid confusion, I remove CTest support in the GoogleTest plugin. IIRC, the feature is undocumented and no customer uses it.