### PR TITLE
Send HTTP requests with sessions

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -8,6 +8,8 @@ from junitparser import JUnitXml, TestSuite
 import xml.etree.ElementTree as ET
 from typing import Callable, Generator, List, Union
 from itertools import repeat, starmap, takewhile, islice
+
+import requests
 from more_itertools import ichunked
 from operator import truth
 from junitparser.junitparser import TestCase
@@ -129,6 +131,7 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
             token, org, workspace = parse_token()
 
             count = 0   # count number of test cases sent
+            session = requests.Session()
 
             def testcases(reports: List[Union[TestSuite, List[TestSuite]]]):
                 exceptions = []
@@ -188,7 +191,7 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
                     "Content-Type": "application/json",
                     "Content-Encoding": "gzip",
                 }
-                client = LaunchableClient(token)
+                client = LaunchableClient(token, session=session)
                 res = client.request(
                     "post", "{}/events".format(session_id), data=payload, headers=headers)
                 res.raise_for_status()
@@ -205,7 +208,7 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
                     "Content-Type": "application/json",
                     "Content-Encoding": "gzip",
                 }
-                client = LaunchableClient(token)
+                client = LaunchableClient(token, session=session)
                 res = client.request(
                     "patch", "{}/close".format(session_id), headers=headers)
                 res.raise_for_status()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -131,7 +131,7 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
             token, org, workspace = parse_token()
 
             count = 0   # count number of test cases sent
-            session = requests.Session()
+            client = LaunchableClient(token)
 
             def testcases(reports: List[Union[TestSuite, List[TestSuite]]]):
                 exceptions = []
@@ -191,7 +191,6 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
                     "Content-Type": "application/json",
                     "Content-Encoding": "gzip",
                 }
-                client = LaunchableClient(token, session=session)
                 res = client.request(
                     "post", "{}/events".format(session_id), data=payload, headers=headers)
                 res.raise_for_status()
@@ -208,7 +207,6 @@ def tests(context, base_path: str, session_id: str, build_name: str, debug: bool
                     "Content-Type": "application/json",
                     "Content-Encoding": "gzip",
                 }
-                client = LaunchableClient(token, session=session)
                 res = client.request(
                     "patch", "{}/close".format(session_id), headers=headers)
                 res.raise_for_status()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -9,7 +9,6 @@ import xml.etree.ElementTree as ET
 from typing import Callable, Generator, List, Union
 from itertools import repeat, starmap, takewhile, islice
 
-import requests
 from more_itertools import ichunked
 from operator import truth
 from junitparser.junitparser import TestCase

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -13,7 +13,7 @@ def get_base_url():
 
 
 class LaunchableClient:
-    def __init__(self, token, base_url="", http=requests):
+    def __init__(self, token: str, base_url: str = "", http: requests.Session = requests.Session()):
         self.base_url = base_url or get_base_url()
         self.http = http
         self.token = token
@@ -23,7 +23,7 @@ class LaunchableClient:
         url = self.base_url + path
         if 'timeout' not in kwargs:
             # (connection timeout, read timeout) in seconds
-            kwargs['timeout'] = (5,60)
+            kwargs['timeout'] = (5, 60)
 
         try:
             return self.http.request(method, url, headers={**headers, **self._headers()}, **kwargs)

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -13,9 +13,9 @@ def get_base_url():
 
 
 class LaunchableClient:
-    def __init__(self, token: str, base_url: str = "", http: requests.Session = requests.Session()):
+    def __init__(self, token: str, base_url: str = "", session: requests.Session = requests.Session()):
         self.base_url = base_url or get_base_url()
-        self.http = http
+        self.session = session
         self.token = token
 
     def request(self, method, path, **kwargs):
@@ -26,7 +26,7 @@ class LaunchableClient:
             kwargs['timeout'] = (5, 60)
 
         try:
-            return self.http.request(method, url, headers={**headers, **self._headers()}, **kwargs)
+            return self.session.request(method, url, headers={**headers, **self._headers()}, **kwargs)
         except Exception as e:
             raise Exception("unable to post to %s" % url) from e
 

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest import mock
 import responses
+import json
+import gzip
 from tests.cli_test_case import CliTestCase
 
 
@@ -8,31 +10,31 @@ class CypressTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath(
         '../data/cypress/').resolve()
 
-    @mock.patch('requests.request')
-    def test_record_test_cypress(self, mock_post):
+    @responses.activate
+    def test_record_test_cypress(self):
         # test-result.xml was generated used to cypress-io/cypress-example-kitchensink
         # cypress run --reporter junit report.xml
         result = self.cli('record', 'tests',  '--session', self.session,
                           'cypress', str(self.test_files_dir) + "/test-result.xml")
         self.assertEqual(result.exit_code, 0)
 
-        payload = self.gzipped_json_payload(mock_post)
+        payload = json.loads(gzip.decompress(
+            b''.join(responses.calls[0].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
         self.assert_json_orderless_equal(expected, payload)
 
-    @mock.patch('requests.request')
-    def test_subset_cypress(self, mock_post):
+    @responses.activate
+    def test_subset_cypress(self):
         # test-report.xml is outputed from cypress/integration/examples/window.spec.js, so set it
         pipe = "cypress/integration/examples/window.spec.js"
         result = self.cli('subset', '--target', '10%',
                           '--session', self.session, 'cypress', input=pipe)
         self.assertEqual(result.exit_code, 0)
 
-        payload = self.gzipped_json_payload(mock_post)
-        print("fooo")
-        print(payload)
+        payload = json.loads(gzip.decompress(
+            responses.calls[0].request.body).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('subset_result.json'))
         self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
From the latest change https://github.com/launchableinc/cli/pull/142, `record tests` command becames running many HTTP requests. To reduce those requests' overheads, introduce [requests's sessions](https://requests.readthedocs.io/en/master/user/advanced/).

This PR also includes Cypress tests refactoring because [`responses`](https://pypi.org/project/responses/) automatically mocks the session requests.