### PR TITLE
Fix CTest to handle skipped case

### DIFF
--- a/launchable/test_runners/ctest.py
+++ b/launchable/test_runners/ctest.py
@@ -52,32 +52,43 @@ def record_tests(client, source_roots):
         testsuite = ET.Element("testsuite", {"name": "CTest"})
         test_count = 0
         failure_count = 0
+        skip_count = 0
 
         for test in original_tree.findall("./Testing/Test"):
             test_name = test.find("Name")
-            duration = test.find(
-                "./Results/NamedMeasurement[@name=\"Execution Time\"]/Value")
-            measurement = test.find("Results/Measurement/Value")
-            testcase = ET.SubElement(testsuite, "testcase", {
-                                     "name": test_name.text, "time": duration.text, "system-out": measurement.text})
+            if test_name != None:
+                duration = test.find(
+                    "./Results/NamedMeasurement[@name=\"Execution Time\"]/Value")
+                measurement = test.find("Results/Measurement/Value")
+                stdout = measurement.text if measurement != None else ''
+                duration = duration.text if duration != None else '0'
 
-            system_out = ET.SubElement(testcase, "system-out")
-            system_out.text = measurement.text
+                testcase = ET.SubElement(testsuite, "testcase", {
+                                        "name": test_name.text, "time": duration, "system-out": stdout})
 
-            test_count += 1
+                system_out = ET.SubElement(testcase, "system-out")
+                system_out.text = stdout
 
-            if test.get("Status") != "passed":
-                failure = ET.SubElement(testcase, "failure")
-                failure.text = measurement.text
+                test_count += 1
 
-                failure_count += 1
+                if test.get("Status") == "failed":
+                    failure = ET.SubElement(testcase, "failure")
+                    failure.text = stdout
+
+                    failure_count += 1
+
+                if test.get("Status") == "norun":
+                    skipped = ET.SubElement(testcase, "skipped")
+                    skipped.text = stdout
+
+                    skip_count += 1
 
         testsuite.attrib.update({
                                 "tests": test_count,
                                 "time": 0,
                                 "failures": failure_count,
                                 "errors": 0,
-                                "skipped": 0
+                                "skipped": skip_count
                                 })
 
         return ET.ElementTree(testsuite)

--- a/launchable/test_runners/ctest.py
+++ b/launchable/test_runners/ctest.py
@@ -70,18 +70,19 @@ def record_tests(client, source_roots):
                 system_out.text = stdout
 
                 test_count += 1
+                status = test.get("Status")
+                if status != None:
+                    if status == "failed":
+                        failure = ET.SubElement(testcase, "failure")
+                        failure.text = stdout
 
-                if test.get("Status") == "failed":
-                    failure = ET.SubElement(testcase, "failure")
-                    failure.text = stdout
+                        failure_count += 1
 
-                    failure_count += 1
+                    if status == "notrun":
+                        skipped = ET.SubElement(testcase, "skipped")
+                        skipped.text = stdout
 
-                if test.get("Status") == "norun":
-                    skipped = ET.SubElement(testcase, "skipped")
-                    skipped.text = stdout
-
-                    skip_count += 1
+                        skip_count += 1
 
         testsuite.attrib.update({
                                 "tests": test_count,

--- a/tests/data/ctest/Testing/latest/Test.xml
+++ b/tests/data/ctest/Testing/latest/Test.xml
@@ -157,20 +157,17 @@ Expected equality of these values:
 				</Measurement>
 			</Results>
 		</Test>
-		<Test Status="passed">
+		<Test Status="notrun">
 			<Name>*/ParameterizedTest.Bar/*</Name>
 			<Path>.</Path>
 			<FullName>./*/ParameterizedTest.Bar/*</FullName>
 			<FullCommandLine>/Users/ninjin/src/github.com/launchableinc/rocket-car-googletest/test_b "--gtest_filter=*/ParameterizedTest.Bar/*" "--gtest_output=xml:./output_b.xml"</FullCommandLine>
 			<Results>
-				<NamedMeasurement type="numeric/double" name="Execution Time">
-					<Value>0.00468914</Value>
-				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="Processors">
 					<Value>1</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="text/string" name="Completion Status">
-					<Value>Completed</Value>
+									<Value>SKIP_REGULAR_EXPRESSION_MATCHED</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="text/string" name="Command Line">
 					<Value>/Users/ninjin/src/github.com/launchableinc/rocket-car-googletest/test_b "--gtest_filter=*/ParameterizedTest.Bar/*" "--gtest_output=xml:./output_b.xml"</Value>

--- a/tests/data/ctest/record_test_result.json
+++ b/tests/data/ctest/record_test_result.json
@@ -42,8 +42,8 @@
           "_lineno": null
         }
       ],
-      "duration": 0.00468914,
-      "status": 1,
+      "duration": 0,
+      "status": 2,
       "stdout": "Note: Google Test filter = */ParameterizedTest.Bar/*\n[==========] Running 3 tests from 1 test suite.\n[----------] Global test environment set-up.\n[----------] 3 tests from IncetanceA/ParameterizedTest\n[ RUN      ] IncetanceA/ParameterizedTest.Bar/0\n[       OK ] IncetanceA/ParameterizedTest.Bar/0 (0 ms)\n[ RUN      ] IncetanceA/ParameterizedTest.Bar/1\n[       OK ] IncetanceA/ParameterizedTest.Bar/1 (0 ms)\n[ RUN      ] IncetanceA/ParameterizedTest.Bar/2\n[       OK ] IncetanceA/ParameterizedTest.Bar/2 (0 ms)\n[----------] 3 tests from IncetanceA/ParameterizedTest (0 ms total)\n\n[----------] Global test environment tear-down\n[==========] 3 tests from 1 test suite ran. (0 ms total)\n[  PASSED  ] 3 tests.\n",
       "stderr": "",
       "data": null


### PR DESCRIPTION
According to our customer, CTest XML format don't have `<NamedMeasurement name="Execution Time" />` element in skipped tests. I fixed CTest plugin to handle missing that element. Also, I added a converter that handles a `notrun` case as a skipped case.