### PR TITLE
Add `record commit` test

### DIFF
--- a/tests/commands/record/test_commit.py
+++ b/tests/commands/record/test_commit.py
@@ -1,9 +1,21 @@
-import unittest
+from tests.cli_test_case import CliTestCase
 from launchable.commands.record.commit import _build_proxy_option
 
-class CommitTest(unittest.TestCase):
-  def test_proxy_options(self):
-      self.assertEqual(_build_proxy_option("https://some_proxy:1234"), "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
-      self.assertEqual(_build_proxy_option("some_proxy:1234"), "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
-      self.assertEqual(_build_proxy_option("some_proxy"), "-Dhttps.proxyHost=some_proxy ")
-      self.assertEqual(_build_proxy_option("https://some_proxy"), "-Dhttps.proxyHost=some_proxy ")
+
+class CommitTest(CliTestCase):
+    def test_run_commit(self):
+        """
+        `record commit` command cause error because we can't mock Apache HTTP Client in Java
+        """
+        result = self.cli("record", "commit")
+        self.assertEqual(result.exit_code, 0, "exit normally")
+
+    def test_proxy_options(self):
+        self.assertEqual(_build_proxy_option("https://some_proxy:1234"),
+                         "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
+        self.assertEqual(_build_proxy_option("some_proxy:1234"),
+                         "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
+        self.assertEqual(_build_proxy_option("some_proxy"),
+                         "-Dhttps.proxyHost=some_proxy ")
+        self.assertEqual(_build_proxy_option(
+            "https://some_proxy"), "-Dhttps.proxyHost=some_proxy ")


### PR DESCRIPTION
[v1.5.6](https://github.com/launchableinc/cli/releases/tag/v1.5.6) caused syntax error. To prevent such errors, I added a simple test to invoke `record commit`.