### PR TITLE
Refactor docs structure

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,25 +4,22 @@
 * [How it works](how-it-works.md)
 * [Getting started](getting-started.md)
 
-## Integrations
+## Phase 1: Training a model <a id="training-a-model"></a>
 
-* [Bazel](integrations/bazel.md)
-* [Cypress](integrations/cypress.md)
-* [GoogleTest \(C++\)](integrations/googletest.md)
-* [Go Test](integrations/go-test.md)
-* [Gradle](integrations/gradle.md)
-* [Maven](integrations/maven.md)
-* [Minitest \(Ruby\)](integrations/minitest.md)
-* [Nose \(Python\)](integrations/nose-python.md)
-* [CTest](integrations/ctest.md)
-* [Generic file based test runner](integrations/file.md)
+* [Recording builds](training-a-model/recording-builds.md)
+* [Recording test results](training-a-model/recording-test-results.md)
+
+## Phase 2: Optimizing test execution <a id="optimizing-test-execution"></a>
+
+* [Subsetting tests](optimizing-test-execution/subsetting-tests.md)
 
 ## Resources
 
-* [CLI reference](resources/cli-reference.md)
-* [Dealing with custom test report format](resources/convert-to-junit.md)
+* [Integrations](resources/integrations.md)
+* [Troubleshooting](resources/troubleshooting.md)
 * [Using 'sessions' to capture test reports from several machines](resources/using-sessions-to-capture-test-reports-from-several-machines.md)
-* [Always record tests](resources/always-run.md)
+* [Dealing with custom test report format](resources/convert-to-junit.md)
+* [CLI reference](resources/cli-reference.md)
 
 ## Security
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Implementing Launchable is a two step process:
+Implementing Launchable is a two phase process:
 
 1. First, you send test results and build info to Launchable every time tests run in your CI pipeline. Launchable uses this data to build a model.
 2. Then, you updated your CI pipeline to use the trained model to optimize test execution.
@@ -33,15 +33,7 @@ bundle exec rails test -v $(cat tests.txt)
 launchable record tests --build <BUILD NAME> [OPTIONS]
 ```
 
-### Data model
-
-Launchable optimizes test execution based on the new changes in a build being tested. Therefore, the data model is based around **builds** and **test sessions:**
-
-**Builds** are inherently related to **commits** from one or several **repositories**. We compare commits between builds to identify changes.
-
-A **test session** represents every time you run tests against a **build**. You can ask for a subset of **tests** specifically for that build, and you can submit **test reports** for that build to train the model.
-
-## Installing the CLI in your CI pipeline
+### Installing the CLI
 
 The Launchable CLI is a Python3 package that can be installed from [PyPI](https://pypi.org/):
 
@@ -75,211 +67,11 @@ launchable version: 1.3.1
 Your CLI configuration is successfully verified 🎉
 ```
 
-If you get an error, see [Troubleshooting](getting-started.md#troubleshooting).
+If you get an error, see [Troubleshooting](resources/troubleshooting.md).
 
 It is always a good idea to run `launchable verify` even for CI builds, as this information is useful in case of any problems. In that case, it is recommended to connect `|| true` so that the exit status is always `0`:
 
 ```bash
 launchable verify || true
 ```
-
-## Training a model
-
-First, you send test results and build info to Launchable every time you run tests. Launchable uses this data to build a model. When the model is trained, you'll update your pipeline again to [optimize test execution](getting-started.md#optimizing-test-execution).
-
-To train the model, you need to implement **commit, build,** and **test report** collection.
-
-At a high level, this looks like:
-
-```bash
-## build step
-
-# before building software, send commit and build info
-# to Launchable
-launchable record build --name <BUILD NAME> [OPTIONS]
-
-# build software the way you normally do, for example
-bundle install
-
-## test step
-
-# run tests
-bundle exec rails test
-
-# send test results to Launchable for this build
-# Note: You need to configure the line to always run wheather test run succeeds/fails.
-#       See each integration page.
-launchable record tests <BUILD NAME> [OPTIONS]
-```
-
-Keen eyes will notice that this is everything from the previous example **except** `launchable subset`, which we don't want to add until we're ready to actually subset tests.
-
-### Recording builds
-
-Launchable decides which tests to prioritize based on the changes contained in a build**.** To enable this, you need to send build and commit information to Launchable.
-
-{% hint style="info" %}
-**Commit collection**
-
-Changes are contained in commits, so you need to record commits and builds alongside each other. Launchable collects commit information from the repositories that you specified using `--source`. We then compare that information with commits from previous builds to determine what's changed in the build currently being tested.
-
-**We do not collect source code.** Only metadata about commits is captured, including:
-
-* Commit hash, author info, committer info, timestamps, and message
-* Names and paths of modified files
-* Count of modified lines
-{% endhint %}
-
-Find the point in your CI process where source code gets converted into the software that eventually get tested. This is typically called compilation, building, packaging, etc., using tools like Maven, make, grunt, etc.
-
-{% hint style="info" %}
-If you're using an interpreted language like Ruby or Python, record a build when you check out the repository as part of the build process.
-{% endhint %}
-
-Right before a build is produced, invoke the Launchable CLI as follows. Remember to make your API key available as the `LAUNCHABLE_TOKEN` environment variable prior to invoking `launchable`. In this example, the repository code is located in the current directory:
-
-```bash
-launchable record build --name <BUILD NAME> --source .
-
-# create the build
-bundle install
-```
-
-The `--source` option for both commands points to the local copy of the Git repository used to produce this build. See **Commit collection** above to learn more about how we use this.
-
-With the `--name` option for `record build`, you assign a unique identifier to this build. You will use this later when you run tests. See [Naming builds](getting-started.md#naming-builds) for tips on choosing this value. This, combined with earlier `launchable record build` invocations, allows Launchable to determine what’s changed for this particular build.
-
-{% hint style="info" %}
-If your software is built from multiple repositories, see [the example below](getting-started.md#example-software-built-from-multiple-repositories).
-{% endhint %}
-
-#### Choosing a value for `<BUILD NAME>`
-
-Your CI process probably already relies on some identifier to distinguish different builds. Such an identifier might be called a build number, build ID, etc. Most CI systems automatically make these values available via built-in environment variables. This makes it easy to pass this value into `record build`:
-
-| CI system | Suggested `<BUILD NAME>` | Documentation |
-| :--- | :--- | :--- |
-| Azure DevOps Pipelines | `Build.BuildId` | [https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables) |
-| Bitbucket Pipelines | `BITBUCKET_BUILD_NUMBER` | [https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) |
-| CircleCI | `CIRCLE_BUILD_NUM` | [https://circleci.com/docs/2.0/env-vars/\#built-in-environment-variables](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables) |
-| GitHub Actions | `GITHUB_RUN_ID` | [https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables\#default-environment-variables](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) |
-| GitLab CI | `CI_JOB_ID` | [https://docs.gitlab.com/ee/ci/variables/predefined\_variables.html](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) |
-| GoCD | `GO_PIPELINE_LABEL` | [https://docs.gocd.org/current/faq/dev\_use\_current\_revision\_in\_build.html\#standard-gocd-environment-variables](https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html#standard-gocd-environment-variables) |
-| Jenkins | `BUILD_TAG` | [https://www.jenkins.io/doc/book/pipeline/jenkinsfile/\#using-environment-variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables) |
-| Travis CI | `TRAVIS_BUILD_NUMBER` | [https://docs.travis-ci.com/user/environment-variables/\#default-environment-variables](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) |
-
-Some examples:
-
-* If your build produces an artifact or file that is later retrieved for testing, then `sha1sum` of the file would be a good build name as it is unique.
-* If you are building a Docker image, its content hash can be used as the unique identifier of a build: `docker inspect -f "{{.Id}}"`.
-
-{% hint style="warning" %}
-If you only have one source code repository, it might tempting to use a Git commit hash \(or `git-describe`\) as the build name, but we discourage this.
-
-It's not uncommon for teams to produce multiple builds from the same commit that are still considered different builds.
-{% endhint %}
-
-#### Example: Software built from multiple repositories
-
-If you produce a build by combining code from several repositories, invoke`launchable record build` with multiple `--source` options to denote them.
-
-To differentiate them, provide a label for each repository in the form of `LABEL=PATH`:
-
-```bash
-# record the build
-launchable record build --name <BUILD NAME> --source main=./main --source lib=./main/lib
-
-# create the build
-bundle install
-```
-
-{% hint style="info" %}
-Note: `record build` automatically recognizes [Git submodules](https://www.git-scm.com/book/en/v2/Git-Tools-Submodules), so there’s no need to explicitly declare them.
-{% endhint %}
-
-### Recording test results
-
-Then, after tests run, you send test reports to Launchable. How you do this depends on what test runners you use:
-
-* [Bazel](integrations/bazel.md#recording-test-results)
-* [Cypress](integrations/cypress.md#recording-test-results)
-* [GoogleTest](integrations/googletest.md#recording-test-results)
-* [Go Test](integrations/go-test.md#recording-test-results)
-* [Gradle](integrations/gradle.md#recording-test-results)
-* [Maven](integrations/maven.md)
-* [Minitest](integrations/minitest.md#recording-test-results)
-* [Nose](integrations/nose-python.md)
-* [CTest](integrations/ctest.md)
-
-Not using any of these? Try the [generic file based test runner](integrations/file.md#recording-test-results) option.
-
-## Subsetting test execution
-
-Your Launchable representative will contact you when your workspace's model is ready for use. Once it is, you can run the `launchable subset` command to get a dynamic list of tests to run from Launchable based on the changes in the `build` and the `target` you specify. In this example, we want to run 10% of tests, and we identify the full list of tests to run by inspecting Ruby files. We then pass that to a text file to be read later, when tests run:
-
-```bash
-launchable subset \
-    --build <BUILD NAME> \
-    --target 10% \
-    ...(test runner specific part)... > launchable-subset.txt
-```
-
-See the following sections for how to fill the `...(test runner specific part)...` in the above example:
-
-* [Bazel](integrations/bazel.md#subsetting-test-execution)
-* [Cypress](integrations/cypress.md#subsetting-test-execution)
-* [GoogleTest](integrations/googletest.md#subsetting-test-execution)
-* [Go Test](integrations/go-test.md#subsetting-test-execution)
-* [Gradle](integrations/gradle.md#subsetting-test-execution)
-* [Maven](integrations/maven.md)
-* [Minitest](integrations/minitest.md#subsetting-test-execution)
-* [Nose](integrations/nose-python.md#subsetting-test-execution)
-* [CTest](integrations/ctest.md#subsetting-test-execution)
-
-Not using any of these? Try the [generic file based test runner](integrations/file.md#subsetting-test-execution) option.
-
-That makes the complete implementation, including capturing commits and builds:
-
-```bash
-# verify connectivity [optional]
-launchable verify || true
-
-# record the build along with commits
-launchable record build --name <BUILD NAME> --source .
-
-# compile
-bundle install
-
-# subset tests
-launchable subset \
-    --build <BUILD NAME> \
-    --target 10% \
-    minitest ./test \
-    > launchable-subset.txt
-
-# set trap to send test results to Launchable for this build either tests succeed/fail
-function record() { \
-    launchable record tests \
-        --build <BUILD NAME> \
-        minitest ./test/reports \
-}
-trap record EXIT SIGHUP
-
-# run the subset
-bundle exec rails test -v $(cat launchable-subset.txt)
-```
-
-## Troubleshooting
-
-### Verification failure
-
-#### Connectivity
-
-If you need to interact with our API via static IPs, set the `LAUNCHABLE_BASE_URL` environment variable to `https://api-static.mercury.launchableinc.com`.
-
-The IP for this hostname will be either `13.248.185.38` or `76.223.54.162`.
-
-{% hint style="info" %}
-This documentation is current as of CLI version `1.3.1`
-{% endhint %}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,36 +4,48 @@
 
 Implementing Launchable is a two phase process:
 
-1. First, you send test results and build info to Launchable every time tests run in your CI pipeline. Launchable uses this data to build a model.
-2. Then, you updated your CI pipeline to use the trained model to optimize test execution.
+1. First, you **record a build** and **record test results** every time tests run in your CI pipeline. Launchable uses this data to build a machine learning model.
+2. Then, you update your CI pipeline to use the trained model to optimize test execution by **subsetting tests**.
 
-At a very high level, the eventual integration looks something like:
+How does this look in practice? Here's an example. Let's say you have a simple CI script that builds and tests your Rails app:
 
 ```bash
+## build step
+# build software
+bundle install
+
+## test step
+# run tests
+bundle exec rails test
+```
+
+After you've added Launchable, this script would look like:
+
+```bash
+## install the Launchable CLI
+pip3 install --user launchable~=1.0
+
 ## build step
 
 # before building software, send commit and build info
 # to Launchable
 launchable record build --name <BUILD NAME> [OPTIONS]
 
-# build software the way you normally do, for example
+# build software as usual
 bundle install
 
 ## test step
-
 # ask Launchable which tests to run for this build
-launchable subset --build <BUILD NAME> [OPTIONS] > tests.txt
+launchable subset --build <BUILD NAME> [OPTIONS] > subset.txt
 
-# run those tests, for example:
-bundle exec rails test -v $(cat tests.txt)
+# run those tests (note `-v $(cat tests.txt)`)
+bundle exec rails test -v $(cat subset.txt)
 
 # send test results to Launchable for this build
-# Note: You need to configure the line to always run wheather test run succeeds/fails.
-#       See each integration page.
 launchable record tests --build <BUILD NAME> [OPTIONS]
 ```
 
-### Installing the CLI
+## Installing the CLI
 
 The Launchable CLI is a Python3 package that can be installed from [PyPI](https://pypi.org/):
 
@@ -43,7 +55,7 @@ pip3 install --user launchable~=1.0
 
 It can be installed as a system package without `--user`, but this way you do not need the root access, which is handy when you are making this a part of the build script on your CI server.
 
-### Setting your API key
+## Setting your API key
 
 You should have received an API key from us already \(if you haven’t, let us know\). This authentication token allows the CLI to talk to the Launchable service.
 
@@ -53,7 +65,7 @@ You’ll need to make this API key available as the `LAUNCHABLE_TOKEN` environme
 * **CircleCI** See [Using Environment Variables](https://circleci.com/docs/2.0/env-vars/), which gets inserted as an environment variable.
 * **GitHub Actions**: See [how to configure a secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets), which gets inserted as an environment variable.
 
-### Verifying connectivity
+## Verifying connectivity
 
 You can run `launchable verify` to test connectivity. If successful, you should receive an output like:
 
@@ -74,4 +86,8 @@ It is always a good idea to run `launchable verify` even for CI builds, as this 
 ```bash
 launchable verify || true
 ```
+
+## Next steps
+
+Now you can start training a model by [Recording builds](training-a-model/recording-builds.md) and [Recording test results](training-a-model/recording-test-results.md).
 

--- a/docs/optimizing-test-execution/subsetting-tests.md
+++ b/docs/optimizing-test-execution/subsetting-tests.md
@@ -1,0 +1,185 @@
+# Subsetting tests
+
+Your Launchable representative will contact you when your workspace's model is ready for use. Once it is, you can run the `launchable subset` command to get a dynamic list of tests to run from Launchable based on the changes in the `build` and the `target` you specify. In this example, we want to run 10% of tests, and we identify the full list of tests to run by inspecting Ruby files. We then pass that to a text file to be read later, when tests run:
+
+```bash
+launchable subset \
+    --build <BUILD NAME> \
+    --target 10% \
+    ...(test runner specific part)... > launchable-subset.txt
+```
+
+See the following sections for how to fill the `...(test runner specific part)...` in the above example:
+
+* [Bazel](subsetting-tests.md#bazel)
+* [CTest](subsetting-tests.md#ctest)
+* [Cypress](subsetting-tests.md#cypress)
+* [GoogleTest](subsetting-tests.md#googletest)
+* [Go Test](subsetting-tests.md#go-test)
+* [Gradle](subsetting-tests.md#gradle)
+* [Maven](subsetting-tests.md#maven)
+* [Minitest](subsetting-tests.md#minitest)
+* [Nose](subsetting-tests.md#nose)
+
+Not using any of these? Try the [generic file based test runner](subsetting-tests.md#generic-file-based-test-runner) option.
+
+## Subsetting tests
+
+### Bazel
+
+To select meaningful subset of tests, first list up all the test targets you consider running, for example:
+
+```bash
+# list up all test targets in the whole workspace
+bazel query 'tests(//...)'
+
+# list up all test targets referenced from the aggregated smoke tests target
+bazel query 'test(//foo:smoke_tests)'
+```
+
+You feed that into `launchable subset bazel` to obtain the subset of those target:
+
+```bash
+bazel query 'tests(//...)' |
+launchable subset \
+    --build <BUILD NAME> \
+    --target 10% \
+    bazel > launchable-subset.txt
+```
+
+You can now invoke Bazel with it:
+
+```bash
+bazel test $(cat launchable-subset.txt)
+```
+
+### CTest
+
+To select meaningful subset of tests, have CTest list your test cases \([documentation](https://cmake.org/cmake/help/latest/manual/ctest.1.html)\), then feed that into Launchable CLI:
+
+```bash
+# --show-only=json-v1 option outputs test list as JSON
+ctest --show-only=json-v1 > test_list.json
+launchable subset ... ctest test_list.json > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. Now invoke CTest by passing those as an argument:
+
+```bash
+# run the test
+ctest -T test --no-compress-output -R $(cat launchable-subset.txt)
+```
+
+### Cypress
+
+To select a meaningful subset of tests, then feed that into Launchable CLI: `cypress/integration` is the [default directory](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-files) for test files, so you'll need to change this if your tests live in a different directory.
+
+```bash
+find ./cypress/integration | launchable subset --build <BUILD NAME>  cypress > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. You can now invoke your test executable to run exactly those tests:
+
+```bash
+cypress run --spec "$(cat launchable-subset.txt)"
+```
+
+### GoogleTest
+
+To select meaningful subset of tests, have GoogleTest list your test cases \([upstream documentation](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#listing-test-names)\), then feed that into Launchable CLI:
+
+```bash
+./my-test --gtest_list_tests | launchable subset ...  googletest > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. You can now invoke your test executable to run exactly those tests:
+
+```bash
+./my-test --gtest_filter="$(cat launchable-subset.txt)"
+```
+
+If you are only dealing with one test executable, you can also use `GTEST_FILTER` environment variable instead of the option. That might reduce the intrusion to your Makefile. See [upstream documentation](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#listing-test-names) for more details.
+
+### Go Test
+
+To select a meaningful subset of tests, have Go Test list your test cases \([upstream documentation](https://golang.org/cmd/go/#hdr-Testing_flags)\), then feed that into Launchable CLI:
+
+```bash
+go test -list ./... | launchable subset ... go-test > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. You can now invoke your test executable to run exactly those tests:
+
+```bash
+go test -run $(cat launchable-subset.txt) ./... -v 2>&1 | go-junit-report > report.xml
+```
+
+### Gradle
+
+To select meaningful subset of tests, give the test source roots to find all test classes.
+
+```bash
+launchable subset ... gradle project1/src/test/java project2/src/test/java > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. Now invoke Gradle by passing those as an argument:
+
+```bash
+gradle test $(cat launchable-subset.txt)
+```
+
+### Maven
+
+To select a meaningful subset of tests, then feed that into Launchable CLI:
+
+```bash
+launchable subset --build <BUILD NAME>  project1/src/test/java project2/src/test/java > launchable-subset.txt
+```
+
+The file will contain the subset of tests that should be run. You can now invoke your test executable to run exactly those tests:
+
+```bash
+maven test -Dsurefire.includeFiles=launchable-subset.txt
+```
+
+### Minitest
+
+To select meaningful subset of tests, feed all test ruby source files to Launchable, like this:
+
+```bash
+launchable subset ...  minitest test/**/*.rb > launchable-subset.txt
+```
+
+The file will contain the subset of test that should be run. You can now invoke minitest to run exactly those tests:
+
+```bash
+bundle exec rails test $(cat launchable-subset.txt)
+```
+
+### Nose
+
+For subsetting, you need an additional flag called `--launchable-subset-target`, which specifies the percentage of subsetting in the total execution time.
+
+For example, `--launchable-subset-target 20` means Launchable optimizes and subsets the tests so that the test duration will be 20% of the total test duration.
+
+```bash
+# subset tests with Launchable
+nosetests --launchable-subset --launchable-subset-target 20
+```
+
+### Generic file-based test runner
+
+To obtain the appropriate subset of tests to run, start by enumerating test files that are considered for execution, then pipe that to `stdin` of `launchable subset` command.
+
+The command will produce the names of the test files to be run to `stdout`, so you will then drive your test runner with this output.
+
+```bash
+find ./test -name '*.js' | 
+launchable subset \
+    --build <BUILD NAME> \
+    --target 10% \
+    file > subset.txt
+
+mocha $(< subset.txt)
+```
+

--- a/docs/optimizing-test-execution/subsetting-tests.md
+++ b/docs/optimizing-test-execution/subsetting-tests.md
@@ -1,5 +1,7 @@
 # Subsetting tests
 
+## Overview
+
 Your Launchable representative will contact you when your workspace's model is ready for use. Once it is, you can run the `launchable subset` command to get a dynamic list of tests to run from Launchable based on the changes in the `build` and the `target` you specify. In this example, we want to run 10% of tests, and we identify the full list of tests to run by inspecting Ruby files. We then pass that to a text file to be read later, when tests run:
 
 ```bash
@@ -23,7 +25,7 @@ See the following sections for how to fill the `...(test runner specific part)..
 
 Not using any of these? Try the [generic file based test runner](subsetting-tests.md#generic-file-based-test-runner) option.
 
-## Subsetting tests
+## Test runner integrations
 
 ### Bazel
 

--- a/docs/resources/cli-reference.md
+++ b/docs/resources/cli-reference.md
@@ -139,7 +139,7 @@ launchable subset [OPTIONS] TESTRUNNER ...
 | `--base DIR` | Advanced option. A large number of test runners use file names to identify tests, and for those test runners, so does Launchable. By default Launchable record test file names as given to it; IOW we expect those to be relative paths, so that identities of tests remain stable no matter where in the file system a Git workspace gets checked out. But in the rare circumstances where this behavior is inadequate, the `--base` option lets you specify a separate directory to relativize the path of tests before recording them. | No |
 | `--target PERCENTAGE` | Create a time-based subset of the given percentage. \(`0%-100%`\) | Yes |
 
-Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`s, see [Integrations]().
+Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`s, see [Integrations](cli-reference.md).
 
 ### record tests
 
@@ -157,7 +157,7 @@ launchable record tests [OPTIONS] TESTRUNNER ...
 
 This command reads JUnit XML report files produced by test runners and sends them to Launchable.
 
-Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`, see [Integrations]()
+Exactly how this command generates the subset and what's required to do this depends on test runners. For available supported `TESTRUNNER`, see [Integrations](cli-reference.md)
 
 ### verify
 

--- a/docs/resources/convert-to-junit.md
+++ b/docs/resources/convert-to-junit.md
@@ -10,7 +10,7 @@ Launchable uses so called JUnit report format, for example in `launchable record
 
 * `<testsuites>`, `<testsuite>`, `<testcase>` are the structural elements that matter. Their `name`, `classname` attributes are used to identify test names.
 * For a failed/errored/skipped test case, `<testcase>` element must have nested `<failure>`, `<error>`, or `<skipped>` child element.
-* While not documented in the referenced pages, `file` or `filepath` attributes on structural elements that point to the test source file path is a must for file-based test runner support, most notably the [file](../integrations/file.md) mode, which is most likely what you will use.
+* While not documented in the referenced pages, `file` or `filepath` attributes on structural elements that point to the test source file path is a must for file-based test runner support, most notably the [file]() mode, which is most likely what you will use.
 * `time` attribute on structural elements that indicates how long a test took to run.
 
 ### Nice to have

--- a/docs/resources/integrations.md
+++ b/docs/resources/integrations.md
@@ -1,0 +1,24 @@
+# Integrations
+
+## Test runners/build tools
+
+The Launchable CLI includes pre-built integrations with the following test runners/build tools:
+
+* [Bazel](https://bazel.build/)
+* [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html#id13)
+* [Cypress](https://www.cypress.io/)
+* [GoogleTest](https://github.com/google/googletest)
+* [Go Test](https://golang.org/pkg/testing/)
+* [Gradle](https://gradle.org/)
+* [Maven](https://maven.apache.org/)
+* [Minitest](https://github.com/seattlerb/minitest)
+* [Nose](https://nose.readthedocs.io/en/latest/index.html)
+
+And if you aren't using any of those, the CLI also provides a generic "file-based" interface.
+
+See [Recording test results](../training-a-model/recording-test-results.md) and [Subsetting tests](../optimizing-test-execution/subsetting-tests.md#subsetting-tests) for instructions specific to each tool.
+
+{% hint style="info" %}
+Using a tool not listed here? [Let us know.](mailto:support@launchableinc.com)
+{% endhint %}
+

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -1,0 +1,10 @@
+# Troubleshooting
+
+### Verification failure
+
+#### Connectivity
+
+If you need to interact with our API via static IPs, set the `LAUNCHABLE_BASE_URL` environment variable to `https://api-static.mercury.launchableinc.com`.
+
+The IP for this hostname will be either `13.248.185.38` or `76.223.54.162`.
+

--- a/docs/resources/using-sessions-to-capture-test-reports-from-several-machines.md
+++ b/docs/resources/using-sessions-to-capture-test-reports-from-several-machines.md
@@ -31,22 +31,22 @@ bundle install
 launchable record session --build <BUILD NAME> --no-save-file > launchable-session.txt
 
     # start multiple test runs
-    
+
         # machine 1
-        
+
             # run tests
             bundle exec rails test
-            
+
             # send test results to Launchable from machine 1
             # Note: You need to configure the line to always run whether test run succeeds/fails.
             #       See each integration page.
             launchable record tests --session $(cat launchable-session.txt) [OPTIONS]
-        
+
         # machine 2
-        
+
             # run tests
             bundle exec rails test
-            
+
             # send test results to Launchable from machine 2
             # Note: You need to configure the line to always run whether test run succeeds/fails.
             #       See each integration page.

--- a/docs/training-a-model/recording-builds.md
+++ b/docs/training-a-model/recording-builds.md
@@ -81,3 +81,7 @@ bundle install
 Note: `record build` automatically recognizes [Git submodules](https://www.git-scm.com/book/en/v2/Git-Tools-Submodules), so there’s no need to explicitly declare them.
 {% endhint %}
 
+## Next steps
+
+Now you can finish training a model by [recording test results](recording-test-results.md).
+

--- a/docs/training-a-model/recording-builds.md
+++ b/docs/training-a-model/recording-builds.md
@@ -1,0 +1,83 @@
+# Recording builds
+
+Launchable decides which tests to prioritize based on the changes contained in a build**.** To enable this, you need to send build and commit information to Launchable.
+
+{% hint style="info" %}
+**Commit collection**
+
+Changes are contained in commits, so you need to record commits and builds alongside each other. Launchable collects commit information from the repositories that you specified using `--source`. We then compare that information with commits from previous builds to determine what's changed in the build currently being tested.
+
+**We do not collect source code.** Only metadata about commits is captured, including:
+
+* Commit hash, author info, committer info, timestamps, and message
+* Names and paths of modified files
+* Count of modified lines
+{% endhint %}
+
+Find the point in your CI process where source code gets converted into the software that eventually get tested. This is typically called compilation, building, packaging, etc., using tools like Maven, make, grunt, etc.
+
+{% hint style="info" %}
+If you're using an interpreted language like Ruby or Python, record a build when you check out the repository as part of the build process.
+{% endhint %}
+
+Right before a build is produced, invoke the Launchable CLI as follows. Remember to make your API key available as the `LAUNCHABLE_TOKEN` environment variable prior to invoking `launchable`. In this example, the repository code is located in the current directory:
+
+```bash
+launchable record build --name <BUILD NAME> --source .
+
+# create the build
+bundle install
+```
+
+The `--source` option for both commands points to the local copy of the Git repository used to produce this build. See **Commit collection** above to learn more about how we use this.
+
+With the `--name` option for `record build`, you assign a unique identifier to this build. You will use this later when you run tests. See [Choosing a value for `<BUILD NAME>`](recording-builds.md#choosing-a-value-for-less-than-build-name-greater-than) for tips on choosing this value. This, combined with earlier `launchable record build` invocations, allows Launchable to determine what’s changed for this particular build.
+
+{% hint style="info" %}
+If your software is built from multiple repositories, see [the example below](recording-builds.md#example-software-built-from-multiple-repositories).
+{% endhint %}
+
+#### Choosing a value for `<BUILD NAME>`
+
+Your CI process probably already relies on some identifier to distinguish different builds. Such an identifier might be called a build number, build ID, etc. Most CI systems automatically make these values available via built-in environment variables. This makes it easy to pass this value into `record build`:
+
+| CI system | Suggested `<BUILD NAME>` | Documentation |
+| :--- | :--- | :--- |
+| Azure DevOps Pipelines | `Build.BuildId` | [https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables) |
+| Bitbucket Pipelines | `BITBUCKET_BUILD_NUMBER` | [https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) |
+| CircleCI | `CIRCLE_BUILD_NUM` | [https://circleci.com/docs/2.0/env-vars/\#built-in-environment-variables](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables) |
+| GitHub Actions | `GITHUB_RUN_ID` | [https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables\#default-environment-variables](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) |
+| GitLab CI | `CI_JOB_ID` | [https://docs.gitlab.com/ee/ci/variables/predefined\_variables.html](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) |
+| GoCD | `GO_PIPELINE_LABEL` | [https://docs.gocd.org/current/faq/dev\_use\_current\_revision\_in\_build.html\#standard-gocd-environment-variables](https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html#standard-gocd-environment-variables) |
+| Jenkins | `BUILD_TAG` | [https://www.jenkins.io/doc/book/pipeline/jenkinsfile/\#using-environment-variables](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables) |
+| Travis CI | `TRAVIS_BUILD_NUMBER` | [https://docs.travis-ci.com/user/environment-variables/\#default-environment-variables](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) |
+
+Some examples:
+
+* If your build produces an artifact or file that is later retrieved for testing, then `sha1sum` of the file would be a good build name as it is unique.
+* If you are building a Docker image, its content hash can be used as the unique identifier of a build: `docker inspect -f "{{.Id}}"`.
+
+{% hint style="warning" %}
+If you only have one source code repository, it might tempting to use a Git commit hash \(or `git-describe`\) as the build name, but we discourage this.
+
+It's not uncommon for teams to produce multiple builds from the same commit that are still considered different builds.
+{% endhint %}
+
+#### Example: Software built from multiple repositories
+
+If you produce a build by combining code from several repositories, invoke`launchable record build` with multiple `--source` options to denote them.
+
+To differentiate them, provide a label for each repository in the form of `LABEL=PATH`:
+
+```bash
+# record the build
+launchable record build --name <BUILD NAME> --source main=./main --source lib=./main/lib
+
+# create the build
+bundle install
+```
+
+{% hint style="info" %}
+Note: `record build` automatically recognizes [Git submodules](https://www.git-scm.com/book/en/v2/Git-Tools-Submodules), so there’s no need to explicitly declare them.
+{% endhint %}
+

--- a/docs/training-a-model/recording-test-results.md
+++ b/docs/training-a-model/recording-test-results.md
@@ -1,8 +1,8 @@
 # Recording test results
 
-## Recording test results
+## Overview
 
-Then, after tests run, you send test reports to Launchable. How you do this depends on what test runners you use:
+Once you've [recorded a build](recording-builds.md), you need to send test reports to Launchable after tests run for that build. How you do this depends on which test runner or build tool you use:
 
 * [Bazel](recording-test-results.md#bazel)
 * [Cypress](recording-test-results.md#cypress)
@@ -15,6 +15,8 @@ Then, after tests run, you send test reports to Launchable. How you do this depe
 * [Nose](recording-test-results.md#nose)
 
 Not using any of these? Try the [generic file based test runner](recording-test-results.md#generic-file-based-test-runner) option.
+
+## Test runner integrations
 
 ### Bazel
 
@@ -302,5 +304,7 @@ trap record EXIT SIGHUP
 bundle exec rails test -v $(cat launchable-subset.txt)
 ```
 
+## Next steps
 
+Once you've started [recording builds](recording-builds.md) and test results for every test run, Launchable will start training a model. Launchable will contact you by email when the model is ready to be used to [subset tests](../optimizing-test-execution/subsetting-tests.md).
 

--- a/docs/training-a-model/recording-test-results.md
+++ b/docs/training-a-model/recording-test-results.md
@@ -1,0 +1,306 @@
+# Recording test results
+
+## Recording test results
+
+Then, after tests run, you send test reports to Launchable. How you do this depends on what test runners you use:
+
+* [Bazel](recording-test-results.md#bazel)
+* [Cypress](recording-test-results.md#cypress)
+* [CTest](recording-test-results.md#ctest)
+* [GoogleTest](recording-test-results.md#googletest)
+* [Go Test](recording-test-results.md#go-test)
+* [Gradle](recording-test-results.md#gradle)
+* [Maven](recording-test-results.md#maven)
+* [Minitest](recording-test-results.md#minitest)
+* [Nose](recording-test-results.md#nose)
+
+Not using any of these? Try the [generic file based test runner](recording-test-results.md#generic-file-based-test-runner) option.
+
+### Bazel
+
+When you are running your tests with Bazel, simply point to the Bazel workspace to collect test results:
+
+```bash
+# run the tests however you normally do
+bazel test //...
+
+launchable record tests --build <BUILD NAME> bazel .
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests bazel --help`
+
+### CTest
+
+Have CTest run tests and produce own format XML reports. Launchable CLI supports the CTest format. By default, this location is `Testing/{date}/Test.xml`.
+
+After running tests, point to the directory that contains all the generated test report XML files:
+
+```bash
+# run the tests however you normally do
+# `-T test` option output own format XML file
+ctest -T test --no-compress-output
+
+# record CTest result XML
+launchable record tests --build <BUILD NAME> ctest Testing/**/Test.xml
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests ctest --help`
+
+### Cypress
+
+Cypress provides a JUnit report runner. See [Reporters \| Cypress Documentation](https://docs.cypress.io/guides/tooling/reporters.html)
+
+After running tests, point to files that contains all the generated test report XML files:
+
+```bash
+# run the tests however you normally do, then produce a JUnit XML file
+cypress run --reporter junit --reporter-options "mochaFile=report/test-output-[hash].xml"
+
+launchable record tests --build <BUILD NAME> cypress ./report/*.xml
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests cypress --help`
+
+### GoogleTest
+
+GoogleTest has to be configured to produce JUnit compatible report files. See [their documentation](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#generating-an-xml-report) for how to do this.
+
+After running tests, point to the directory that contains all the generated test report XML files:
+
+```bash
+# run the tests however you normally do
+./my-test --gtest_output=xml:./report/my-test.xml
+
+launchable record tests --build <BUILD NAME> googletest ./report
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests googletest --help`
+
+### Go Test
+
+Go Test does not natively produce JUnit compatible test report files, so you should use an extra tool such as [github.com/jstemmer/go-junit-report](https://github.com/jstemmer/go-junit-report) to convert them for use with Launchable.
+
+After running tests, point to the directory that contains all the generated test report XML files:
+
+```bash
+# install JUnit report formatter
+go get -u github.com/jstemmer/go-junit-report
+
+# run the tests however you normally do, then produce a JUnit XML file
+go test -v ./... | go-junit-report > report.xml
+
+launchable record tests ... go-test .
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests go-test --help`
+
+### Gradle
+
+Have Gradle run tests and produce JUnit compatible reports. By default, this location is `build/test-results/test/` but that might be different depending on how your Gradle project is configured.
+
+After running tests, point to the directory that contains all the generated test report XML files. You can specify multiple directories, for example if you do multi-project build:
+
+```bash
+# run the tests however you normally do
+gradle test ...
+
+launchable record tests --build <BUILD NAME> gradle ./build/test-results/test/
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For a large project, a dedicated Gradle task to list up all report directories might be convenient. See [the upstream documentation](https://docs.gradle.org/current/userguide/java_testing.html#test_reporting) for more details and insights.
+
+Alternatively, you can specify a glob pattern for directories or individual test report files \(this pattern might already be specified in your pipeline script\):
+
+```bash
+# run the tests however you normally do
+gradle test ...
+
+launchable record tests --build <BUILD NAME> gradle **/build/**/TEST-*.xml
+```
+
+For more information and advanced options, run `launchable record tests gradle --help`
+
+### Maven
+
+The Surefire Plugin is default report plugin for [Apache Maven](https://maven.apache.org/) and used during the test phase of the build lifecycle to execute the unit tests of an application. See [Maven Surefire Plugin – Introduction](https://maven.apache.org/surefire/maven-surefire-plugin/)
+
+After running tests, point to the directory that contains all the generated test report XML files. You can specify multiple directories, for example if you do multi-project build:
+
+```bash
+# run the tests however you normally do, then produce a JUnit XML file
+maven tests
+
+launchable record tests --build <BUILD NAME> maven ./project1/target/surefire-reports/ ./project2/target/surefire-reports/
+```
+
+For more information and advanced options, run `launchable record tests maven --help`
+
+### Minitest
+
+First, minitest has to be configured to produce JUnit compatible report files. We recommend [minitest-ci](https://github.com/circleci/minitest-ci).
+
+After running tests, point to the directory that contains all the generated test report XML files:
+
+```bash
+# run the tests however you normally do
+bundle exec rails test
+
+launchable record tests --build <BUILD NAME> minitest "$CIRCLE_TEST_REPORTS/reports"
+```
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+For more information and advanced options, run `launchable record tests minitest --help`
+
+### Nose
+
+Install the Launchable plugin for Nose using PIP:
+
+```bash
+$ pip install nose-launchable
+```
+
+### Generic file-based test runner
+
+The "file" test runner support is primarily designed to work with test runners not explicitly supported, including in-house custom test runners.
+
+In order to work with Launchable through this integration mechanism, your test runner has to satisfy the following conditions:
+
+* **File based**: your test runner accepts file names as an input of a test execution, to execute just those
+
+  specified set of tests.
+
+* **File names in JUnit reports**: your test runner has to produce results of tests in
+
+  the JUnit compatible format, with additional attributes that capture
+
+  the file names of the tests that run. If not, see [Dealing with custom test report format](../resources/convert-to-junit.md) for how to convert.
+
+For example, [Mocha](https://mochajs.org/#getting-started) is a test runner that meets those criteria. You write tests in JavaScript files:
+
+```bash
+$ cat foo.js
+var assert = require('assert');
+describe('Array', function() {
+  describe('#indexOf()', function() {
+    it('should return -1 when the value is not present', function() {
+      assert.equal([1, 2, 3].indexOf(4), -1);
+    });
+  });
+});
+```
+
+Mocha test runner takes those files as arguments:
+
+```bash
+$ mocha --reporter mocha-junit-reporter foo.js
+```
+
+And it produces JUnit report files, where the name of the test file is captured, in this case the `file` attribute:
+
+```bash
+$ cat test-results.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="0.0000" tests="1" failures="0">
+  <testsuite name="#indexOf()" file="/home/kohsuke/ws/foo.js" ...>
+    <testcase  ... />
+...
+```
+
+The rest of this section uses Mocha as an example.
+
+To have Launchable capture the executed test results, run `record tests file` command and specify file names of report files:
+
+```bash
+launchable record tests \
+    --build <BUILD NAME> \
+    --base . \
+    file ./reports/*.xml
+```
+
+When test reports contain absolute path names of test files, it prevents Launchable from seeing that `/home/kohsuke/ws/foo.js` from one test execution and `/home/john/src/foo.js` from another execution are actually the same test, so the `--base` option is used to relativize the test file names.
+
+Note: `launchable record tests` requires always run whether test run succeeds or fails. See [Always record tests](recording-test-results.md#always-record-tests).
+
+## Always record tests
+
+`launchable record tests` requires always run whether test run succeeds or fails. The way depends on your CI environment.
+
+### Jenkins
+
+Jenkins has [`post { always { ... } }`](https://www.jenkins.io/doc/book/pipeline/syntax/#post) option:
+
+```text
+pipeline {
+  ...
+  sh 'bundle exec rails test -v $(cat launchable-subset.txt)'
+  ...
+  post {
+    always {
+      sh 'launchable record tests <BUILD NAME> [OPTIONS]'
+    }
+  }
+}
+```
+
+### CircleCI
+
+CircleCI has [`when: always`](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute) option:
+
+```yaml
+- jobs:
+  - test:
+    ...
+    - run:
+        name: Run tests
+        command: bundle exec rails test -v $(cat launchable-subset.txt)
+    - run:
+        name: Record test results
+        command: launchable record tests <BUILD NAME> [OPTIONS]
+        when: always
+```
+
+### Github Actions
+
+GithubAction has [`if: ${{ always() }}`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always) option:
+
+```yaml
+jobs:
+  test:
+    steps:
+      ...
+      - name: Run tests
+        run: bundle exec rails test -v $(cat launchable-subset.txt)
+      - name: Record test result
+        run: launchable record tests <BUILD NAME> [OPTIONS]
+        if: always()
+```
+
+### Bash
+
+If you run tests on your local or other CI, you can use `trap`:
+
+```bash
+function record() {
+  launchable record tests <BUILD NAME> [OPTIONS]
+}
+# set a trap to send test results to Launchable for this build either tests succeed/fail
+trap record EXIT SIGHUP
+
+bundle exec rails test -v $(cat launchable-subset.txt)
+```
+
+
+


### PR DESCRIPTION
This change is best reviewed on the rendered version: https://launchable.gitbook.io/development/v/docs%2Frefactor-3/getting-started

- Split out "recording builds," "recording test results," and "subsetting test execution" into their own pages
- Move integration-specific instructions into the new "recording builds" and "subsetting test execution" pages to keep users from bouncing between pages
- Add a page that lists all the integrations, since the previous changes made it less clear

Out of scope:

- Other content updates (those will be handled in another PR)