### PR TITLE
remove Literal

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -1,8 +1,8 @@
 import datetime
 import os
 import sys
-from typing import Callable, Dict, Literal
-from junitparser import Failure, Error, Skipped, TestCase, TestSuite # type: ignore
+from typing import Callable, Dict
+from junitparser import Failure, Error, Skipped, TestCase, TestSuite  # type: ignore
 from ...testpath import TestPath
 
 


### PR DESCRIPTION
in 3.7, need to use typing_extensions

> Python 3.7 stdlib has an older version of typing.py and won't be updated.

https://github.com/python/typing/issues/707

in 3.8, Literal was added in typing
https://docs.python.org/3/library/typing.html#typing.Literal

but we don't use Literal so I removed 

