### PR TITLE
Avoid JUnitParser's value escaping 

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -22,7 +22,7 @@ class CaseEvent:
         """
 
         def f(case: TestCase, suite: TestSuite, report_file: str) -> TestPath:
-            classname = case.classname or suite._elem.attrib.get("classname")
+            classname = case._elem.attrib.get("classname") or suite._elem.attrib.get("classname")
             filepath = case._elem.attrib.get(
                 "file") or suite._elem.attrib.get("filepath")
             if filepath:
@@ -35,7 +35,7 @@ class CaseEvent:
                 test_path.append({"type": "class", "name": classname})
             if case.name:
                 test_path.append(
-                    {"type": "testcase", "name": case.name, "_lineno": case._elem.attrib.get("lineno")})
+                    {"type": "testcase", "name": case._elem.attrib.get("name"), "_lineno": case._elem.attrib.get("lineno")})
             return test_path
 
         return f
@@ -58,8 +58,8 @@ class CaseEvent:
             "testPath": path_builder(case, suite, report_file),
             "duration": case.time,
             "status": status,
-            "stdout": case.system_out or "",
-            "stderr": case.system_err or "",
+            "stdout": case._elem.attrib.get("system-out") or "",
+            "stderr": case._elem.attrib.get("system-err") or "",
             "created_at": suite.timestamp or datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "data": data
         }

--- a/tests/data/googletest/output_a.xml
+++ b/tests/data/googletest/output_a.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" failures="0" disabled="0" errors="0" time="0" timestamp="2021-01-15T17:39:19" name="AllTests">
-  <testsuite name="FooTest" tests="1" failures="0" disabled="0" errors="0" time="0" timestamp="2021-01-15T17:39:19">
+<testsuites tests="3" failures="0" disabled="0" errors="0" time="0" timestamp="2021-01-15T17:39:19" name="AllTests">
+  <testsuite name="FooTest" tests="3" failures="0" disabled="0" errors="0" time="0" timestamp="2021-01-15T17:39:19">
     <testcase name="Foo" status="run" result="completed" time="0" timestamp="2021-01-15T17:39:19" classname="FooTest" />
+    <testcase name="Foo'1'" status="run" result="completed" time="0" timestamp="2021-01-15T17:39:19" classname="FooTest" />
+    <testcase name='Foo"1"' status="run" result="completed" time="0" timestamp="2021-01-15T17:39:19" classname="FooTest" />
   </testsuite>
 </testsuites>

--- a/tests/data/googletest/record_test_result.json
+++ b/tests/data/googletest/record_test_result.json
@@ -1,6 +1,10 @@
 {"events": [
 {"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Foo", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-15T17:39:19", "data": null}
 ,
+{"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Foo'1'", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-15T17:39:19", "data": null}
+  ,  
+{"type": "case", "testPath": [{"type": "class", "name": "FooTest"}, {"type": "testcase", "name": "Foo\"1\"", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-15T17:39:19", "data": null}
+  ,  
 {"type": "case", "testPath": [{"type": "class", "name": "IncetanceA/ParameterizedTest"}, {"type": "testcase", "name": "Bar/0", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-15T17:39:19", "data": null}
 ,
 {"type": "case", "testPath": [{"type": "class", "name": "IncetanceA/ParameterizedTest"}, {"type": "testcase", "name": "Bar/1", "_lineno": null}], "duration": 0.0, "status": 1, "stdout": "", "stderr": "", "created_at": "2021-01-15T17:39:19", "data": null}


### PR DESCRIPTION
JUnitPerser escape value in the JUnit XML by default. So, we need non escaped values in test names. Therefore, I modified the value handling to retrieve element value directly.
