### PR TITLE
User friendliness improvements

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -1,6 +1,7 @@
 import click
 import json
 import os
+import sys
 from os.path import *
 import glob
 import gzip
@@ -109,6 +110,17 @@ def subset(context, target, session_id, base_path: str, build_name: str):
             """register one test"""
             self.test_paths.append(self.to_test_path(path))
 
+        def stdin(self):
+            """
+            Returns sys.stdin, but after ensuring that it's connected to something reasonable.
+
+            This prevents a typical problem where users think CLI is hanging because
+            they didn't feed anything from stdin
+            """
+            if sys.stdin.isatty():
+                click.echo(click.style("Warning: this command reads from stdin but it doesn't appear to be connected to anything. Did you forget to pipe from another command?", fg='yellow'), err=True)
+            return sys.stdin
+
         @staticmethod
         def to_test_path(x: TestPathLike) -> TestPath:
             """Convert input to a TestPath"""
@@ -189,6 +201,8 @@ def subset(context, target, session_id, base_path: str, build_name: str):
                         raise e
                     else:
                         click.echo(e, err=True)
+                    click.echo(click.style("Warning: the service failed to subset. Falling back to running all tests", fg='yellow'), err=True)
+
 
             # regardless of whether we managed to talk to the service
             # we produce test names

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from os.path import join
 
 import click
@@ -16,7 +15,7 @@ def make_test_path(pkg, target) -> TestPath:
 @launchable.subset
 def subset(client):
     # Read targets from stdin, which generally looks like //foo/bar:zot
-    for label in sys.stdin:
+    for label in client.stdin():
         # //foo/bar:zot -> //foo/bar & zot
         if label.startswith('//'):
             pkg, target = label.rstrip('\n').split(':')

--- a/launchable/test_runners/ctest.py
+++ b/launchable/test_runners/ctest.py
@@ -16,7 +16,7 @@ def subset(client, file):
         with Path(file).open() as json_file:
             data = json.load(json_file)
     else:
-        data = json.loads(sys.stdin)
+        data = json.loads(client.stdin())
 
     for test in data['tests']:
         case = test['name']

--- a/launchable/test_runners/cypress.py
+++ b/launchable/test_runners/cypress.py
@@ -1,6 +1,4 @@
 import click
-import os
-import sys
 from . import launchable
 from junitparser import TestSuite, JUnitXml
 from xml.etree import ElementTree as ET
@@ -29,7 +27,7 @@ def record_tests(client, reports):
 @launchable.subset
 def subset(client):
     # read lines as test file names
-    for t in sys.stdin:
+    for t in client.stdin():
         client.test_path(t.rstrip("\n"))
 
     client.separator = ','

--- a/launchable/test_runners/file.py
+++ b/launchable/test_runners/file.py
@@ -2,16 +2,16 @@
 # The most bare-bone versions of the test runner support
 #
 import click
-import sys
-from . import launchable
 from junitparser import TestCase, TestSuite
+
+from . import launchable
 from ..testpath import TestPath
 
 
 @launchable.subset
 def subset(client):
     # read lines as test file names
-    for t in sys.stdin:
+    for t in client.stdin():
         client.test_path(t.rstrip("\n"))
     client.run()
 

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -1,10 +1,8 @@
-import sys
-import click
 from . import launchable
 
 @launchable.subset
 def subset(client):
-    for case in sys.stdin:
+    for case in client.stdin():
         # Avoid last line such as `ok      github.com/launchableinc/rocket-car-gotest      0.268s`
         if not ' ' in case:
             client.test_path([{'type': 'testcase', 'name': case.rstrip('\n')}])

--- a/launchable/test_runners/googletest.py
+++ b/launchable/test_runners/googletest.py
@@ -1,6 +1,4 @@
-import sys
 import re
-import click
 
 from . import launchable
 from ..testpath import TestPath
@@ -13,7 +11,7 @@ def make_test_path(cls, case) -> TestPath:
 @launchable.subset
 def subset(client):
     cls = ''
-    for label in map(str.rstrip, sys.stdin):
+    for label in map(str.rstrip, client.stdin()):
         # handle Google Test's --gtest_list_tests output
         # FooTest.
         #  Bar


### PR DESCRIPTION
- If we are reading stdin but it's not piped from a file/process, issue a warning. In a rare case this is intended (someone interactively debugging), but more often this is just a misunderstanding of the way CLI works, and an user mistakenly thinks that the CLI is hanging.
- If the server reports an error and we fall back, tell users we are doing that, again to avoid a surprise.