### PR TITLE
[ENG-113] use os.path.relpath

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -185,7 +185,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             for b in glob.iglob(base):
                 for t in glob.iglob(join(b, pattern), recursive=True):
                     if path_builder:
-                        path = path_builder(t[len(b)+1:])
+                        path = path_builder(os.path.relpath(t, b))
                     if path:
                         self.test_paths.append(self.to_test_path(path))
 


### PR DESCRIPTION
to avoid operate path as an array

I checked used by https://github.com/launchableinc/examples/tree/master/rspec

## before 

```
$ launchable subset --target 50% --build mm rspec spec/
spec/odels/article_spec.rb
spec/odels/comment_spec.rb
spec/equests/articles_spec.rb
spec/equests/comments_spec.rb
```

## after 

```
$ launchable subset --target 50% --build mm rspec spec/
spec/models/article_spec.rb
spec/models/comment_spec.rb
spec/requests/articles_spec.rb
spec/requests/comments_spec.rb
```