### PR TITLE
Specify correct action-discord version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Actions for Discord
-      uses: Ilshidur/action-discord@0.0.2
+      uses: Ilshidur/action-discord@0.3.0
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:


### PR DESCRIPTION
Follow up for https://github.com/launchableinc/cli/pull/151. I fixed the misspecified module version. [0.3.0](https://github.com/Ilshidur/action-discord/releases) is the latest.