### PR TITLE
Ant support

### DIFF
--- a/launchable/test_runners/ant.py
+++ b/launchable/test_runners/ant.py
@@ -1,0 +1,32 @@
+import os
+from typing import List
+import click
+from . import launchable
+from ..utils.file_name_pattern import jvm_test_pattern
+
+
+@click.argument('source_roots', required=True, nargs=-1)
+@launchable.subset
+def subset(client, source_roots: List[str]):
+    def file2test(f: str):
+        if jvm_test_pattern.match(f):
+            f = f[:f.rindex('.')]   # remove extension
+            # directory -> package name conversion
+            cls_name = f.replace(os.path.sep, '.')
+            return [{"type": "class", "name": cls_name}]
+        else:
+            return None
+    
+    for root in source_roots:
+        # split "src/**/*Test.java" to "src/" and "**/*Test.java"
+        glob = "**/*"
+        if '*' in root:
+          idx = root.find('*')
+          glob = root[idx:]
+          root = root[:idx]
+        client.scan(root.rstrip('/'), glob, file2test)
+    
+    client.run()
+
+
+record_tests = launchable.CommonRecordTestImpls(__name__).report_files()

--- a/launchable/test_runners/ant.py
+++ b/launchable/test_runners/ant.py
@@ -18,13 +18,7 @@ def subset(client, source_roots: List[str]):
             return None
     
     for root in source_roots:
-        # split "src/**/*Test.java" to "src/" and "**/*Test.java"
-        glob = "**/*"
-        if '*' in root:
-          idx = root.find('*')
-          glob = root[idx:]
-          root = root[:idx]
-        client.scan(root.rstrip('/'), glob, file2test)
+        client.scan(root.rstrip('/'), "**/*Test.java", file2test)
     
     client.run()
 

--- a/tests/data/ant/junitreport/TEST-com.launchable.HelloWorldTest.xml
+++ b/tests/data/ant/junitreport/TEST-com.launchable.HelloWorldTest.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="1" hostname="MacBookKun.local" name="com.launchable.HelloWorldTest" skipped="0" tests="2" time="0.305" timestamp="2021-04-28T10:36:31">
+  <properties>
+    <property name="ant.project.invoked-targets" value="junit" />
+    <property name="java.runtime.name" value="OpenJDK Runtime Environment" />
+    <property name="sun.boot.library.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib" />
+    <property name="java.vm.version" value="25.252-b09" />
+    <property name="ant.library.dir" value="/usr/local/Cellar/ant/1.10.8/libexec/lib" />
+    <property name="gopherProxySet" value="false" />
+    <property name="ant.version" value="Apache Ant(TM) version 1.10.8 compiled on May 10 2020" />
+    <property name="ant.java.version" value="1.8" />
+    <property name="java.vm.vendor" value="AdoptOpenJDK" />
+    <property name="java.vendor.url" value="http://java.oracle.com/" />
+    <property name="path.separator" value=":" />
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM" />
+    <property name="file.encoding.pkg" value="sun.io" />
+    <property name="user.country" value="JP" />
+    <property name="sun.java.launcher" value="SUN_STANDARD" />
+    <property name="sun.os.patch.level" value="unknown" />
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification" />
+    <property name="user.dir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+    <property name="java.runtime.version" value="1.8.0_252-b09" />
+    <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment" />
+    <property name="basedir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+    <property name="java.endorsed.dirs" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/endorsed" />
+    <property name="os.arch" value="x86_64" />
+    <property name="java.io.tmpdir" value="/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/" />
+    <property name="ant.core.lib" value="/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar" />
+    <property name="line.separator" value="&#xa;" />
+    <property name="java.vm.specification.vendor" value="Oracle Corporation" />
+    <property name="os.name" value="Mac OS X" />
+    <property name="ant.home" value="/usr/local/Cellar/ant/1.10.8/libexec" />
+    <property name="build.dir" value="build" />
+    <property name="sun.jnu.encoding" value="UTF-8" />
+    <property name="java.library.path" value="/Users/ninjin/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:." />
+    <property name="java.specification.name" value="Java Platform API Specification" />
+    <property name="java.class.version" value="52.0" />
+    <property name="lib.dir" value="lib" />
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers" />
+    <property name="os.version" value="10.16" />
+    <property name="ant.file" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build.xml" />
+    <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="user.home" value="/Users/ninjin" />
+    <property name="user.timezone" value="" />
+    <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob" />
+    <property name="java.specification.version" value="1.8" />
+    <property name="file.encoding" value="UTF-8" />
+    <property name="java.class.path" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/hamcrest-all-1.3.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/junit-4.13.2.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/log4j-1.2.17.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/jar/${ant.project.name}.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-launcher.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit4.jar" />
+    <property name="user.name" value="ninjin" />
+    <property name="report.dir" value="build/junitreport" />
+    <property name="java.vm.specification.version" value="1.8" />
+    <property name="java.home" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre" />
+    <property name="sun.java.command" value="org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner com.launchable.HelloWorldTest skipNonTests=false filtertrace=true haltOnError=false haltOnFailure=false formatter=org.apache.tools.ant.taskdefs.optional.junit.SummaryJUnitResultFormatter showoutput=false outputtoformatters=true logfailedtests=true threadid=0 logtestlistenerevents=false formatter=org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter,/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/junitreport/TEST-com.launchable.HelloWorldTest.xml crashfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junitvmwatcher7518065668325657626.properties propsfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junit1687636369704213518.properties" />
+    <property name="sun.arch.data.model" value="64" />
+    <property name="java.specification.vendor" value="Oracle Corporation" />
+    <property name="user.language" value="en" />
+    <property name="classes.dir" value="build/classes" />
+    <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit" />
+    <property name="java.vm.info" value="mixed mode" />
+    <property name="java.version" value="1.8.0_252" />
+    <property name="java.ext.dirs" value="/Users/ninjin/Library/Java/Extensions:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java" />
+    <property name="sun.boot.class.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/resources.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/rt.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/sunrsasign.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jsse.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jce.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/charsets.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jfr.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/classes" />
+    <property name="java.vendor" value="AdoptOpenJDK" />
+    <property name="file.separator" value="/" />
+    <property name="src.dir" value="src" />
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/" />
+    <property name="sun.cpu.endian" value="little" />
+    <property name="sun.io.unicode.encoding" value="UnicodeBig" />
+    <property name="main-class" value="com.launchable.HelloWorld" />
+    <property name="ant.file.type" value="file" />
+    <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="jar.dir" value="build/jar" />
+    <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="sun.cpu.isalist" value="" />
+  </properties>
+  <testcase classname="com.launchable.HelloWorldTest" name="testWillAlwaysFail" time="0.006">
+    <failure message="An error message" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: An error message
+	at com.launchable.HelloWorldTest.testWillAlwaysFail(Unknown Source)
+</failure>
+  </testcase>
+  <testcase classname="com.launchable.HelloWorldTest" name="testNothing" time="0.0" />
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/tests/data/ant/junitreport/TEST-com.launchable.library.CacheTest.xml
+++ b/tests/data/ant/junitreport/TEST-com.launchable.library.CacheTest.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="0" hostname="MacBookKun.local" name="com.launchable.library.CacheTest" skipped="0" tests="1" time="0.039" timestamp="2021-04-28T10:36:32">
+  <properties>
+    <property name="ant.project.invoked-targets" value="junit" />
+    <property name="java.runtime.name" value="OpenJDK Runtime Environment" />
+    <property name="sun.boot.library.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib" />
+    <property name="java.vm.version" value="25.252-b09" />
+    <property name="ant.library.dir" value="/usr/local/Cellar/ant/1.10.8/libexec/lib" />
+    <property name="gopherProxySet" value="false" />
+    <property name="ant.version" value="Apache Ant(TM) version 1.10.8 compiled on May 10 2020" />
+    <property name="ant.java.version" value="1.8" />
+    <property name="java.vm.vendor" value="AdoptOpenJDK" />
+    <property name="java.vendor.url" value="http://java.oracle.com/" />
+    <property name="path.separator" value=":" />
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM" />
+    <property name="file.encoding.pkg" value="sun.io" />
+    <property name="user.country" value="JP" />
+    <property name="sun.java.launcher" value="SUN_STANDARD" />
+    <property name="sun.os.patch.level" value="unknown" />
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification" />
+    <property name="user.dir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+    <property name="java.runtime.version" value="1.8.0_252-b09" />
+    <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment" />
+    <property name="basedir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+    <property name="java.endorsed.dirs" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/endorsed" />
+    <property name="os.arch" value="x86_64" />
+    <property name="java.io.tmpdir" value="/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/" />
+    <property name="ant.core.lib" value="/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar" />
+    <property name="line.separator" value="&#xa;" />
+    <property name="java.vm.specification.vendor" value="Oracle Corporation" />
+    <property name="os.name" value="Mac OS X" />
+    <property name="ant.home" value="/usr/local/Cellar/ant/1.10.8/libexec" />
+    <property name="build.dir" value="build" />
+    <property name="sun.jnu.encoding" value="UTF-8" />
+    <property name="java.library.path" value="/Users/ninjin/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:." />
+    <property name="java.specification.name" value="Java Platform API Specification" />
+    <property name="java.class.version" value="52.0" />
+    <property name="lib.dir" value="lib" />
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers" />
+    <property name="os.version" value="10.16" />
+    <property name="ant.file" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build.xml" />
+    <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="user.home" value="/Users/ninjin" />
+    <property name="user.timezone" value="" />
+    <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob" />
+    <property name="java.specification.version" value="1.8" />
+    <property name="file.encoding" value="UTF-8" />
+    <property name="java.class.path" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/hamcrest-all-1.3.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/junit-4.13.2.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/log4j-1.2.17.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/jar/${ant.project.name}.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-launcher.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit4.jar" />
+    <property name="user.name" value="ninjin" />
+    <property name="report.dir" value="build/junitreport" />
+    <property name="java.vm.specification.version" value="1.8" />
+    <property name="java.home" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre" />
+    <property name="sun.java.command" value="org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner com.launchable.library.CacheTest skipNonTests=false filtertrace=true haltOnError=false haltOnFailure=false formatter=org.apache.tools.ant.taskdefs.optional.junit.SummaryJUnitResultFormatter showoutput=false outputtoformatters=true logfailedtests=true threadid=0 logtestlistenerevents=false formatter=org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter,/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/junitreport/TEST-com.launchable.library.CacheTest.xml crashfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junitvmwatcher3186351552913495657.properties propsfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junit1208074720031226095.properties" />
+    <property name="sun.arch.data.model" value="64" />
+    <property name="java.specification.vendor" value="Oracle Corporation" />
+    <property name="user.language" value="en" />
+    <property name="classes.dir" value="build/classes" />
+    <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit" />
+    <property name="java.vm.info" value="mixed mode" />
+    <property name="java.version" value="1.8.0_252" />
+    <property name="java.ext.dirs" value="/Users/ninjin/Library/Java/Extensions:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java" />
+    <property name="sun.boot.class.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/resources.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/rt.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/sunrsasign.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jsse.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jce.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/charsets.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jfr.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/classes" />
+    <property name="java.vendor" value="AdoptOpenJDK" />
+    <property name="file.separator" value="/" />
+    <property name="src.dir" value="src" />
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/" />
+    <property name="sun.cpu.endian" value="little" />
+    <property name="sun.io.unicode.encoding" value="UnicodeBig" />
+    <property name="main-class" value="com.launchable.HelloWorld" />
+    <property name="ant.file.type" value="file" />
+    <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="jar.dir" value="build/jar" />
+    <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+    <property name="sun.cpu.isalist" value="" />
+  </properties>
+  <testcase classname="com.launchable.library.CacheTest" name="testCache" time="0.001" />
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/tests/data/ant/junitreport/TESTS-TestSuites.xml
+++ b/tests/data/ant/junitreport/TESTS-TestSuites.xml
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="1" hostname="MacBookKun.local" id="0" name="HelloWorldTest" package="com.launchable" skipped="0" tests="2" time="0.305" timestamp="2021-04-28T10:36:31">
+      <properties>
+          <property name="ant.project.invoked-targets" value="junit" />
+
+          <property name="java.runtime.name" value="OpenJDK Runtime Environment" />
+
+          <property name="sun.boot.library.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib" />
+
+          <property name="java.vm.version" value="25.252-b09" />
+
+          <property name="ant.library.dir" value="/usr/local/Cellar/ant/1.10.8/libexec/lib" />
+
+          <property name="gopherProxySet" value="false" />
+
+          <property name="ant.version" value="Apache Ant(TM) version 1.10.8 compiled on May 10 2020" />
+
+          <property name="ant.java.version" value="1.8" />
+
+          <property name="java.vm.vendor" value="AdoptOpenJDK" />
+
+          <property name="java.vendor.url" value="http://java.oracle.com/" />
+
+          <property name="path.separator" value=":" />
+
+          <property name="java.vm.name" value="OpenJDK 64-Bit Server VM" />
+
+          <property name="file.encoding.pkg" value="sun.io" />
+
+          <property name="user.country" value="JP" />
+
+          <property name="sun.java.launcher" value="SUN_STANDARD" />
+
+          <property name="sun.os.patch.level" value="unknown" />
+
+          <property name="java.vm.specification.name" value="Java Virtual Machine Specification" />
+
+          <property name="user.dir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+
+          <property name="java.runtime.version" value="1.8.0_252-b09" />
+
+          <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment" />
+
+          <property name="basedir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+
+          <property name="java.endorsed.dirs" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/endorsed" />
+
+          <property name="os.arch" value="x86_64" />
+
+          <property name="java.io.tmpdir" value="/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/" />
+
+          <property name="ant.core.lib" value="/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar" />
+
+          <property name="line.separator" value="&#xa;" />
+
+          <property name="java.vm.specification.vendor" value="Oracle Corporation" />
+
+          <property name="os.name" value="Mac OS X" />
+
+          <property name="ant.home" value="/usr/local/Cellar/ant/1.10.8/libexec" />
+
+          <property name="build.dir" value="build" />
+
+          <property name="sun.jnu.encoding" value="UTF-8" />
+
+          <property name="java.library.path" value="/Users/ninjin/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:." />
+
+          <property name="java.specification.name" value="Java Platform API Specification" />
+
+          <property name="java.class.version" value="52.0" />
+
+          <property name="lib.dir" value="lib" />
+
+          <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers" />
+
+          <property name="os.version" value="10.16" />
+
+          <property name="ant.file" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build.xml" />
+
+          <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="user.home" value="/Users/ninjin" />
+
+          <property name="user.timezone" value="" />
+
+          <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob" />
+
+          <property name="java.specification.version" value="1.8" />
+
+          <property name="file.encoding" value="UTF-8" />
+
+          <property name="java.class.path" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/hamcrest-all-1.3.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/junit-4.13.2.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/log4j-1.2.17.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/jar/${ant.project.name}.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-launcher.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit4.jar" />
+
+          <property name="user.name" value="ninjin" />
+
+          <property name="report.dir" value="build/junitreport" />
+
+          <property name="java.vm.specification.version" value="1.8" />
+
+          <property name="java.home" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre" />
+
+          <property name="sun.java.command" value="org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner com.launchable.HelloWorldTest skipNonTests=false filtertrace=true haltOnError=false haltOnFailure=false formatter=org.apache.tools.ant.taskdefs.optional.junit.SummaryJUnitResultFormatter showoutput=false outputtoformatters=true logfailedtests=true threadid=0 logtestlistenerevents=false formatter=org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter,/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/junitreport/TEST-com.launchable.HelloWorldTest.xml crashfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junitvmwatcher7518065668325657626.properties propsfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junit1687636369704213518.properties" />
+
+          <property name="sun.arch.data.model" value="64" />
+
+          <property name="java.specification.vendor" value="Oracle Corporation" />
+
+          <property name="user.language" value="en" />
+
+          <property name="classes.dir" value="build/classes" />
+
+          <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit" />
+
+          <property name="java.vm.info" value="mixed mode" />
+
+          <property name="java.version" value="1.8.0_252" />
+
+          <property name="java.ext.dirs" value="/Users/ninjin/Library/Java/Extensions:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java" />
+
+          <property name="sun.boot.class.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/resources.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/rt.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/sunrsasign.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jsse.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jce.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/charsets.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jfr.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/classes" />
+
+          <property name="java.vendor" value="AdoptOpenJDK" />
+
+          <property name="file.separator" value="/" />
+
+          <property name="src.dir" value="src" />
+
+          <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/" />
+
+          <property name="sun.cpu.endian" value="little" />
+
+          <property name="sun.io.unicode.encoding" value="UnicodeBig" />
+
+          <property name="main-class" value="com.launchable.HelloWorld" />
+
+          <property name="ant.file.type" value="file" />
+
+          <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="jar.dir" value="build/jar" />
+
+          <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="sun.cpu.isalist" value="" />
+
+      </properties>
+
+      <testcase classname="com.launchable.HelloWorldTest" name="testWillAlwaysFail" time="0.006">
+          <failure message="An error message" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: An error message
+	at com.launchable.HelloWorldTest.testWillAlwaysFail(Unknown Source)
+</failure>
+
+      </testcase>
+
+      <testcase classname="com.launchable.HelloWorldTest" name="testNothing" time="0.0" />
+
+      <system-out><![CDATA[]]></system-out>
+
+      <system-err><![CDATA[]]></system-err>
+
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="MacBookKun.local" id="1" name="CacheTest" package="com.launchable.library" skipped="0" tests="1" time="0.039" timestamp="2021-04-28T10:36:32">
+      <properties>
+          <property name="ant.project.invoked-targets" value="junit" />
+
+          <property name="java.runtime.name" value="OpenJDK Runtime Environment" />
+
+          <property name="sun.boot.library.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib" />
+
+          <property name="java.vm.version" value="25.252-b09" />
+
+          <property name="ant.library.dir" value="/usr/local/Cellar/ant/1.10.8/libexec/lib" />
+
+          <property name="gopherProxySet" value="false" />
+
+          <property name="ant.version" value="Apache Ant(TM) version 1.10.8 compiled on May 10 2020" />
+
+          <property name="ant.java.version" value="1.8" />
+
+          <property name="java.vm.vendor" value="AdoptOpenJDK" />
+
+          <property name="java.vendor.url" value="http://java.oracle.com/" />
+
+          <property name="path.separator" value=":" />
+
+          <property name="java.vm.name" value="OpenJDK 64-Bit Server VM" />
+
+          <property name="file.encoding.pkg" value="sun.io" />
+
+          <property name="user.country" value="JP" />
+
+          <property name="sun.java.launcher" value="SUN_STANDARD" />
+
+          <property name="sun.os.patch.level" value="unknown" />
+
+          <property name="java.vm.specification.name" value="Java Virtual Machine Specification" />
+
+          <property name="user.dir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+
+          <property name="java.runtime.version" value="1.8.0_252-b09" />
+
+          <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment" />
+
+          <property name="basedir" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant" />
+
+          <property name="java.endorsed.dirs" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/endorsed" />
+
+          <property name="os.arch" value="x86_64" />
+
+          <property name="java.io.tmpdir" value="/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/" />
+
+          <property name="ant.core.lib" value="/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar" />
+
+          <property name="line.separator" value="&#xa;" />
+
+          <property name="java.vm.specification.vendor" value="Oracle Corporation" />
+
+          <property name="os.name" value="Mac OS X" />
+
+          <property name="ant.home" value="/usr/local/Cellar/ant/1.10.8/libexec" />
+
+          <property name="build.dir" value="build" />
+
+          <property name="sun.jnu.encoding" value="UTF-8" />
+
+          <property name="java.library.path" value="/Users/ninjin/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:." />
+
+          <property name="java.specification.name" value="Java Platform API Specification" />
+
+          <property name="java.class.version" value="52.0" />
+
+          <property name="lib.dir" value="lib" />
+
+          <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers" />
+
+          <property name="os.version" value="10.16" />
+
+          <property name="ant.file" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build.xml" />
+
+          <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="user.home" value="/Users/ninjin" />
+
+          <property name="user.timezone" value="" />
+
+          <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob" />
+
+          <property name="java.specification.version" value="1.8" />
+
+          <property name="file.encoding" value="UTF-8" />
+
+          <property name="java.class.path" value="/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/hamcrest-all-1.3.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/junit-4.13.2.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/lib/log4j-1.2.17.jar:/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/jar/${ant.project.name}.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-launcher.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit.jar:/usr/local/Cellar/ant/1.10.8/libexec/lib/ant-junit4.jar" />
+
+          <property name="user.name" value="ninjin" />
+
+          <property name="report.dir" value="build/junitreport" />
+
+          <property name="java.vm.specification.version" value="1.8" />
+
+          <property name="java.home" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre" />
+
+          <property name="sun.java.command" value="org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner com.launchable.library.CacheTest skipNonTests=false filtertrace=true haltOnError=false haltOnFailure=false formatter=org.apache.tools.ant.taskdefs.optional.junit.SummaryJUnitResultFormatter showoutput=false outputtoformatters=true logfailedtests=true threadid=0 logtestlistenerevents=false formatter=org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter,/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/build/junitreport/TEST-com.launchable.library.CacheTest.xml crashfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junitvmwatcher3186351552913495657.properties propsfile=/Users/ninjin/src/github.com/launchableinc/rocket-car-ant/junit1208074720031226095.properties" />
+
+          <property name="sun.arch.data.model" value="64" />
+
+          <property name="java.specification.vendor" value="Oracle Corporation" />
+
+          <property name="user.language" value="en" />
+
+          <property name="classes.dir" value="build/classes" />
+
+          <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit" />
+
+          <property name="java.vm.info" value="mixed mode" />
+
+          <property name="java.version" value="1.8.0_252" />
+
+          <property name="java.ext.dirs" value="/Users/ninjin/Library/Java/Extensions:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java" />
+
+          <property name="sun.boot.class.path" value="/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/resources.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/rt.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/sunrsasign.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jsse.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jce.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/charsets.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/lib/jfr.jar:/Users/ninjin/.sdkman/candidates/java/8.0.252.hs-adpt/jre/classes" />
+
+          <property name="java.vendor" value="AdoptOpenJDK" />
+
+          <property name="file.separator" value="/" />
+
+          <property name="src.dir" value="src" />
+
+          <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/" />
+
+          <property name="sun.cpu.endian" value="little" />
+
+          <property name="sun.io.unicode.encoding" value="UnicodeBig" />
+
+          <property name="main-class" value="com.launchable.HelloWorld" />
+
+          <property name="ant.file.type" value="file" />
+
+          <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="jar.dir" value="build/jar" />
+
+          <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16" />
+
+          <property name="sun.cpu.isalist" value="" />
+
+      </properties>
+
+      <testcase classname="com.launchable.library.CacheTest" name="testCache" time="0.001" />
+
+      <system-out><![CDATA[]]></system-out>
+
+      <system-err><![CDATA[]]></system-err>
+
+  </testsuite>
+</testsuites>

--- a/tests/data/ant/record_test_result.json
+++ b/tests/data/ant/record_test_result.json
@@ -1,0 +1,43 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "class", "name": "com.launchable.HelloWorldTest" },
+        { "type": "testcase", "name": "testWillAlwaysFail" }
+      ],
+      "duration": 0.006,
+      "status": 0,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2021-04-28T10:36:31",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "class", "name": "com.launchable.HelloWorldTest" },
+        { "type": "testcase", "name": "testNothing" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2021-04-28T10:36:31",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "class", "name": "com.launchable.library.CacheTest" },
+        { "type": "testcase", "name": "testCache" }
+      ],
+      "duration": 0.001,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2021-04-28T10:36:32",
+      "data": null
+    }
+  ]
+}

--- a/tests/data/ant/src/com/launchable/HelloWorld.java
+++ b/tests/data/ant/src/com/launchable/HelloWorld.java
@@ -1,0 +1,11 @@
+package com.launchable;
+import org.apache.log4j.Logger;
+import org.apache.log4j.BasicConfigurator;
+
+public class HelloWorld {
+    static Logger logger = Logger.getLogger(HelloWorld.class);
+    public static void main(String[] args) {
+        BasicConfigurator.configure();
+        logger.info("Hello World");
+    }
+}

--- a/tests/data/ant/src/com/launchable/HelloWorldTest.java
+++ b/tests/data/ant/src/com/launchable/HelloWorldTest.java
@@ -1,0 +1,18 @@
+package com.launchable;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class HelloWorldTest {
+
+    @Test
+    public void testNothing() {
+    }
+
+    @Test
+    public void testWillAlwaysFail() {
+        fail("An error message");
+    }
+
+}

--- a/tests/data/ant/src/com/launchable/library/Cache.java
+++ b/tests/data/ant/src/com/launchable/library/Cache.java
@@ -1,0 +1,19 @@
+package com.launchable.library;
+
+import java.util.HashMap;
+
+public class Cache<T> {
+  private HashMap<String, T> cache;
+
+  public Cache() {
+    super();
+    this.cache = new HashMap<>();
+  }
+  public void set(String key, T value) {
+    this.cache.put(key, value);
+  }
+  public T get(String key) {
+    return this.cache.get(key);
+  }
+}
+

--- a/tests/data/ant/src/com/launchable/library/CacheTest.java
+++ b/tests/data/ant/src/com/launchable/library/CacheTest.java
@@ -1,0 +1,16 @@
+package com.launchable.library;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CacheTest {
+  @Test
+  public void testCache() {
+    Cache<String> cache = new Cache<>();
+    String key = "key";
+    String val = "123";
+    cache.set(key, val);
+    assertEquals(val, cache.get(key));
+  }  
+}

--- a/tests/data/ant/subset_result.json
+++ b/tests/data/ant/subset_result.json
@@ -1,0 +1,8 @@
+{
+  "testPaths": [
+    [{ "type": "class", "name": "com.launchable.HelloWorldTest" }],
+    [{ "type": "class", "name": "com.launchable.library.CacheTest" }]
+  ],
+  "session": { "id": "16" },
+  "target": 0.1
+}

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -14,7 +14,7 @@ class AntTest(CliTestCase):
     @responses.activate
     def test_subset(self):
         result = self.cli('subset', '--target', '10%', '--session',
-                          self.session, 'ant', str(self.test_files_dir.joinpath('src').resolve()) + '**/*Test.java')
+                          self.session, 'ant', str(self.test_files_dir.joinpath('src').resolve()))
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from unittest import mock
+import responses  # type: ignore
+import json
+import gzip
+from tests.cli_test_case import CliTestCase
+from launchable.utils.http_client import get_base_url
+
+
+class AntTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath(
+        '../data/ant/').resolve()
+
+    @responses.activate
+    def test_subset(self):
+        result = self.cli('subset', '--target', '10%', '--session',
+                          self.session, 'ant', str(self.test_files_dir.joinpath('src').resolve()) + '**/*Test.java')
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(
+            responses.calls[0].request.body).decode())
+
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath('subset_result.json'))
+
+        self.assert_json_orderless_equal(expected, payload)
+
+    @ responses.activate
+    def test_record_test_maven(self):
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          'ant', str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(
+            b''.join(responses.calls[0].request.body)).decode())
+
+        def removeDate(data):
+            for e in data["events"]:
+                del e["created_at"]
+
+
+        expected = self.load_json_from_file(
+            self.test_files_dir.joinpath("record_test_result.json"))
+
+        removeDate(payload)
+        removeDate(expected)
+
+        self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
# Usage
## Subsetting
According to [this Ant tutorial](https://ant.apache.org/manual/tutorial-HelloWorldWithAnt.html), Ant (or old Java project?) put test files into an `src` directory instead of `src/test/java/...`. That is why I thought the plugin needs to support root path + glob like `src/**/*Test.java`.

```shell
launchable subset --build 123 ant 'src/**/*Test.java' > check-launchable.txt
ant junit
```

Users need to edit their `build.xml` to import the subset text file like below (complete `build.xml` is in https://github.com/launchableinc/rocket-car-ant).

```xml
   <target name="check-launchable">
      <available file="launchable-subset.txt" property="launchable"/>
    </target>

    <target name="junit" depends="jar,check-launchable">
        <mkdir dir="${report.dir}"/>
        <junit printsummary="yes">
            <classpath>
                <path refid="classpath"/>
                <path refid="application"/>
            </classpath>

            <formatter type="xml"/>

            <batchtest fork="yes" todir="${report.dir}">
              <fileset dir="${src.dir}" >
                <includesfile name="launchable-subset.txt" if="${launchable}" />
                <include name="**/*Test.java" unless="${launchable}" />
            </fileset>
            </batchtest>
        </junit>
    </target>
```

## Recording tests
```shell
launchable record tests --build 123 ant  build/junitreport/TESTS-TestSuites.xm
```
