### PR TITLE
[ST-817]Fix `TypeError("'NoneType' object is not iterable")` error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ setup_requires =
 install_requires =
     click>=7.0
     requests
-    junitparser>=1.6.3
+    junitparser>=2.0.0
     setuptools
     more_itertools
 python_requires = >=3.4


### PR DESCRIPTION
We had specified junitparser v1.6.3 or later. However, the CLI code wasn't compatible with v1.6.3. We handled `TestCase.result` as a list in [here](https://github.com/launchableinc/cli/blob/b58eb1131cebc3f0f673c61b5543f9ee25b86671/launchable/commands/record/case_event.py#L49), but the version returned it as a single instance. It caused `TypeError("'NoneType' object is not iterable")`. Since junitparser v2.0.0 was shipped on Jan 11, most of our customers may use the version. But I assume a few earlier tried customers are still using v1.6.3. I convinced this is the cause of ST-817 because the error log also contained `TypeError("'Skipped' object is not iterable")`. It means this is related to the object from junitparser.

If you want to represent this error, do the following processes.

1. specify `junitparser==1.6.3` in `setup.cfg`
2. run `pipenv update`
3. run `pipenv run test`.