### PR TITLE
[ENG-115] to check report file timestamp

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -103,10 +103,19 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         def junitxml_parse_func(self, f: JUnitXmlParseFunc):
             self._junitxml_parse_func = f
 
+        @property
+        def check_timestamp(self):
+            return self._check_timestamp
+
+        @check_timestamp.setter
+        def check_timestamp(self, enable: bool):
+            self._check_timestamp = enable
+
         def __init__(self):
             self.reports = []
             self.path_builder = CaseEvent.default_path_builder(base_path)
             self.junitxml_parse_func = None
+            self.check_timestamp = True
 
         def make_file_path_component(self, filepath) -> TestPathComponent:
             """Create a single TestPathComponent from the given file path"""
@@ -118,7 +127,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             ctime = datetime.datetime.fromtimestamp(
                 os.path.getctime(junit_report_file))
 
-            if ctime.timestamp() < record_start_at.timestamp():
+            if self.check_timestamp and ctime.timestamp() < record_start_at.timestamp():
                 format = "%Y-%m-%d %H:%M:%S"
                 logger.debug("skip: {} is old to report. start_record_at: {} file_created_at:{}".format(
                     junit_report_file, record_start_at.strftime(format), ctime.strftime(format)))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -22,6 +22,7 @@ from ..helper import find_or_create_session
 from http import HTTPStatus
 from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
+import datetime
 
 
 @click.group()
@@ -68,6 +69,12 @@ from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 def tests(context, base_path: str, session: Optional[str], build_name: Optional[str], debug: bool, post_chunk: int, flavor):
     session_id = find_or_create_session(context, session, build_name, flavor)
 
+    token, org, workspace = parse_token()
+    record_start_at = get_record_start_at(
+        token, org, workspace, build_name, session)
+
+    logger = Logger()
+
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class
 
@@ -108,7 +115,15 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             return {"type": "file", "name": filepath}
 
         def report(self, junit_report_file: str):
-            """Add one report file by its path name"""
+            ctime = datetime.datetime.fromtimestamp(
+                os.path.getctime(junit_report_file))
+
+            if ctime.timestamp() < record_start_at.timestamp():
+                format = "%Y-%m-%d %H:%M:%S"
+                logger.debug("skip: {} is old to report. start_record_at: {} file_created_at:{}".format(
+                    junit_report_file, record_start_at.strftime(format), ctime.strftime(format)))
+                return
+
             self.reports.append(junit_report_file)
 
         def scan(self, base, pattern):
@@ -121,9 +136,8 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                 self.report(t)
 
         def run(self):
-            token, org, workspace = parse_token()
-
             count = 0   # count number of test cases sent
+
             client = LaunchableClient(
                 token, test_runner=context.invoked_subcommand)
 
@@ -189,7 +203,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                         args.append(d)
                         yield d
 
-                    Logger().audit(AUDIT_LOG_FORMAT.format(
+                    logger.audit(AUDIT_LOG_FORMAT.format(
                         "post", "{}/events".format(session_id), headers, list(args)))
 
                 payload = (s.encode() for s in audit_log(payload))
@@ -238,3 +252,33 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                     "Looks like tests didn't run? If not, make sure the right files/directories are passed", 'yellow'))
 
     context.obj = RecordTests()
+
+
+def get_record_start_at(token: str, org: str, workspace: str, build_name: Optional[str], session: Optional[str]):
+    if session is None and build_name is None:
+        raise click.UsageError(
+            'Either --build or --session has to be specified')
+
+    if session:
+        _, _, build_name, _ = parse_session(session)
+
+    client = LaunchableClient(token)
+    headers = {
+        "Content-Type": "application/json",
+    }
+    path = "/intake/organizations/{}/workspaces/{}/builds/{}".format(
+        org, workspace, build_name)
+
+    Logger().audit(AUDIT_LOG_FORMAT.format(
+        "get", path, headers, None))
+
+    res = client.request("get", path, headers=headers)
+    if res.status_code == 404:
+        click.echo(click.style(
+            "Build {} was not found. Make sure to run `launchable record build --name {}` before `launchable record tests`".format(build_name, build_name), 'yellow'), err=True)
+    elif res.status_code != 200:
+        # to avoid stop report command
+        return datetime.datetime.now()
+
+    # e.g) "2021-04-01T09:35:47.934+00:00"
+    return datetime.datetime.strptime(res.json()["createdAt"], "%Y-%m-%dT%H:%M:%S.%f%z")

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -3,7 +3,7 @@ from os.path import join
 from pathlib import Path
 
 import click
-from junitparser import TestCase, TestSuite # type: ignore
+from junitparser import TestCase, TestSuite  # type: ignore
 
 from . import launchable
 from ..testpath import TestPath
@@ -55,7 +55,7 @@ def record_tests(client, workspace):
         return path
 
     client.path_builder = f
-
+    client.check_timestamp = False
     client.scan(base, '**/test.xml')
 
     client.run()

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -3,7 +3,8 @@ import json
 import os
 import unittest
 import types
-import responses # type: ignore
+import responses  # type: ignore
+import datetime
 
 import click.testing
 from click.testing import CliRunner
@@ -38,6 +39,8 @@ class CliTestCase(unittest.TestCase):
                       json={}, status=200)
         responses.add(responses.PATCH, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/close".format(get_base_url(), self.organization, self.workspace, self.build_name, self.session_id),
                       json={}, status=200)
+        responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/builds/{}".format(get_base_url(), self.organization, self.workspace, self.build_name),
+                      json={'createdAt': "2020-01-02T03:45:56.123+00:00", 'id': 123}, status=200)
 
     def tearDown(self):
         clean_session_files()

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import gzip
 import sys
 from tests.cli_test_case import CliTestCase
@@ -8,10 +8,13 @@ from tests.cli_test_case import CliTestCase
 class TestsTest(CliTestCase):
 
     @responses.activate
-    def test_filename_in_error_message(self):        
-        normal_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/normal.xml').resolve())
-        broken_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/broken.xml').resolve())
-        result = self.cli('record', 'tests', '--build', self.build_name, 'file', normal_xml, broken_xml)
+    def test_filename_in_error_message(self):
+        normal_xml = str(Path(__file__).parent.joinpath(
+            '../../data/broken_xml/normal.xml').resolve())
+        broken_xml = str(Path(__file__).parent.joinpath(
+            '../../data/broken_xml/broken.xml').resolve())
+        result = self.cli('record', 'tests', '--build',
+                          self.build_name, 'file', normal_xml, broken_xml)
 
         def remove_backslash(input: str) -> str:
             # Hack for Windowns. They containts double escaped backslash such as \\\\
@@ -21,7 +24,9 @@ class TestsTest(CliTestCase):
                 return input
 
         # making sure the offending file path name is being printed.
-        self.assertIn(remove_backslash(broken_xml), remove_backslash(result.output))
+        self.assertIn(remove_backslash(broken_xml),
+                      remove_backslash(result.output))
 
         # normal.xml
-        self.assertIn('open_class_user_test.rb', gzip.decompress(b''.join(responses.calls[1].request.body)).decode())
+        self.assertIn('open_class_user_test.rb', gzip.decompress(
+            b''.join(responses.calls[2].request.body)).decode())

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,8 +8,8 @@ class PluginTest(CliTestCase):
         Load plugins/foo.py as a plugin and execute its code
         """
         plugin_dir = Path(__file__).parent.joinpath('plugins').resolve()
-        result = self.cli('--plugins', str(plugin_dir), 'record', 'tests', '--session', 'dummy', 'foo', 'alpha', 'bravo', 'charlie')
+        result = self.cli('--plugins', str(plugin_dir), 'record', 'tests',
+                          '--session', '/intake/organizations/org/workspaces/work/builds/dummy/test_sessions/123', 'foo', 'alpha', 'bravo', 'charlie')
         self.assertTrue("foo:alpha" in result.stdout, result.stdout)
         self.assertTrue("foo:bravo" in result.stdout, result.stdout)
         self.assertTrue("foo:charlie" in result.stdout, result.stdout)
-

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -32,12 +32,11 @@ class AntTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         def removeDate(data):
             for e in data["events"]:
                 del e["created_at"]
-
 
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath("record_test_result.json"))

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 import itertools
@@ -44,7 +44,7 @@ Loading: 2 packages loaded
         self.assertEqual(read_session(self.build_name), self.session)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[1].request.body)).decode())
+            b''.join(responses.calls[2].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
@@ -70,12 +70,15 @@ Loading: 2 packages loaded
         self.assertEqual(result.exit_code, 0)
 
         record_payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[2].request.body)).decode())
+            b''.join(responses.calls[3].request.body)).decode())
 
-        record_test_paths = itertools.chain.from_iterable(e['testPath'] for e in record_payload['events'])
-        record_test_path_dict = { t['name'] : t for t in record_test_paths }
+        record_test_paths = itertools.chain.from_iterable(
+            e['testPath'] for e in record_payload['events'])
+        record_test_path_dict = {t['name']: t for t in record_test_paths}
 
         for test_paths in subset_payload['testPaths']:
             for subset_test_path in test_paths:
-                record_test_path = record_test_path_dict.get(subset_test_path['name'])
-                self.assert_json_orderless_equal(record_test_path, subset_test_path)
+                record_test_path = record_test_path_dict.get(
+                    subset_test_path['name'])
+                self.assert_json_orderless_equal(
+                    record_test_path, subset_test_path)

--- a/tests/test_runners/test_behave.py
+++ b/tests/test_runners/test_behave.py
@@ -32,7 +32,7 @@ class BehaveTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         for e in payload["events"]:
             del e["created_at"]

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from launchable.utils.session import read_session
@@ -30,7 +30,7 @@ class CTestTest(CliTestCase):
         self.assertEqual(read_session(self.build_name), self.session)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[1].request.body)).decode())
+            b''.join(responses.calls[2].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from unittest import mock
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from tests.cli_test_case import CliTestCase
@@ -19,7 +19,7 @@ class CypressTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
@@ -39,11 +39,11 @@ class CypressTest(CliTestCase):
             self.test_files_dir.joinpath('subset_result.json'))
         self.assert_json_orderless_equal(expected, payload)
 
-
     @responses.activate
     def test_empty_xml(self):
         # parse empty test report XML
         result = self.cli('record', 'tests',  '--session', self.session,
                           'cypress', str(self.test_files_dir) + "/empty.xml")
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("close", responses.calls[0].request.url, "No record request")
+        self.assertIn(
+            "close", responses.calls[1].request.url, "No record request")

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from launchable.utils.session import read_session
@@ -44,9 +44,10 @@ class GoTestTest(CliTestCase):
                           self.session, 'go-test', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
-        self.assertIn('events', responses.calls[0].request.url, 'call events API')
+        self.assertIn(
+            'events', responses.calls[1].request.url, 'call events API')
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
         # Remove timestamp because it depends on the machine clock
         for c in payload['events']:
             del c['created_at']
@@ -55,8 +56,8 @@ class GoTestTest(CliTestCase):
             self.test_files_dir.joinpath('record_test_result.json'))
         self.assert_json_orderless_equal(expected, payload)
 
-        self.assertIn('close', responses.calls[1].request.url, 'call close API')
-
+        self.assertIn(
+            'close', responses.calls[2].request.url, 'call close API')
 
     @responses.activate
     def test_record_tests_without_session(self):
@@ -66,9 +67,10 @@ class GoTestTest(CliTestCase):
 
         self.assertEqual(read_session(self.build_name), self.session)
 
-        self.assertIn('events', responses.calls[1].request.url, 'call events API')
+        self.assertIn(
+            'events', responses.calls[2].request.url, 'call events API')
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[1].request.body)).decode())
+            b''.join(responses.calls[2].request.body)).decode())
         for c in payload['events']:
             del c['created_at']
 
@@ -76,4 +78,5 @@ class GoTestTest(CliTestCase):
             self.test_files_dir.joinpath('record_test_result.json'))
         self.assert_json_orderless_equal(expected, payload)
 
-        self.assertIn('close', responses.calls[2].request.url, 'call close API')
+        self.assertIn(
+            'close', responses.calls[3].request.url, 'call close API')

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 from tests.cli_test_case import CliTestCase
@@ -34,7 +34,7 @@ class GoogleTestTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
@@ -48,7 +48,7 @@ class GoogleTestTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('fail/record_test_result.json'))
 

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -51,7 +51,7 @@ class GradleTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         expected = self.load_json_from_file(self.result_file_path)
         self.assert_json_orderless_equal(expected, payload)

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -46,7 +46,7 @@ class MavenTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         for e in payload["events"]:
             del e["created_at"]

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -20,26 +20,30 @@ class MinitestTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         expected = self.load_json_from_file(self.result_file_path)
         self.assert_json_orderless_equal(expected, payload)
 
     @responses.activate
     def test_record_test_minitest_chunked(self):
-        result = self.cli('record', 'tests',  '--session', self.session, '--post-chunk', 5, 'minitest', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          '--post-chunk', 5, 'minitest', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
         payload1 = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
-        expected1 = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result_chunk1.json'))
+            b''.join(responses.calls[1].request.body)).decode())
+        expected1 = self.load_json_from_file(
+            self.test_files_dir.joinpath('record_test_result_chunk1.json'))
 
         payload2 = json.loads(gzip.decompress(
-            b''.join(responses.calls[1].request.body)).decode())
-        expected2 = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result_chunk2.json'))
+            b''.join(responses.calls[2].request.body)).decode())
+        expected2 = self.load_json_from_file(
+            self.test_files_dir.joinpath('record_test_result_chunk2.json'))
 
         # concat 1st and 2nd request for unstable order
-        self.assert_json_orderless_equal(expected1['events'] + expected2['events'], payload1['events'] + payload2['events'])
+        self.assert_json_orderless_equal(
+            expected1['events'] + expected2['events'], payload1['events'] + payload2['events'])
 
     @responses.activate
     def test_subset(self):

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -32,7 +32,7 @@ class RobotTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
 
         for e in payload["events"]:
             del e["created_at"]

--- a/tests/test_runners/test_rspec.py
+++ b/tests/test_runners/test_rspec.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import responses # type: ignore
+import responses  # type: ignore
 import json
 import gzip
 import sys
@@ -12,9 +12,10 @@ class RspecTest(CliTestCase):
 
     @responses.activate
     def test_record_test_rspec(self):
-        result = self.cli('record', 'tests',  '--session', self.session, 'rspec', str(self.test_files_dir.joinpath("rspec.xml")))
+        result = self.cli('record', 'tests',  '--session', self.session,
+                          'rspec', str(self.test_files_dir.joinpath("rspec.xml")))
         self.assertEqual(result.exit_code, 0)
         payload = json.loads(gzip.decompress(
-            b''.join(responses.calls[0].request.body)).decode())
+            b''.join(responses.calls[1].request.body)).decode())
         expected = self.load_json_from_file(self.result_file_path)
         self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
In some environments, the report files have been staying. then the record tests command sends old test results to Launchable.
So we changed to check that timestamp of the report file is newer than the time of record build start at.