### PR TITLE
[ST-796] Introduce logging logger and print audit log

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -15,7 +15,7 @@ from .utils import logger
 @click.option(
     '--log-level',
     'log_level',
-    help='Set logger log level.\nlevels are CRITICAL > ERROR > WARNING > AUDIT > INFO > DEBUG.',
+    help='Set logger\'s log level (CRITICAL, ERROR, WARNING, AUDIT, INFO, DEBUG).',
     type=str,
     default=logger.LOG_LEVEL_DEFAULT_STR,
 )

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -15,7 +15,7 @@ from .utils import logger
 @click.option(
     '--log-level',
     'log_level',
-    help='Set logger log level.\nlevels are AUDIT > CRITICAL > ERROR > WARNING > INFO > DEBUG.',
+    help='Set logger log level.\nlevels are CRITICAL > ERROR > WARNING > AUDIT > INFO > DEBUG.',
     type=str,
     default=logger.LOG_LEVEL_DEFAULT_STR,
 )

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -1,16 +1,28 @@
 from .version import __version__
 import click
 import importlib
+import logging
 from os.path import dirname, basename, join
 from glob import glob
 from .commands.record import record
 from .commands.subset import subset
 from .commands.verify import verify
+from .utils import logger
 
 
 @click.group()
 @click.version_option(version=__version__, prog_name='launchable-cli')
-def main():
+@click.option(
+    '--log-level',
+    'log_level',
+    help='Set logger log level.\nlevels are AUDIT > CRITICAL > ERROR > WARNING > INFO > DEBUG.',
+    type=str,
+    default=logger.LOG_LEVEL_DEFAULT_STR,
+)
+def main(log_level):
+    level = logger.get_log_level(log_level)
+    logging.basicConfig(level=level)
+
     # load all test runners
     for f in glob(join(dirname(__file__), 'test_runners', "*.py")):
         f = basename(f)[:-3]

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -2,7 +2,7 @@ import requests
 import os
 import platform
 from launchable.version import __version__
-
+from .logger import Logger
 
 BASE_URL_KEY = "LAUNCHABLE_BASE_URL"
 DEFAULT_BASE_URL = "https://api.mercury.launchableinc.com"
@@ -25,7 +25,10 @@ class LaunchableClient:
             # (connection timeout, read timeout) in seconds
             kwargs['timeout'] = (5, 60)
 
+        logger = Logger()
         try:
+            logger.audit(
+                "send request method:{} path:{} headers:{} args:{}".format(method, path, headers, kwargs))
             return self.session.request(method, url, headers={**headers, **self._headers()}, **kwargs)
         except Exception as e:
             raise Exception("unable to post to %s" % url) from e

--- a/launchable/utils/logger.py
+++ b/launchable/utils/logger.py
@@ -1,0 +1,53 @@
+import logging
+
+
+LOG_LEVEL_DEFAULT = 999
+LOG_LEVEL_DEFAULT_STR = "DEFAULT"
+LOG_LEVEL_AUDIT = 90
+LOG_LEVEL_AUDIT_STR = "AUDIT"
+
+
+logging.addLevelName(LOG_LEVEL_AUDIT, "AUDIT")
+
+
+def get_log_level(level=str) -> int:
+    level = level.lower()
+
+    if level == "audit":
+        return LOG_LEVEL_AUDIT
+    elif level == "critical":
+        return logging.CRITICAL
+    elif level == "error":
+        return logging.ERROR
+    elif level == "warn" or level == "warning":
+        return logging.WARNING
+    elif level == "info":
+        return logging.INFO
+    elif level == "debug":
+        return logging.DEBUG
+    else:
+        return LOG_LEVEL_DEFAULT
+
+
+class Logger(object):
+    def __init__(self, name="launchable"):
+        logger = logging.getLogger(name)
+        self.logger = logger
+
+    def audit(self, msg, *args, **kargs):
+        self.logger.log(LOG_LEVEL_AUDIT, msg, *args, **kargs)
+
+    def debug(self, msg, *args, **kargs):
+        self.logger.debug(msg, *args, **kargs)
+
+    def info(self, msg, *args, **kargs):
+        self.logger.info(msg, *args, **kargs)
+
+    def warning(self, msg, *args, **kargs):
+        self.logger.warning(msg, *args, **kargs)
+
+    def error(self, msg, *args, **kargs):
+        self.logger.error(msg, *args, **kargs)
+
+    def critical(self, msg, *args, **kargs):
+        self.logger.critical(msg, *args, **kargs)

--- a/launchable/utils/logger.py
+++ b/launchable/utils/logger.py
@@ -8,6 +8,7 @@ LOG_LEVEL_AUDIT_STR = "AUDIT"
 
 
 logging.addLevelName(LOG_LEVEL_AUDIT, "AUDIT")
+logging.addLevelName(LOG_LEVEL_DEFAULT, "DEFAULT")
 
 
 def get_log_level(level=str) -> int:

--- a/launchable/utils/logger.py
+++ b/launchable/utils/logger.py
@@ -1,9 +1,9 @@
 import logging
 
 
-LOG_LEVEL_DEFAULT = 999
+LOG_LEVEL_DEFAULT = 100
 LOG_LEVEL_DEFAULT_STR = "DEFAULT"
-LOG_LEVEL_AUDIT = 90
+LOG_LEVEL_AUDIT = 25
 LOG_LEVEL_AUDIT_STR = "AUDIT"
 
 
@@ -13,14 +13,14 @@ logging.addLevelName(LOG_LEVEL_AUDIT, "AUDIT")
 def get_log_level(level=str) -> int:
     level = level.lower()
 
-    if level == "audit":
-        return LOG_LEVEL_AUDIT
-    elif level == "critical":
+    if level == "critical":
         return logging.CRITICAL
     elif level == "error":
         return logging.ERROR
     elif level == "warn" or level == "warning":
         return logging.WARNING
+    elif level == "audit":
+        return LOG_LEVEL_AUDIT
     elif level == "info":
         return logging.INFO
     elif level == "debug":

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -5,20 +5,21 @@ import launchable.utils.logger as logger
 from unittest import TestCase
 from unittest.mock import patch
 import logging
+import copy
 
 
 class LoggerTest(TestCase):
-    default_root_handler = None
+    default_root_handlers = None
 
     def setUp(self):
-        self.default_root_handler = logging.root
+        self.default_root_handlers = copy.copy(logging.root.handlers)
 
-        # reset logging handelr for test
+        # reset logging handler for test
         for handler in logging.root.handlers[:]:
             logging.root.removeHandler(handler)
 
     def tearDown(self):
-        logging.root = self.default_root_handler
+        logging.root.handlers = copy.copy(self.default_root_handlers)
 
     @patch("sys.stderr", new_callable=StringIO)
     def test_logging_default(self, mock_err):

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,29 @@
+from io import StringIO
+import sys
+from launchable.utils.logger import Logger
+import launchable.utils.logger as logger
+from unittest import TestCase
+from unittest.mock import patch
+import logging
+
+
+class LoggerTest(TestCase):
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_logging_default(self, mock_err):
+        logging.basicConfig(level=logger.LOG_LEVEL_DEFAULT)
+        l = Logger()
+        l.audit("audit")
+        l.info("info")
+        l.warning("warn")
+        l.debug("debug")
+        self.assertEqual(mock_err.getvalue(), "")
+
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_log_level_audit(self, mock_err):
+        logging.basicConfig(level=logger.LOG_LEVEL_AUDIT)
+        l = Logger()
+        l.audit("audit")
+        l.info("info")
+        l.warning("warn")
+        l.debug("debug")
+        self.assertEqual(mock_err.getvalue(), "AUDIT:launchable:audit\n")

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -8,6 +8,18 @@ import logging
 
 
 class LoggerTest(TestCase):
+    default_root_handler = None
+
+    def setUp(self):
+        self.default_root_handler = logging.root
+
+        # reset logging handelr for test
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+    def tearDown(self):
+        logging.root = self.default_root_handler
+
     @patch("sys.stderr", new_callable=StringIO)
     def test_logging_default(self, mock_err):
         logging.basicConfig(level=logger.LOG_LEVEL_DEFAULT)

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -23,7 +23,10 @@ class LoggerTest(TestCase):
         logging.basicConfig(level=logger.LOG_LEVEL_AUDIT)
         l = Logger()
         l.audit("audit")
-        l.info("info")
+        l.critical("critical")
+        l.error("error")
         l.warning("warn")
+        l.info("info")
         l.debug("debug")
-        self.assertEqual(mock_err.getvalue(), "AUDIT:launchable:audit\n")
+        self.assertEqual(mock_err.getvalue(
+        ), "AUDIT:launchable:audit\nCRITICAL:launchable:critical\nERROR:launchable:error\nWARNING:launchable:warn\n")


### PR DESCRIPTION
### abstract

I introduced a logger used by logging and set log levels default and audit. add a global option `--log-level` to change level for printing logs. when we only set the log level, the logger print log. 

I'd like to replace the @command.echo log output with this logger in the future.

#### example

when we set `log-level`, logs are printed like below,

```
$ LAUNCHABLE_TOKEN=XXX launchable --log-level audit subset --build sample-1  --target 10% maven ./src/test/java/com/example/app/App*
AUDIT:launchable:send request method:post path:/intake/organizations/<ORG>/workspaces/<WORKSPACE>/builds/sample-1/test_sessions headers:{'Content-Type': 'application/json'} args:{'timeout': (5, 60)}
AUDIT:launchable:send request method:post path:/intake/organizations/<ORG>/workspaces/<WORKSPACE>/subset headers:{'Content-Type': 'application/json', 'Content-Encoding': 'gzip'} args:{'data': b'\x1f\x8b\x08\x00C^3`\x02\xff\xabV*I-.\tH,\xc9(V\xb2R\x88\x8e\xd5QP*I,JO-\x01\xf2\x0c\xf4\x0c\x81\xdc\xe2\xd4\xe2\xe2\xcc\xfc< \xbfZ)3\x05H)\x19\x9b+\xd5\xd6\x02\x00\xd1bG\xaa9\x00\x00\x00', 'timeout': (5, 180)}
```



#### about log level

I was going to set the highest level to the audit log level. However, when I use some times, I found it a little noisy that if we set the error to log level, the audit logs were printed.
Also, when we want to show the audit logs, there weren't any errors usually. so error log level and audit log level behavior don't conflict.
So I changed log levels from audit>critical>error>warn>info>debug to critical>error>warn>audit>info>debug.


