### PR TITLE
[ENG-61] change to flavor option format

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -31,8 +31,6 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     "--flavor",
     "flavor",
     help='flavors',
-    nargs=2,
-    type=(str, str),
     multiple=True,
 )
 def session(build_name: str, save_session_file: bool, print_session: bool = True, flavor=[]):
@@ -50,7 +48,18 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
     # TODO: check duplicate keys
     flavor_dict = {}
     for f in flavor:
-        flavor_dict[f[0]] = f[1]
+        if "=" not in f:
+            click.echo(
+                "Skip to set --flavor {}. Make sure to set `--flavor key=value`.".format(f), err=True)
+            continue
+
+        k, v = f.split('=')
+        if not k or not v:
+            click.echo(
+                "Skip to set --flavor {}. Make sure to set `--flavor key=value`.".format(f), err=True)
+            continue
+
+        flavor_dict[k] = v
 
     client = LaunchableClient(token)
     try:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -6,7 +6,7 @@ from ...utils.http_client import LaunchableClient
 from ...utils.token import parse_token
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.session import write_session
-
+from ...utils.click import KeyValueType
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 
@@ -31,6 +31,7 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     "--flavor",
     "flavor",
     help='flavors',
+    cls=KeyValueType,
     multiple=True,
 )
 def session(build_name: str, save_session_file: bool, print_session: bool = True, flavor=[]):
@@ -40,26 +41,14 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
     If you run this command from the other command such as `subset` and `record tests`, you should set print_session = False because users don't expect to print session ID to the subset output.
     """
     token, org, workspace = parse_token()
-
     headers = {
         "Content-Type": "application/json",
     }
 
     # TODO: check duplicate keys
     flavor_dict = {}
-    for f in flavor:
-        if "=" not in f:
-            click.echo(
-                "Skip to set --flavor {}. Make sure to set `--flavor key=value`.".format(f), err=True)
-            continue
-
-        k, v = f.split('=')
-        if not k or not v:
-            click.echo(
-                "Skip to set --flavor {}. Make sure to set `--flavor key=value`.".format(f), err=True)
-            continue
-
-        flavor_dict[k.strip()] = v.strip()
+    for kv in flavor:
+        flavor_dict[kv[0]] = kv[1]
 
     client = LaunchableClient(token)
     try:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -59,7 +59,7 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
                 "Skip to set --flavor {}. Make sure to set `--flavor key=value`.".format(f), err=True)
             continue
 
-        flavor_dict[k] = v
+        flavor_dict[k.strip()] = v.strip()
 
     client = LaunchableClient(token)
     try:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -45,10 +45,9 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
         "Content-Type": "application/json",
     }
 
-    # TODO: check duplicate keys
     flavor_dict = {}
-    for kv in flavor:
-        flavor_dict[kv[0]] = kv[1]
+    for (k, v) in flavor:
+        flavor_dict[k] = v
 
     client = LaunchableClient(token)
     try:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -59,12 +59,10 @@ from http import HTTPStatus
     "--flavor",
     "flavor",
     help='flavors',
-    nargs=2,
-    type=(str, str),
     multiple=True,
 )
 @click.pass_context
-def tests(context, base_path: str, session: Optional[str], build_name: Optional[str], debug: bool, post_chunk: int, flavor=[]):
+def tests(context, base_path: str, session: Optional[str], build_name: Optional[str], debug: bool, post_chunk: int, flavor):
     session_id = find_or_create_session(context, session, build_name, flavor)
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -20,6 +20,7 @@ from ...testpath import TestPathComponent
 from .session import session as session_command
 from ..helper import find_or_create_session
 from http import HTTPStatus
+from ...utils.click import KeyValueType
 
 
 @click.group()
@@ -59,6 +60,7 @@ from http import HTTPStatus
     "--flavor",
     "flavor",
     help='flavors',
+    cls=KeyValueType,
     multiple=True,
 )
 @click.pass_context

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -14,6 +14,7 @@ from ..testpath import TestPath
 from ..utils.session import read_session
 from .record.session import session as session_command
 from .helper import find_or_create_session
+from ..utils.click import KeyValueType
 
 # TODO: rename files and function accordingly once the PR landscape
 
@@ -61,7 +62,9 @@ from .helper import find_or_create_session
     "--flavor",
     "flavor",
     help='flavors',
+    cls=KeyValueType,
     multiple=True,
+
 )
 @click.pass_context
 def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: Optional[str], rest: str, duration, flavor):

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -61,12 +61,10 @@ from .helper import find_or_create_session
     "--flavor",
     "flavor",
     help='flavors',
-    nargs=2,
-    type=(str, str),
     multiple=True,
 )
 @click.pass_context
-def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: Optional[str], rest: str, duration, flavor=[]):
+def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: Optional[str], rest: str, duration, flavor):
     token, org, workspace = parse_token()
 
     session_id = find_or_create_session(context, session, build_name, flavor)

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -49,6 +49,8 @@ class DurationType(click.ParamType):
 
 
 class KeyValueType(click.Option):
+    error_message = "Expected key-value like --option kye=value or --option key value. but got '{}'"
+
     def __init__(self, *args, **kwargs):
         super(KeyValueType, self).__init__(*args, **kwargs)
         self._previous_parser_process = None
@@ -56,13 +58,12 @@ class KeyValueType(click.Option):
 
     def add_to_parser(self, parser, ctx):
         def parser_process(value, state):
-            errorMessage = "Expected key-value like --option kye=value or --option key value. but got '{}'"
             # case: --option key=value
             if '=' in value:
                 kv = value.split('=')
                 if len(kv) != 2:
                     raise ValueError(
-                        errorMessage.format(value))
+                        self.error_message.format(value))
 
                 value = tuple([kv[0].strip(), kv[1].strip()])
             # case: --option key value
@@ -71,11 +72,11 @@ class KeyValueType(click.Option):
                 # --option key-only
                 if len(rargs) < 1:
                     raise ValueError(
-                        errorMessage.format(value))
+                        self.error_message.format(value))
                 # --option key --other-option / -option key - other-argument
                 elif 0 < len(rargs) and any(rargs[0].startswith(p) for p in self._key_value_parser.prefixes):
                     raise ValueError(
-                        errorMessage.format(" ".join([value, rargs[0]])))
+                        self.error_message.format(" ".join([value, rargs[0]])))
 
                 value = [value, state.rargs.pop(0)]
 

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -16,11 +16,15 @@ class SessionTest(CliTestCase):
     @responses.activate
     def test_run_session_with_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name,
-                          "--flavor", "key", "value", "--flavor", "k", "v")
+                          "--flavor", "key=value", "--flavor", "k = v", "--flavor", "k e y = v a l u e", "--flavor", "no-value",)
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body)
         self.assert_json_orderless_equal({"flavors": {
             "key": "value",
             "k": "v",
+            "k e y": "v a l u e",
         }}, payload)
+
+        self.assertTrue(
+            "Skip to set --flavor no-value." in result.output)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -16,7 +16,7 @@ class SessionTest(CliTestCase):
     @responses.activate
     def test_run_session_with_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name,
-                          "--flavor", "key=value", "--flavor", "k = v", "--flavor", "k e y = v a l u e", "--flavor", "no-value",)
+                          "--flavor", "key=value", "--flavor", "k", "v", "--flavor", "k e y = v a l u e")
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body)
@@ -26,5 +26,9 @@ class SessionTest(CliTestCase):
             "k e y": "v a l u e",
         }}, payload)
 
-        self.assertTrue(
-            "Skip to set --flavor no-value." in result.output)
+        with self.assertRaises(ValueError):
+            result = self.cli("record", "session", "--build", self.build_name,
+                              "--flavor", "only-key")
+            self.assertEqual(result.exit_code, 1)
+            self.assertTrue(
+                "Expected key-value like --option kye=value or --option key value." in result.output)


### PR DESCRIPTION
before this change, the flavor option provides a `--flavor key value` format.

but the source option in the record build command provides a `--source repo=name` format.
IOW, the source option already supports a `key=value` style.

so I changed to keep the `key=value` format