### PR TITLE
Fix `record commit` command

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -45,7 +45,7 @@ def exec_jar(source):
 
     base_url = get_base_url()
 
-    https_proxy = os.environ("HTTPS_PROXY")
+    https_proxy = os.getenv("HTTPS_PROXY")
     proxy_option = _build_proxy_option(https_proxy) if https_proxy else ""
 
     os.system(


### PR DESCRIPTION
My fault, `os.environ` isn't callable. I use `os.getenv()` instead of that.