### PR TITLE
Demonstration of the plugin loading mechanism

### DIFF
--- a/tests/plugins/foo.py
+++ b/tests/plugins/foo.py
@@ -1,0 +1,13 @@
+import click
+from launchable.test_runners import launchable
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    for r in reports:
+        click.echo('foo:{}'.format(r))
+
+@launchable.subset
+def subset(client):
+    click.echo("Subset!")
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,15 @@
+from .cli_test_case import CliTestCase
+from pathlib import Path
+
+
+class PluginTest(CliTestCase):
+    def test_plugin_loading(self):
+        """
+        Load plugins/foo.py as a plugin and execute its code
+        """
+        plugin_dir = Path(__file__).parent.joinpath('plugins').resolve()
+        result = self.cli('--plugins', str(plugin_dir), 'record', 'tests', '--session', 'dummy', 'foo', 'alpha', 'bravo', 'charlie')
+        self.assertTrue("foo:alpha" in result.stdout, result.stdout)
+        self.assertTrue("foo:bravo" in result.stdout, result.stdout)
+        self.assertTrue("foo:charlie" in result.stdout, result.stdout)
+


### PR DESCRIPTION
To allow some customers to maintain custom test runner support more easily, define a mechanism to load test runner support from arbitrary user specified directory. This is also handy for rapid experiments.