### PR TITLE
add check wildcard characters are contained or not

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -118,6 +118,9 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
         def test_path(self, path: TestPathLike):
             if isinstance(path, str) and any(s in path for s in ('/**', '**/', '*.', "/*")):
                 for i in glob.iglob(path, recursive=True):
+                    if os.path.isdir(i):
+                        continue
+
                     self.test_path(i)
                 return
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -116,7 +116,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             self._separator = s
 
         def test_path(self, path: TestPathLike):
-            if isinstance(path, str) and any(s in path for s in ('/**', '**/', '*.')):
+            if isinstance(path, str) and any(s in path for s in ('/**', '**/', '*.', "/*")):
                 for i in glob.iglob(path, recursive=True):
                     self.test_path(i)
                 return

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -116,6 +116,11 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             self._separator = s
 
         def test_path(self, path: TestPathLike):
+            if isinstance(path, str) and any(s in path for s in ('/**', '**/', '*.')):
+                for i in glob.iglob(path, recursive=True):
+                    self.test_path(i)
+                return
+
             """register one test"""
             self.test_paths.append(self.to_test_path(path))
 


### PR DESCRIPTION
before this change, if the test_path method receives test path strings which are contained wildcards, this method sets test_paths directly.

```sh
$ launchable subset --build 1 --target 20% minitest "test/**/*.rb"
test/**/*.rb

$ launchable subset --build 1 --target 20% minitest test/**/*.rb
test/application_system_test_case.rb
test/channels/application_cable/connection_test.rb
test/controllers/user_test.rb
test/models/admin/user_test.rb
test/models/open_class_user_test.rb
test/models/user_copy_test.rb
test/models/user_test.rb
test/test_h*ge.rb
test/test_helper.rb
```

so I fixed the test_path method expands wildcards 
```sh
$ launchable subset --build 1 --target 20% minitest "test/**/*.rb"
test/test_h*ge.rb
test/application_system_test_case.rb
test/test_helper.rb
test/models/open_class_user_test.rb
test/models/user_copy_test.rb
test/models/user_test.rb
test/models/admin/user_test.rb
test/controllers/user_test.rb
test/channels/application_cable/connection_test.rb
```

SHELLs usually expand wildcard, but when we combine some commands, SHELLs realize the wildcards as strings and don't expand, I think