### PR TITLE
ADB plugin doc

### DIFF
--- a/docs/test-runners/adb.md
+++ b/docs/test-runners/adb.md
@@ -1,0 +1,106 @@
+# ADB
+
+{% hint style="info" %}
+Hey there, did you land here from search? FYI, Launchable helps teams test faster, push more commits, and ship more often without sacrificing quality \([here's how](https://www.launchableinc.com/how-it-works)\). [Sign up](https://app.launchableinc.com/signup) for a free trial for your team, then read on to see how to add Launchable to your testing pipeline.
+{% endhint %}
+
+## Getting started
+
+First, follow the steps in the [Getting started](../getting-started.md) guide to install the Launchable CLI, set your API key, and verify your connection.
+
+Then return to this page to complete the three steps of implementation:
+
+1. Recording builds
+2. Recording test results
+3. Subsetting test execution
+
+## Recording builds
+
+Launchable selects tests based on the changes contained in a **build**. To send metadata about changes to Launchable, run `launchable record build` before you create a build in your CI script:
+
+```bash
+launchable record build --name <BUILD NAME> --source src=<PATH TO SOURCE>
+```
+
+* With the `--name` option, you assign a unique identifier to this build. You will use this value later when you request a subset and record test results. See [Choosing a value for `<BUILD NAME>`](../resources/build-names.md) for tips on choosing this value.
+* The `--source` option points to the local copy of the Git repository used to produce this build, such as `.` or `src`. See [Data privacy and protection](../security/data-privacy-and-protection.md) for more info.
+
+## Recording test results
+
+Currently ADB plugin don't have record results feature. Use [Gradle](./gradle#recording-builds) instead.
+
+## Subsetting tests
+
+Subsetting instructions differ depending on whether you plan to [shift tests left](../#shift-left) or [shift tests right](../#shift-right):
+
+### Shift left
+
+First, set up a new test execution job/step/pipeline to run earlier in your software development lifecyle.
+
+Then, to retrieve a subset of tests, first list all the tests you would normally run and pass that to `launchable subset`:
+
+```bash
+# '-e log true' option outputs test names without running
+adb shell am instrument \
+  -w \
+  -r \
+  -e log true \
+  -e debug false \
+  com.yourdomain.test/androidx.test.runner.AndroidJUnitRunner \
+  > test_list.txt
+cat test_list.txt | \
+  launchable subset \
+  --build <BUILD NAME> \
+  --target <TARGET> \
+  adb > launchable-subset.txt
+```
+
+* The `--build` should use the same `<BUILD NAME>` value that you used before in `launchable record build`.
+* The `--target` option should be a percentage; we suggest `20%` to start. This creates a subset of the most important tests that will run in 20% of the full execution time. As the model learns from your builds, the tests in the subset will become more and more relevant.
+
+This creates a file called `launchable-subset.txt` that you can pass into your command to run tests:
+
+```bash
+adb shell am instrument -w -e class $(cat launchable-subset.txt) com.yourdomain.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+Make sure to continue running the full test suite at some stage. Run `launchable record build` and `launchable record tests` for those runs to continually train the model.
+
+### Shift right
+
+The [shift right](../#shift-right) diagram suggests first splitting your existing test run into two parts:
+
+1. A subset of dynamically selected tests, and
+2. The rest of the tests
+
+To retrieve a subset of tests, first pass the full list of test candidates to `launchable subset`. For example:
+
+```bash
+adb shell am instrument \
+  -w \
+  -r \
+  -e log true \
+  -e debug false \
+  com.yourdomain.test/androidx.test.runner.AndroidJUnitRunner \
+  > test_list.txt
+cat test_list.txt | launchable subset \
+  --build <BUILD NAME> \
+  --target <TARGET> \
+  --rest launchable-remainder.txt
+  adb > launchable-subset.txt
+```
+
+* The `--build` should use the same `<BUILD NAME>` value that you used before in `launchable record build`.
+* The `--target` option should be a percentage; we suggest `20%` to start. This creates a subset of the most important tests that will run in 20% of the full execution time. As the model learns from your builds, the tests in the subset will become more and more relevant.
+* The `--rest` option writes all the other tests to a file so you can run them separately.
+
+This creates two files called `launchable-subset.txt` and `launchable-remainder.txt` that you can pass into your command to run tests in two stages:
+
+```bash
+adb shell am instrument -w -e class $(cat launchable-subset.txt) com.yourdomain.test/androidx.test.runner.AndroidJUnitRunner
+
+adb shell am instrument -w -e class $(cat launchable-remainder.txt) com.yourdomain.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+You can remove the second part after we've let you know that the model is sufficiently trained. Once you do this, make sure to continue running the full test suite at some stage. Run `launchable record build` and `launchable record tests` for those runs to continually train the model.
+

--- a/docs/test-runners/adb.md
+++ b/docs/test-runners/adb.md
@@ -27,7 +27,7 @@ launchable record build --name <BUILD NAME> --source src=<PATH TO SOURCE>
 
 ## Recording test results
 
-Currently ADB plugin don't have record results feature. Use [Gradle](./gradle#recording-builds) instead.
+Currently, the CLI doesn't have a `record tests` command for ADB. Use the [Gradle command](./gradle#recording-test-results) instead.
 
 ## Subsetting tests
 
@@ -103,4 +103,3 @@ adb shell am instrument -w -e class $(cat launchable-remainder.txt) com.yourdoma
 ```
 
 You can remove the second part after we've let you know that the model is sufficiently trained. Once you do this, make sure to continue running the full test suite at some stage. Run `launchable record build` and `launchable record tests` for those runs to continually train the model.
-


### PR DESCRIPTION
I added ADB plugin doc about #226. 

@awilkes We decided to release the first ADB plugin as a pre-release. So, I'd like to ask you about:

* Do we announce this release as "pre-release" in [the release notes](https://github.com/launchableinc/cli/releases)?
* I filled the "Recording test results" section with the link to the Gradle plugin. Please review and revise it.