### PR TITLE
[ST-871] add patch to create session

### DIFF
--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -16,7 +16,18 @@ def _session_file_dir() -> Path:
 
 
 def _session_file_path(build_name: str) -> Path:
-    return _session_file_dir() / (hashlib.sha1("{}:{}".format(build_name, os.getsid(os.getpid())).encode()).hexdigest() + ".txt")
+    return _session_file_dir() / (hashlib.sha1("{}:{}".format(build_name, _get_session_id()).encode()).hexdigest() + ".txt")
+
+
+def _get_session_id():
+    id = os.getsid(os.getpid())
+
+    # CircleCI changes unix session id each steps, so set non change variable
+    # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+    if os.environ.get("CIRCLECI") is not None:
+        id = os.environ.get("CIRCLE_WORKFLOW_ID")
+
+    return id
 
 
 def read_session(build_name: str) -> Optional[str]:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,6 @@
-from unittest import TestCase
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files
+from unittest import TestCase, mock
+from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, _get_session_id
+import os
 
 
 class SessionTestClass(TestCase):
@@ -32,3 +33,12 @@ class SessionTestClass(TestCase):
     def test_different_pid(self):
         # TODO
         pass
+
+    def test_get_session_id(self):
+        id = _get_session_id()
+
+        with mock.patch.dict(os.environ, {"CIRCLECI": "TRUE", "CIRCLE_WORKFLOW_ID": "abc-123"}):
+            id_in_circleci = _get_session_id()
+
+            self.assertEqual(id_in_circleci, "abc-123")
+            self.assertNotEqual(id, id_in_circleci)


### PR DESCRIPTION
we use unix session id as flavor to create session file. but when the cli run in the CircleCI, unix session id is changed each step.

so, I changed when the cli runs in the CircleCI, the cli uses the `CIRCLE_WORKFLOW_ID` instead of unix session id.