### PR TITLE
Set a time out

### DIFF
--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -21,6 +21,10 @@ class LaunchableClient:
     def request(self, method, path, **kwargs):
         headers = kwargs.pop("headers")
         url = self.base_url + path
+        if 'timeout' not in kwargs:
+            # (connection timeout, read timeout) in seconds
+            kwargs['timeout'] = (5,60)
+
         try:
             return self.http.request(method, url, headers={**headers, **self._headers()}, **kwargs)
         except Exception as e:


### PR DESCRIPTION
... so that a call will never hang and block people's builds/tests.

The connection time out is set aggressively, given that we have the
acess terminated at ALB and it's hard to imagine the pick up taking
longer than milliseconds order.

The read time out needs to be lax at the moment, mainly for `subset`
that might have to wait for a model to load, which is currently costly.