### PR TITLE
[ENG-115] add error handling to parse the time string

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -23,6 +23,7 @@ from http import HTTPStatus
 from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 import datetime
+from dateutil.parser import parse
 
 
 @click.group()
@@ -295,7 +296,7 @@ def get_record_start_at(token: str, org: str, workspace: str, build_name: Option
 def parse_launchable_timeformat(t: str) -> datetime.datetime:
     # e.g) "2021-04-01T09:35:47.934+00:00"
     try:
-        return datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return parse(t)
     except Exception as e:
         Logger().error(
             "parse time error {}. time: {}".format(str(e), t))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -292,11 +292,11 @@ def get_record_start_at(token: str, org: str, workspace: str, build_name: Option
     return parse_launchable_timeformat(res.json()["createdAt"])
 
 
-def parse_launchable_timeformat(t: str):
+def parse_launchable_timeformat(t: str) -> datetime.datetime:
     # e.g) "2021-04-01T09:35:47.934+00:00"
     try:
         return datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%f%z")
     except Exception as e:
         Logger().error(
             "parse time error {}. time: {}".format(str(e), t))
-        return datetime.datetime.now
+        return datetime.datetime.now()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -289,5 +289,14 @@ def get_record_start_at(token: str, org: str, workspace: str, build_name: Option
         # to avoid stop report command
         return datetime.datetime.now()
 
+    return parse_launchable_timeformat(res.json()["createdAt"])
+
+
+def parse_launchable_timeformat(t: str):
     # e.g) "2021-04-01T09:35:47.934+00:00"
-    return datetime.datetime.strptime(res.json()["createdAt"], "%Y-%m-%dT%H:%M:%S.%f%z")
+    try:
+        return datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%f%z")
+    except Exception as e:
+        Logger().error(
+            "parse time error {}. time: {}".format(str(e), t))
+        return datetime.datetime.now

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     setuptools
     more_itertools
     wmi;platform_system=='Windows'
+    python-dateutil
 python_requires = >=3.4
 
 [options.entry_points]

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -4,6 +4,7 @@ import gzip
 import sys
 from tests.cli_test_case import CliTestCase
 from launchable.commands.record.tests import parse_launchable_timeformat
+import datetime
 
 
 class TestsTest(CliTestCase):
@@ -35,9 +36,17 @@ class TestsTest(CliTestCase):
     def test_parse_launchable_timeformat(self):
         t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934
         t2 = "2021-05-24T18:29:04.285+00:00"  # 1621880944.285
+        t3 = "2021-05-32T26:29:04.285+00:00"  # invalid time format
 
         parse_launchable_time1 = parse_launchable_timeformat(t1)
         parse_launchable_time2 = parse_launchable_timeformat(t2)
 
         self.assertEqual(parse_launchable_time1.timestamp(), 1617269747.934)
         self.assertEqual(parse_launchable_time2.timestamp(), 1621880944.285)
+
+        now = datetime.datetime.now()
+        before = now + datetime.timedelta(seconds=-1)
+        after = now + datetime.timedelta(seconds=1)
+
+        self.assertTrue(before.timestamp() < parse_launchable_timeformat(
+            t3).timestamp() < after.timestamp())

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -3,6 +3,7 @@ import responses  # type: ignore
 import gzip
 import sys
 from tests.cli_test_case import CliTestCase
+from launchable.commands.record.tests import parse_launchable_time
 
 
 class TestsTest(CliTestCase):
@@ -30,3 +31,13 @@ class TestsTest(CliTestCase):
         # normal.xml
         self.assertIn('open_class_user_test.rb', gzip.decompress(
             b''.join(responses.calls[2].request.body)).decode())
+
+    def test_parse_launchable_time(self):
+        t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934
+        t2 = "2021-05-24T18:29:04.285+00:00"  # 1621880944.285
+
+        parse_launchable_time1 = parse_launchable_time(t1)
+        parse_launchable_time2 = parse_launchable_time(t2)
+
+        self.assertEqual(parse_launchable_time1.timestamp(), 1617269747.934)
+        self.assertEqual(parse_launchable_time2.timestamp(), 1621880944.285)

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -3,7 +3,7 @@ import responses  # type: ignore
 import gzip
 import sys
 from tests.cli_test_case import CliTestCase
-from launchable.commands.record.tests import parse_launchable_time
+from launchable.commands.record.tests import parse_launchable_timeformat
 
 
 class TestsTest(CliTestCase):
@@ -32,12 +32,12 @@ class TestsTest(CliTestCase):
         self.assertIn('open_class_user_test.rb', gzip.decompress(
             b''.join(responses.calls[2].request.body)).decode())
 
-    def test_parse_launchable_time(self):
+    def test_parse_launchable_timeformat(self):
         t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934
         t2 = "2021-05-24T18:29:04.285+00:00"  # 1621880944.285
 
-        parse_launchable_time1 = parse_launchable_time(t1)
-        parse_launchable_time2 = parse_launchable_time(t2)
+        parse_launchable_time1 = parse_launchable_timeformat(t1)
+        parse_launchable_time2 = parse_launchable_timeformat(t2)
 
         self.assertEqual(parse_launchable_time1.timestamp(), 1617269747.934)
         self.assertEqual(parse_launchable_time2.timestamp(), 1621880944.285)


### PR DESCRIPTION
the CLI should continue to report the results if the CLI can't parse the time string.
so I add an error handling when parsing the time string.