### PR TITLE
For better diagnostics, report the path of the offending file

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -123,24 +123,27 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
                 first = True        # used to control ',' in printing
 
                 for p in self.reports:
-                    # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful
-                    # TODO: robustness: what's the best way to deal with broken XML file, if any?
-                    xml = JUnitXml.fromfile(p, self.junitxml_parse_func)
-                    if isinstance(xml, JUnitXml):
-                        testsuites = [suite for suite in xml]
-                    elif isinstance(xml, TestSuite):
-                        testsuites = [xml]
-                    else:
-                        # TODO: what is a Pythonesque way to do this?
-                        assert False
+                    try:
+                        # To understand JUnit XML format, https://llg.cubic.org/docs/junit/ is helpful
+                        # TODO: robustness: what's the best way to deal with broken XML file, if any?
+                        xml = JUnitXml.fromfile(p, self.junitxml_parse_func)
+                        if isinstance(xml, JUnitXml):
+                            testsuites = [suite for suite in xml]
+                        elif isinstance(xml, TestSuite):
+                            testsuites = [xml]
+                        else:
+                            # TODO: what is a Pythonesque way to do this?
+                            assert False
 
-                    for suite in testsuites:
-                        for case in suite:
-                            if not first:
-                                yield ','
-                            first = False
+                        for suite in testsuites:
+                            for case in suite:
+                                if not first:
+                                    yield ','
+                                first = False
 
-                            yield json.dumps(CaseEvent.from_case_and_suite(self.path_builder, case, suite, p))
+                                yield json.dumps(CaseEvent.from_case_and_suite(self.path_builder, case, suite, p))
+                    except Exception as e:
+                        raise Exception("Failed to process a report file: %s" % p) from e
                 yield ']}'
 
             def printer(f):

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import responses, traceback
+
+from tests.cli_test_case import CliTestCase
+
+
+class TestsTest(CliTestCase):
+
+    @responses.activate
+    def test_filename_in_error_message(self):
+        broken_xml = str(Path(__file__).parent.joinpath('../../data/broken.xml').resolve())
+        self.cli('record', 'tests', '--build', self.build_name, 'file', broken_xml)
+        # mock doesn't evaluate generator so we need to do so here
+        g = responses.calls[1].request.body
+        try:
+            b''.join(g)
+        except Exception as e:
+            # making sure the offending file path name is being printed.
+            self.assertIn(broken_xml, traceback.format_exc())
+        else:
+            self.fail("Expected to see an error")

--- a/tests/data/broken.xml
+++ b/tests/data/broken.xml
@@ -1,0 +1,1 @@
+this is not an XML!


### PR DESCRIPTION
A number of users repored problems while recording test results. When the parsing blows up, right now we don't know which file is offending, which makes the error diagnostics harder. Report the name of the offending file, so that we can pin down exactly which file is problematic.