### PR TITLE
[ST-831] support subset --split option

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -216,7 +216,7 @@ def subset(context, target, session_id, base_path: str, build_name: str, rest: s
 
             # regardless of whether we managed to talk to the service
             # we produce test names
-            if rest != "":
+            if rest is not None:
                 rests = []
 
                 subset = [self.formatter(t) for t in output]

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -226,8 +226,8 @@ def subset(context, target, session_id, base_path: str, build_name: str, rest: s
                         rests.append(p)
 
                 if len(rests) == 0:
-                    click.echo(click.style(
-                        "Warning: remainder files don't exists.", fg='yellow'),  err=True)
+                    # no tests will be in the "rest" file. but add a test case to avoid failing tests using this
+                    rests.append(subset[-1])
 
                 open(rest, "w+").write(self.separator.join(rests))
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -219,19 +219,20 @@ def subset(context, target, session_id, base_path: str, build_name: str, split):
             # we produce test names
             if 0 < len(split):
                 remainder = []
+
+                subset = [self.formatter(t) for t in output]
                 for path in self.test_paths:
-                    if path not in output:
-                        remainder.append(path)
+                    p = self.formatter(path)
+                    if p not in subset:
+                        remainder.append(p)
 
                 if len(remainder) == 0:
                     click.echo(click.style(
                         "Warning: remainder files don't exists. add a subset file to remainder to avoid test fail", fg='yellow'),  err=True)
-                    remainder.append(output[0])
+                    remainder.append(self.formatter(output[0]))
 
-                open(split[0], "w+").write(self.separator.join(self.formatter(t)
-                                                               for t in output))
-                open(split[1], "w+").write(self.separator.join(self.formatter(t)
-                                                               for t in remainder))
+                open(split[0], "w+").write(self.separator.join(subset))
+                open(split[1], "w+").write(self.separator.join(remainder))
             else:
                 click.echo(self.separator.join(self.formatter(t)
                                                for t in output))

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -46,14 +46,13 @@ from .record.session import session
     metavar='BUILD_NAME'
 )
 @click.option(
-    '--split',
-    'split',
-    help='output subset and remainder to file',
-    nargs=2,
+    '--rest',
+    'rest',
+    help='output the rest of subset',
     type=str,
 )
 @click.pass_context
-def subset(context, target, session_id, base_path: str, build_name: str, split):
+def subset(context, target, session_id, base_path: str, build_name: str, rest: str):
     token, org, workspace = parse_token()
 
     if session_id and build_name:
@@ -217,24 +216,22 @@ def subset(context, target, session_id, base_path: str, build_name: str, split):
 
             # regardless of whether we managed to talk to the service
             # we produce test names
-            if 0 < len(split):
-                remainder = []
+            if rest != "":
+                rests = []
 
                 subset = [self.formatter(t) for t in output]
-                for path in self.test_paths:
-                    p = self.formatter(path)
+                for test_path in self.test_paths:
+                    p = self.formatter(test_path)
                     if p not in subset:
-                        remainder.append(p)
+                        rests.append(p)
 
-                if len(remainder) == 0:
+                if len(rests) == 0:
                     click.echo(click.style(
-                        "Warning: remainder files don't exists. add a subset file to remainder to avoid test fail", fg='yellow'),  err=True)
-                    remainder.append(self.formatter(output[0]))
+                        "Warning: remainder files don't exists.", fg='yellow'),  err=True)
 
-                open(split[0], "w+").write(self.separator.join(subset))
-                open(split[1], "w+").write(self.separator.join(remainder))
-            else:
-                click.echo(self.separator.join(self.formatter(t)
-                                               for t in output))
+                open(rest, "w+").write(self.separator.join(rests))
+
+            click.echo(self.separator.join(self.formatter(t)
+                                           for t in output))
 
     context.obj = Optimize()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,10 @@
+import unittest
+import warnings
+
+
+def ignore_warnings(test_func):
+    def do_test(self, *args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            test_func(self, *args, **kwargs)
+    return do_test

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -6,6 +6,7 @@ import gzip
 from tests.cli_test_case import CliTestCase
 from launchable.utils.http_client import get_base_url
 import tempfile
+from tests.helper import ignore_warnings
 
 
 class GradleTest(CliTestCase):
@@ -23,6 +24,7 @@ class GradleTest(CliTestCase):
         output = '--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.sub.AppTest3 --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest'
         self.assertEqual(result.output.rstrip('\n'), output)
 
+    @ignore_warnings
     @responses.activate
     def test_subset_rest(self):
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -24,21 +24,20 @@ class GradleTest(CliTestCase):
         self.assertEqual(result.output.rstrip('\n'), output)
 
     @responses.activate
-    def test_subset_split(self):
+    def test_subset_rest(self):
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
                           json={'testPaths': [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest2'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
 
-        subset = tempfile.NamedTemporaryFile()
-        remainder = tempfile.NamedTemporaryFile()
+        rest = tempfile.NamedTemporaryFile()
 
         result = self.cli('subset', '--target', '10%', '--build',
-                          self.build_name, '--split', subset.name, remainder.name, 'gradle', str(self.test_files_dir.joinpath('java/app/src/test/java').resolve()))
+                          self.build_name, '--rest', rest.name, 'gradle', str(self.test_files_dir.joinpath('java/app/src/test/java').resolve()))
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(subset.read().decode(
-        ), "--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest")
-        self.assertEqual(remainder.read().decode(),
-                         '--tests com.launchableinc.rocket_car_gradle.sub.AppTest3')
+        self.assertEqual(result.output.rstrip(
+            '\n'), "--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest")
+        self.assertEqual(rest.read().decode(
+        ), '--tests com.launchableinc.rocket_car_gradle.sub.AppTest3')
 
     @responses.activate
     def test_record_test_gradle(self):

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 from unittest import mock
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from tests.cli_test_case import CliTestCase
 from launchable.utils.http_client import get_base_url
+import tempfile
 
 
 class GradleTest(CliTestCase):
@@ -21,6 +22,23 @@ class GradleTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
         output = '--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.sub.AppTest3 --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest'
         self.assertEqual(result.output.rstrip('\n'), output)
+
+    @responses.activate
+    def test_subset_split(self):
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json={'testPaths': [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest2'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
+
+        subset = tempfile.NamedTemporaryFile()
+        remainder = tempfile.NamedTemporaryFile()
+
+        result = self.cli('subset', '--target', '10%', '--build',
+                          self.build_name, '--split', subset.name, remainder.name, 'gradle', str(self.test_files_dir.joinpath('java/app/src/test/java').resolve()))
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(subset.read().decode(
+        ), "--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest")
+        self.assertEqual(remainder.read().decode(),
+                         '--tests com.launchableinc.rocket_car_gradle.sub.AppTest3')
 
     @responses.activate
     def test_record_test_gradle(self):


### PR DESCRIPTION
`--split` option helps to introduce subsetting. if test framework support excluding, you should use it and subsetting list.
but some test frameworks don't support excluding so I add this option.

e.g) I tried the `--split` option to a maven project.

there are two test files
```sh
$ tree ./src/test/java/com/launchableinc/rocket_car_maven
./src/test/java/com/launchableinc/rocket_car_maven
├── App2Test.java
└── AppTest.java
```

first, tried to subset without the split option to check the subsetting result

```sh
$ launchable subset --build maven-1 --target 10% maven ./src/test/**
com.launchableinc.rocket_car_maven.AppTest
```

next, tried to subset with the split option and check results.

```sh
$ launchable subset --build maven-1 --target 10% --split subset.txt remainder.txt maven ./src/test/**
$ cat subset.txt
com.launchableinc.rocket_car_maven.AppTest
$ cat remainder.txt
com.launchableinc.rocket_car_maven.App2Test
```

that's it

