### PR TITLE
[ST-830] add time option for absolute time-based subsetting

### DIFF
--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -38,30 +38,13 @@ class DurationType(click.ParamType):
     name = "duration"
 
     def convert(self, value: str, param, ctx):
-        if value.isdigit():
-            return float(value)
-
         try:
-            units = {'s': 1, 'm': 60,
-                     'h': 60*60, 'd': 60*60*24, 'w': 60*60*24*7}
+            return convert_to_seconds(value)
 
-            duration = 0
-            for m in re.finditer(r'(?P<val>\d+)(?P<unit>[smhdw]?)', value, flags=re.I):
-                val = m.group('val')
-                unit = m.group('unit')
-
-                if val is not None and unit is not None:
-                    v = units.get(unit)
-                    if v is None:
-                        raise ValueError("unable to parse: {}".format(value))
-
-                    duration += int(m.group('val')) * v
-
-            return float(duration)
         except ValueError:
             pass
 
-        self.fail("Expected duration like 3600 or 30m but got '{}'".format(
+        self.fail("Expected duration like 3600, 30m, 1h15m but got '{}'".format(
             value), param, ctx)
 
 
@@ -85,3 +68,27 @@ def emoji(s: str, fallback: str = ''):
     Returns 's' in an environment where stdout can deal with emojis, but 'fallback' otherwise.
     """
     return s if EMOJI else fallback
+
+
+def convert_to_seconds(s: str):
+    units = {'s': 1, 'm': 60,
+             'h': 60*60, 'd': 60*60*24, 'w': 60*60*24*7}
+
+    if s.isdigit():
+        return float(s)
+
+    duration = 0
+    for m in re.finditer(r'(?P<val>\d+)(?P<unit>[smhdw]?)', s, flags=re.I):
+        val = m.group('val')
+        unit = m.group('unit')
+
+        if val is None or unit is None:
+            raise ValueError("unable to parse: {}".format(s))
+
+        u = units.get(unit)
+        if u is None:
+            raise ValueError("unable to parse: {}".format(s))
+
+        duration += int(val) * u
+
+    return float(duration)

--- a/tests/data/maven/subset_by_absolute_time_result.json
+++ b/tests/data/maven/subset_by_absolute_time_result.json
@@ -1,0 +1,13 @@
+{
+  "testPaths": [
+    [
+      {"type": "class", "name": "com.launchableinc.rocket_car_maven.App2Test"}
+    ],
+    [
+      { "type": "class",  "name": "com.launchableinc.rocket_car_maven.AppTest"}
+    ]],
+  "session": {
+      "id":  "16"
+  },
+  "goal": {"type": "subset-by-absolute-time", "duration": 5400}
+}

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from unittest import mock
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from tests.cli_test_case import CliTestCase
@@ -22,6 +22,20 @@ class MavenTest(CliTestCase):
 
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('subset_result.json'))
+
+        self.assert_json_orderless_equal(expected, payload)
+
+    @responses.activate
+    def test_subset_by_absolute_time(self):
+        result = self.cli('subset', '--time', '1h30m', '--session',
+                          self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(
+            responses.calls[0].request.body).decode())
+
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('subset_by_absolute_time_result.json'))
 
         self.assert_json_orderless_equal(expected, payload)
 

--- a/tests/utils/test_click.py
+++ b/tests/utils/test_click.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from launchable.utils.click import convert_to_seconds
+
+
+class DurationTypeTest(TestCase):
+    def test_convert_to_seconds(self):
+        self.assertEqual(convert_to_seconds('30s'), 30)
+        self.assertEqual(convert_to_seconds('5m'), 300)
+        self.assertEqual(convert_to_seconds('1h30m'), 5400)
+        self.assertEqual(convert_to_seconds('1d10h15m'), 123300)
+        self.assertEqual(convert_to_seconds('15m 1d 10h'), 123300)
+
+        with self.assertRaises(ValueError):
+            convert_to_seconds('1h30k')


### PR DESCRIPTION
I support absolute time-based subsetting.

e.g)
```sh
launchable subset --time 30m <SUBSET ARGS>
```


