### PR TITLE
[ST-863] show warning message when request gets 404

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -1,0 +1,27 @@
+import click
+from typing import Optional
+from .record.session import session as session_command
+from ..utils.session import read_session
+
+
+def find_or_create_session(context, session: Optional[str], build_name: Optional[str], flavor=[]) -> Optional[str]:
+    if session and build_name:
+        raise click.UsageError(
+            'Only one of --build or --session should be specified')
+
+    if session is None and build_name is None:
+        raise click.UsageError(
+            'Either --build or --session has to be specified')
+
+    if session:
+        return session
+    elif build_name:
+        session_id = read_session(build_name)
+        if session_id:
+            return session_id
+        else:
+            context.invoke(
+                session_command, build_name=build_name, save_session_file=True, print_session=False, flavor=flavor)
+            return read_session(build_name)
+    else:
+        return None

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -4,7 +4,7 @@ from .record.session import session as session_command
 from ..utils.session import read_session
 
 
-def find_or_create_session(context, session: Optional[str], build_name: Optional[str], flavor=[]) -> Optional[str]:
+def _validate_session_and_build_name(session: Optional[str], build_name: Optional[str]):
     if session and build_name:
         raise click.UsageError(
             'Only one of --build or --session should be specified')
@@ -12,6 +12,10 @@ def find_or_create_session(context, session: Optional[str], build_name: Optional
     if session is None and build_name is None:
         raise click.UsageError(
             'Either --build or --session has to be specified')
+
+
+def find_or_create_session(context, session: Optional[str], build_name: Optional[str], flavor=[]) -> Optional[str]:
+    _validate_session_and_build_name(session, build_name)
 
     if session:
         return session

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,7 +1,7 @@
 import click
 import os
 import json
-
+from http import HTTPStatus
 from ...utils.http_client import LaunchableClient
 from ...utils.token import parse_token
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -62,7 +62,7 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
                                  {"flavors": flavor_dict},
                              ))
 
-        if res.status_code == 404:
+        if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
                 "Build {} was not found. Make sure to run `launchable record build --name {}` before".format(build_name, build_name), 'yellow'), err=True)
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -57,14 +57,17 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
         session_path = "/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions".format(
             org, workspace, build_name)
 
-        res = client.request("post", session_path, headers=headers, data=json.dumps({"flavors": flavor_dict})
+        res = client.request("post", session_path,
+                             headers=headers, data=json.dumps(
+                                 {"flavors": flavor_dict},
+                             ))
 
         if res.status_code == 404:
             click.echo(click.style(
                 "Build {} was not found. Make sure to run `launchable record build --name {}` before".format(build_name, build_name), 'yellow'), err=True)
 
         res.raise_for_status()
-        session_id=res.json()['id']
+        session_id = res.json()['id']
 
         if save_session_file:
             write_session(build_name, "{}/{}".format(session_path, session_id))

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -56,12 +56,15 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
     try:
         session_path = "/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions".format(
             org, workspace, build_name)
-        res = client.request("post", session_path,
-                             headers=headers, data=json.dumps({
-                                 "flavors": flavor_dict,
-                             }))
+
+        res = client.request("post", session_path, headers=headers, data=json.dumps({"flavors": flavor_dict})
+
+        if res.status_code == 404:
+            click.echo(click.style(
+                "Build {} was not found. Make sure to run `launchable record build --name {}` before".format(build_name, build_name), 'yellow'), err=True)
+
         res.raise_for_status()
-        session_id = res.json()['id']
+        session_id=res.json()['id']
 
         if save_session_file:
             write_session(build_name, "{}/{}".format(session_path, session_id))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -5,10 +5,9 @@ import traceback
 import click
 from junitparser import JUnitXml, TestSuite, TestCase  # type: ignore
 import xml.etree.ElementTree as ET
-from typing import Callable, Generator, Iterator, List, Union, Optional
+from typing import Callable, Generator, Iterator, List, Optional
 from itertools import repeat, starmap, takewhile, islice
 from more_itertools import ichunked
-from operator import truth
 from .case_event import CaseEvent
 from ...testpath import TestPathComponent
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -20,6 +19,7 @@ from ...utils.session import read_session, parse_session
 from ...testpath import TestPathComponent
 from .session import session as session_command
 from ..helper import find_or_create_session
+from http import HTTPStatus
 
 
 @click.group()
@@ -179,7 +179,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                 res = client.request(
                     "post", "{}/events".format(session_id), data=payload, headers=headers)
 
-                if res.status_code == 404:
+                if res.status_code == HTTPStatus.NOT_FOUND:
                     if session:
                         _, _, build, _ = parse_session(session)
                         click.echo(click.style(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -14,6 +14,7 @@ from ..testpath import TestPath
 from ..utils.session import read_session
 from .record.session import session as session_command
 from .helper import find_or_create_session
+from http import HTTPStatus
 
 # TODO: rename files and function accordingly once the PR landscape
 
@@ -222,7 +223,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     res = client.request("post", path, data=gzip.compress(json.dumps(
                         payload).encode()), headers=headers, timeout=timeout)
 
-                    if res.status_code == 404:
+                    if res.status_code == HTTPStatus.NOT_FOUND:
                         if session:
                             _, _, build, _ = parse_session(session)
                             click.echo(click.style(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -66,7 +66,7 @@ from .helper import find_or_create_session
     multiple=True,
 )
 @click.pass_context
-def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: str, rest: str, duration, flavor=[]):
+def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: Optional[str], rest: str, duration, flavor=[]):
     token, org, workspace = parse_token()
 
     session_id = find_or_create_session(context, session, build_name, flavor)
@@ -221,6 +221,16 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     timeout = (5, 180)
                     res = client.request("post", path, data=gzip.compress(json.dumps(
                         payload).encode()), headers=headers, timeout=timeout)
+
+                    if res.status_code == 404:
+                        if session:
+                            _, _, build, _ = parse_session(session)
+                            click.echo(click.style(
+                                "Session {} was not found. Make sure to run `launchable record session --build {}` before `launchable record tests`".format(session, build), 'yellow'), err=True)
+                        elif build_name:
+                            click.echo(click.style(
+                                "Build {} was not found. Make sure to run `launchable record build --name {}` before `launchable record tests`".format(build_name, build_name), 'yellow'), err=True)
+
                     res.raise_for_status()
                     output = res.json()["testPaths"]
                 except Exception as e:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -14,7 +14,6 @@ from ..testpath import TestPath
 from ..utils.session import read_session
 from .record.session import session as session_command
 from .helper import find_or_create_session
-from http import HTTPStatus
 
 # TODO: rename files and function accordingly once the PR landscape
 
@@ -222,15 +221,6 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     timeout = (5, 180)
                     res = client.request("post", path, data=gzip.compress(json.dumps(
                         payload).encode()), headers=headers, timeout=timeout)
-
-                    if res.status_code == HTTPStatus.NOT_FOUND:
-                        if session:
-                            _, _, build, _ = parse_session(session)
-                            click.echo(click.style(
-                                "Session {} was not found. Make sure to run `launchable record session --build {}` before `launchable record tests`".format(session, build), 'yellow'), err=True)
-                        elif build_name:
-                            click.echo(click.style(
-                                "Build {} was not found. Make sure to run `launchable record build --name {}` before `launchable record tests`".format(build_name, build_name), 'yellow'), err=True)
 
                     res.raise_for_status()
                     output = res.json()["testPaths"]

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -12,7 +12,7 @@ from ..utils.http_client import LaunchableClient
 from ..utils.token import parse_token
 from ..testpath import TestPath
 from ..utils.session import read_session
-from .record.session import session
+from .record.session import session as session_command
 
 # TODO: rename files and function accordingly once the PR landscape
 
@@ -32,7 +32,7 @@ from .record.session import session
 )
 @click.option(
     '--session',
-    'session_id',
+    'session',
     help='Test session ID',
     type=str,
 )
@@ -65,26 +65,32 @@ from .record.session import session
     multiple=True,
 )
 @click.pass_context
-def subset(context, target, session_id, base_path: str, build_name: str, rest: str, duration, flavor=[]):
+def subset(context, target, session, base_path: str, build_name: str, rest: str, duration, flavor=[]):
     token, org, workspace = parse_token()
 
-    if session_id and build_name:
+    if session and build_name:
         raise click.UsageError(
             'Only one of --build or --session should be specified')
 
-    if not session_id:
-        if build_name:
+    if session is None and build_name is None:
+        raise click.UsageError(
+            'Either --build or --session has to be specified')
+
+    if session:
+        session_id = session
+    elif build_name:
+        session_id = read_session(build_name)
+        if not session_id:
+            context.invoke(
+                session_command, build_name=build_name, save_session_file=True, print_session=False, flavor=flavor)
             session_id = read_session(build_name)
-            if not session_id:
-                context.invoke(session, build_name=build_name,
-                               save_session_file=True, print_session=False, flavor=flavor)
-                session_id = read_session(build_name)
-        else:
-            raise click.UsageError(
-                'Either --build or --session has to be specified')
+            # failed to create test session
+            if session_id is None:
+                return
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class
+
     class Optimize:
         # test_paths: List[TestPath]  # doesn't work with Python 3.5
 
@@ -138,7 +144,8 @@ def subset(context, target, session_id, base_path: str, build_name: str, rest: s
             they didn't feed anything from stdin
             """
             if sys.stdin.isatty():
-                click.echo(click.style("Warning: this command reads from stdin but it doesn't appear to be connected to anything. Did you forget to pipe from another command?", fg='yellow'), err=True)
+                click.echo(click.style(
+                    "Warning: this command reads from stdin but it doesn't appear to be connected to anything. Did you forget to pipe from another command?", fg='yellow'), err=True)
             return sys.stdin
 
         @staticmethod

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -65,7 +65,7 @@ from .record.session import session as session_command
     multiple=True,
 )
 @click.pass_context
-def subset(context, target, session, base_path: str, build_name: str, rest: str, duration, flavor=[]):
+def subset(context, target, session: Optional[str], base_path: str, build_name: str, rest: str, duration, flavor=[]):
     token, org, workspace = parse_token()
 
     if session and build_name:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -70,3 +70,13 @@ def clean_session_files(days_ago: int = 0) -> None:
             clean_date = datetime.datetime.now() - datetime.timedelta(days=days_ago)
             if file_created < clean_date:
                 child.unlink()
+
+
+def parse_session(session: str):
+    try:
+        _, _, _, org, _, workspace, _, build_name, _, session_id = session.split(
+            "/")
+    except Exception as e:
+        raise Exception("Can't parse session: {}".format(session)) from e
+
+    return org, workspace, build_name, session_id

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -74,6 +74,8 @@ def clean_session_files(days_ago: int = 0) -> None:
 
 def parse_session(session: str):
     try:
+        # session format:
+        # /intake/organizations/<org name>/workspaces/<workspace name>/builds/<build name>/test_sessions/<test session id>
         _, _, _, org, _, workspace, _, build_name, _, session_id = session.split(
             "/")
     except Exception as e:

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from launchable.commands.helper import _validate_session_and_build_name
+import click
+
+
+class TestHelper(TestCase):
+
+    def test__validate_session_and_build_name(self):
+        with self.assertRaises(click.UsageError):
+            _validate_session_and_build_name(None, None)
+
+        with self.assertRaises(click.UsageError):
+            _validate_session_and_build_name("session", "build_name")
+
+        _validate_session_and_build_name("session", None)
+        _validate_session_and_build_name(None, "build_name")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, mock
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, _get_session_id
+from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, _get_session_id, parse_session
 import os
 
 
@@ -42,3 +42,14 @@ class SessionTestClass(TestCase):
 
             self.assertEqual(id_in_circleci, "abc-123")
             self.assertNotEqual(id, id_in_circleci)
+
+    def test_parse_session(self):
+        session = "/intake/organizations/org-name/workspaces/workspace-name/builds/build-name/test_sessions/123"
+        org, workspace, build_name, session_id = parse_session(session)
+        self.assertEqual(org, "org-name")
+        self.assertEqual(workspace, "workspace-name")
+        self.assertEqual(build_name, "build-name")
+        self.assertEqual(session_id, "123")
+
+        with self.assertRaises(Exception):
+            parse_session("hoge/fuga")


### PR DESCRIPTION
I have made 2 changed in this PR

- show an error message when the request gets 404 error
- the commonality to setup session

## show an error message when the request gets 404 error

If we request to create a session before record a build, got 404 error. But unfortunately, the error message isn't easy to understand what is the cause of the error now. So, I changed to show the message that what should we do.
Also, sometimes the subset command and the record tests get a 404 error. 
But I only added to the create session command and the record tests command, because the subset command gets 404 when the subset model doesn't create yet. https://github.com/launchableinc/cli/pull/183/commits/2c49478f38bc8d92c951398a483e57499562b685

#### before 

```sh
$ LAUNCHABLE_TOKEN=<TOKEN> launchable record session  --build teeeeeeeeeeeest
404 Client Error:  for url: https://api.mercury.launchableinc.com/intake/organizations/<org>/workspaces/<workspace>/builds/teeeeeeeeeeeest/test_sessions
```

#### after 

```sh
$ LAUNCHABLE_TOKEN=<TOKEN> launchable record session  --build teeeeeeeeeeeest
Build teeeeeeeeeeeest was not found. Make sure to run `launchable record build --name teeeeeeeeeeeest` before
404 Client Error:  for url: https://api.mercury.launchableinc.com/intake/organizations/<org>/workspaces/<workspace>/builds/teeeeeeeeeeeest/test_sessions
```

note: the create test session commands will be called by the subset command and the record tests command

## the commonality to setup session

the subset command and the record tests command build the session_id used by session or build_name on head of these methods. 
these logics are similar, so I optimize it and added test code.