### PR TITLE
Update the PyPI link to point to the launchable page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ The Launchable CLI enables this integration.
 
 ## Installing the CLI
 
-The Launchable CLI is a Python3 package that you can install from [PyPI](https://pypi.org/):
+The Launchable CLI is a Python3 package that you can install from [PyPI](https://pypi.org/project/launchable/):
 
 {% hint style="warning" %}
 Note that the CLI requires both **Python 3.5+** *and* **Java 8+**.


### PR DESCRIPTION
Intuitively, I want the link to point to the launchable PyPI page instead of PyPI home page otherwise I feel the link is kind of useless.