### PR TITLE
print warning message when output list is empty

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -117,19 +117,26 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             self._separator = s
 
         def test_path(self, path: TestPathLike):
+            def rel_base_path(path: str):
+                p = path
+                if base_path:
+                    p = normpath(relpath(path, start=base_path))
+
+                return p
+
             if isinstance(path, str) and any(s in path for s in ('*', "?")):
                 for i in glob.iglob(path, recursive=True):
                     if os.path.isfile(i):
-                        test_path = i
-                        if base_path:
-                            test_path = normpath(
-                                relpath(i, start=base_path))
-
-                        self.test_paths.append(self.to_test_path(test_path))
+                        self.test_paths.append(
+                            self.to_test_path(rel_base_path(i)))
                 return
 
             """register one test"""
-            self.test_paths.append(self.to_test_path(path))
+            p = path
+            if base_path and isinstance(p, str):
+                p = rel_base_path(p)
+
+            self.test_paths.append(self.to_test_path(p))
 
         def stdin(self):
             """

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -120,7 +120,12 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             if isinstance(path, str) and any(s in path for s in ('*', "?")):
                 for i in glob.iglob(path, recursive=True):
                     if os.path.isfile(i):
-                        self.test_paths.append(self.to_test_path(i))
+                        test_path = i
+                        if base_path:
+                            test_path = normpath(
+                                relpath(i, start=base_path))
+
+                        self.test_paths.append(self.to_test_path(test_path))
                 return
 
             """register one test"""

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -239,6 +239,11 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     click.echo(click.style(
                         "Warning: the service failed to subset. Falling back to running all tests", fg='yellow'), err=True)
 
+            if len(output) == 0:
+                click.echo(click.style(
+                    "Error: no tests found matching the path.", 'yellow'), err=True)
+                return
+
             # regardless of whether we managed to talk to the service
             # we produce test names
             if rest is not None:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -117,12 +117,11 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             self._separator = s
 
         def test_path(self, path: TestPathLike):
-            def rel_base_path(path: str):
-                p = path
-                if base_path:
-                    p = normpath(relpath(path, start=base_path))
+            def rel_base_path(path):
+                if isinstance(path, str):
+                    return normpath(relpath(path, start=base_path)) if base_path else path
 
-                return p
+                return path
 
             if isinstance(path, str) and any(s in path for s in ('*', "?")):
                 for i in glob.iglob(path, recursive=True):
@@ -132,11 +131,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                 return
 
             """register one test"""
-            p = path
-            if base_path and isinstance(p, str):
-                p = rel_base_path(p)
-
-            self.test_paths.append(self.to_test_path(p))
+            self.test_paths.append(self.to_test_path(rel_base_path(path)))
 
         def stdin(self):
             """

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -118,10 +118,10 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
 
         def test_path(self, path: TestPathLike):
             def rel_base_path(path):
-                if isinstance(path, str):
-                    return normpath(relpath(path, start=base_path)) if base_path else path
-
-                return path
+                if isinstance(path, str) and base_path:
+                    return normpath(relpath(path, start=base_path))
+                else:
+                    return path
 
             if isinstance(path, str) and any(s in path for s in ('*', "?")):
                 for i in glob.iglob(path, recursive=True):

--- a/tests/data/minitest/subset_result.json
+++ b/tests/data/minitest/subset_result.json
@@ -1,0 +1,10 @@
+{
+  "testPaths": [
+    [{"type": "file", "name": "test/example_test.rb"}]
+  ],
+  "target": 0.2,
+  "session": {
+      "id":  "16"
+  }
+}
+

--- a/tests/data/minitest/test/example_test.rb
+++ b/tests/data/minitest/test/example_test.rb
@@ -1,0 +1,2 @@
+# empty file for test 
+

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -36,3 +36,27 @@ class MinitestTest(CliTestCase):
 
         # concat 1st and 2nd request for unstable order
         self.assert_json_orderless_equal(expected1['events'] + expected2['events'], payload1['events'] + payload2['events'])
+
+    @responses.activate
+    def test_subset(self):
+        result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir),
+                          'minitest', str(self.test_files_dir) + "/test/**/*.rb")
+
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(
+            responses.calls[0].request.body).decode())
+
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('subset_result.json'))
+
+        self.assert_json_orderless_equal(expected, payload)
+
+    @responses.activate
+    def test_subset_with_invalid_path(self):
+        result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir),
+                          'minitest', str(self.test_files_dir) + "/dummy")
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(
+            "Error: no tests found matching the path." in result.output)


### PR DESCRIPTION
- if the users run subset command in miss place, the cli show error message
- fix to trim base path when the user set base option in subset command