### PR TITLE
support when base has magic

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -159,7 +159,8 @@ def subset(context, target, session_id, base_path: str, build_name: str):
 
             for b in glob.iglob(base):
                 for t in glob.iglob(join(b, pattern), recursive=True):
-                    path = path_builder(t[len(b)+1:])  # type: ignore
+                    if path_builder:
+                        path = path_builder(t[len(b)+1:])
                     if path:
                         self.test_paths.append(self.to_test_path(path))
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -157,16 +157,9 @@ def subset(context, target, session_id, base_path: str, build_name: str):
                     return file_name
                 path_builder = default_path_builder
 
-            for t in glob.iglob(join(base, pattern), recursive=True):
-                if path_builder:
-                    if glob.has_magic(base):
-                        for b in glob.glob(base):
-                            if b in t:
-                                path = path_builder(t[len(b)+1:])
-                                break
-                    else:
-                        path = path_builder(t[len(base)+1:])
-
+            for b in glob.iglob(base):
+                for t in glob.iglob(join(b, pattern), recursive=True):
+                    path = path_builder(t[len(b)+1:])  # type: ignore
                     if path:
                         self.test_paths.append(self.to_test_path(path))
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -159,7 +159,14 @@ def subset(context, target, session_id, base_path: str, build_name: str):
 
             for t in glob.iglob(join(base, pattern), recursive=True):
                 if path_builder:
-                    path = path_builder(t[len(base)+1:])
+                    if glob.has_magic(base):
+                        for b in glob.glob(base):
+                            if b in t:
+                                path = path_builder(t[len(b)+1:])
+                                break
+                    else:
+                        path = path_builder(t[len(base)+1:])
+
                     if path:
                         self.test_paths.append(self.to_test_path(path))
 


### PR DESCRIPTION
before cli didn't expand the base path that includes magic words e.g `*`, `?`, etc
so, if the user sets the path that includes magic words, subset path will be broken.

### before

```
$ launchable subset <SUBSET ARGS> '**/src/test/java'

--tests .com.launchableinc.rocket_car_gradle.AppTest2 --tests .com.launchableinc.rocket_car_gradle.AppTest --tests .com.launchableinc.rocket_car_gradle.sub.AppTest3 --tests ava.com.launchableinc.rocket_car_gradle.utils.UtilsTest
```

### after

```
$ launchable subset <SUBSET ARGS> '**/src/test/java'

--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.sub.AppTest3 --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest
```