### PR TITLE
Fix GitHub URL in Discord post

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,4 +34,4 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI {{ EVENT_PAYLOAD.release.tag_name }} is released! {{ EVENT_PAYLOAD.release.url }}'
+        args: 'Launchable CLI {{ EVENT_PAYLOAD.release.tag_name }} is released! {{ EVENT_PAYLOAD.release.html_url }}'


### PR DESCRIPTION
Current Discord release post has a wrong URL like https://api.github.com/repos/launchableinc/cli/releases/38715080. `release.html_url` returns collect release URL such as https://github.com/launchableinc/cli/releases/tag/v1.6.1
