### PR TITLE
Run verify command on Windows

### DIFF
--- a/launchable/utils/java.py
+++ b/launchable/utils/java.py
@@ -1,10 +1,8 @@
 import os
-import subprocess
-
+import shutil
 
 def get_java_command():
-    res = subprocess.run(["which", "java"], stdout=subprocess.DEVNULL)
-    if res.returncode == 0:
+    if shutil.which("java"):
         return "java"
 
     if os.access(os.path.expandvars("$JAVA_HOME/bin/java"), os.X_OK):

--- a/launchable/utils/java.py
+++ b/launchable/utils/java.py
@@ -6,6 +6,6 @@ def get_java_command():
         return "java"
 
     if os.access(os.path.expandvars("$JAVA_HOME/bin/java"), os.X_OK):
-        return "$JAVA_HOME/bin/java"
+        return os.path.expandvars("$JAVA_HOME/bin/java")
 
     return None


### PR DESCRIPTION
To run `launchable verify` on Windows, I modified the code to use `shutil.which`.

Here is the command result.

```shell
PS C:\Users\IEUser> launchable verify
Organization: ninjinkun2
Workspace: oreore
Platform: Windows-10-10.0.17763-SP0
Python version: 3.9.4
Java command: java
launchable version: 1.13.3.dev7+g360b92b
Your CLI configuration is successfully verified