### PR TITLE
[ST-804] https_proxy might look like 'http://foobar/'

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -54,7 +54,7 @@ def exec_jar(source):
 
 
 def _build_proxy_option(https_proxy: str) -> str:
-    if not https_proxy.startswith("https"):
+    if not (https_proxy.startswith("https://") or https_proxy.startswith("http://")):
         https_proxy = "https://" + https_proxy
     proxy_url = urlparse(https_proxy)
 

--- a/tests/commands/record/test_commit.py
+++ b/tests/commands/record/test_commit.py
@@ -7,3 +7,4 @@ class CommitTest(unittest.TestCase):
       self.assertEqual(_build_proxy_option("some_proxy:1234"), "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
       self.assertEqual(_build_proxy_option("some_proxy"), "-Dhttps.proxyHost=some_proxy ")
       self.assertEqual(_build_proxy_option("https://some_proxy"), "-Dhttps.proxyHost=some_proxy ")
+      self.assertEqual(_build_proxy_option("http://yoyoyo"), "-Dhttps.proxyHost=yoyoyo ")


### PR DESCRIPTION
`https_proxy=http://foobar/` means browsers interested in connecting to an HTTPS site will first use plain HTTP to connect to foobar, then send an HTTP CONNECT command in plain text, then get a tunnel to the intended destination over which they initiate the TLS handshake.

I believe this is blocking a certain customer.