### PR TITLE
Add Java Test name heuristics to the Gradle plugin

### DIFF
--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,16 +1,16 @@
 import os
-import re
 
 import click
 
 from . import launchable
-
+from ..utils.file_name_pattern import jvm_test_pattern
 
 @click.argument('source_roots', required=True, nargs=-1)
 @launchable.subset
 def subset(client, source_roots):
     def file2test(f: str):
-        if re.match(r'^.*Test(?:Case|s)?\.(?:java|scala|kt)$', f):
+        # find *Test, *Tests, *TestCase + .java, .scala, .kt
+        if jvm_test_pattern.match(f):
             f = f[:f.rindex('.')]   # remove extension
             # directory -> package name conversion
             cls_name = f.replace(os.path.sep, '.')

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import click
 
@@ -9,7 +10,7 @@ from . import launchable
 @launchable.subset
 def subset(client, source_roots):
     def file2test(f: str):
-        if f.endswith('.java') or f.endswith('.scala') or f.endswith('.kt'):
+        if re.match(r'^.*Test(?:Case|s)?\.(?:java|scala|kt)$', f):
             f = f[:f.rindex('.')]   # remove extension
             # directory -> package name conversion
             cls_name = f.replace(os.path.sep, '.')

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -9,7 +9,6 @@ from ..utils.file_name_pattern import jvm_test_pattern
 @launchable.subset
 def subset(client, source_roots):
     def file2test(f: str):
-        # find *Test, *Tests, *TestCase + .java, .scala, .kt
         if jvm_test_pattern.match(f):
             f = f[:f.rindex('.')]   # remove extension
             # directory -> package name conversion

--- a/launchable/utils/file_name_pattern.py
+++ b/launchable/utils/file_name_pattern.py
@@ -1,3 +1,4 @@
 import re
 
+ # find *Test, *Tests, *TestCase + .java, .scala, .kt
 jvm_test_pattern = re.compile(r'^.*Test(?:Case|s)?\.(?:java|scala|kt)$')

--- a/launchable/utils/file_name_pattern.py
+++ b/launchable/utils/file_name_pattern.py
@@ -1,0 +1,3 @@
+import re
+
+jvm_test_pattern = re.compile(r'^.*Test(?:Case|s)?\.(?:java|scala|kt)$')

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/App2Test.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/App2Test.java
@@ -6,7 +6,7 @@ package com.launchableinc.rocket_car_gradle;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-public class AppTest2 {
+public class App2Test {
     @Test public void testAppHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/sub/App3Test.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/sub/App3Test.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import com.launchableinc.rocket_car_gradle.App;
 
-public class AppTest3 {
+public class App3Test {
     @Test public void testAppHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -18,18 +18,18 @@ class GradleTest(CliTestCase):
     @responses.activate
     def test_subset_without_session(self):
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
-                          json={'testPaths': [[{'name': 'com.launchableinc.rocket_car_gradle.AppTest2'}], [{'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'name': 'com.launchableinc.rocket_car_gradle.sub.AppTest3'}], [{'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
+                          json={'testPaths': [[{'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'name': 'com.launchableinc.rocket_car_gradle.sub.App3Test'}], [{'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
         result = self.cli('subset', '--target', '10%', '--build',
                           self.build_name, 'gradle', str(self.test_files_dir.joinpath('java/app/test').resolve()))
         self.assertEqual(result.exit_code, 0)
-        output = '--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.sub.AppTest3 --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest'
+        output = '--tests com.launchableinc.rocket_car_gradle.App2Test --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.sub.App3Test --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest'
         self.assertEqual(result.output.rstrip('\n'), output)
 
     @ignore_warnings
     @responses.activate
     def test_subset_rest(self):
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
-                          json={'testPaths': [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest2'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
+                          json={'testPaths': [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]]}, status=200)
 
         rest = tempfile.NamedTemporaryFile()
 
@@ -38,9 +38,9 @@ class GradleTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output.rstrip(
-            '\n'), "--tests com.launchableinc.rocket_car_gradle.AppTest2 --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest")
+            '\n'), "--tests com.launchableinc.rocket_car_gradle.App2Test --tests com.launchableinc.rocket_car_gradle.AppTest --tests com.launchableinc.rocket_car_gradle.utils.UtilsTest")
         self.assertEqual(rest.read().decode(
-        ), '--tests com.launchableinc.rocket_car_gradle.sub.AppTest3')
+        ), '--tests com.launchableinc.rocket_car_gradle.sub.App3Test')
 
     @responses.activate
     def test_record_test_gradle(self):

--- a/tests/utils/test_file_name_pattern.py
+++ b/tests/utils/test_file_name_pattern.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from launchable.utils.file_name_pattern import jvm_test_pattern
+
+class FileNameHeuristicTest(TestCase):
+  def test_jvm_file_name(self):
+    file_names = [
+      'LaunchableTest.java',
+      'LaunchableTests.java',
+      'LaunchableTestCase.java'
+    ]
+    for file_name in file_names:
+      self.assertTrue(jvm_test_pattern.match(file_name))
+
+    file_names = [
+      'LaunchableTest2.java',
+      'LaunchableTests2.java',
+      'LaunchableTestCase2.java'
+      'LaunchableTestUtil.java',
+      'LaunchableTestss.java',
+      'LaunchableTest2Case.java'
+    ]
+    for file_name in file_names:
+      self.assertFalse(jvm_test_pattern.match(file_name))


### PR DESCRIPTION
The current Gradle plugin has a problem that it retrieves non-test files. To resolve it, I add test name heuristics such as `*Test.java`, `*Tests.java`, `*TestCase.java` (Of course I remained `.scala` and `.kt` support). These heuristics are based on [this reference](https://docs.gradle.org/current/userguide/java_testing.html).