### PR TITLE
Change the default log level to warning

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -42,12 +42,6 @@ from dateutil.parser import parse
     metavar='BUILD_NAME'
 )
 @click.option(
-    '--debug',
-    help='print request payload',
-    default=False,
-    is_flag=True,
-)
-@click.option(
     '--post-chunk',
     help='Post chunk',
     default=1000,
@@ -61,7 +55,7 @@ from dateutil.parser import parse
     multiple=True,
 )
 @click.pass_context
-def tests(context, base_path: str, session: Optional[str], build_name: Optional[str], debug: bool, post_chunk: int,
+def tests(context, base_path: str, session: Optional[str], build_name: Optional[str], post_chunk: int,
           flavor):
     session_id = find_or_create_session(context, session, build_name, flavor)
 
@@ -228,8 +222,6 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
 
             try:
                 tc = testcases(self.reports)
-                if debug:
-                    logger.debug(tc)
 
                 exceptions = []
                 for chunk in ichunked(tc, post_chunk):

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -31,7 +31,7 @@ class LaunchableClient:
 
         headers = self._headers(compress)
 
-        Logger().audit(AUDIT_LOG_FORMAT.format("post", url, headers, payload))
+        Logger().audit(AUDIT_LOG_FORMAT.format(method, url, headers, payload))
 
         data = _build_data(payload, compress)
 

--- a/launchable/utils/logger.py
+++ b/launchable/utils/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 
-LOG_LEVEL_DEFAULT = 100
+LOG_LEVEL_DEFAULT = logging.WARNING
 LOG_LEVEL_DEFAULT_STR = "DEFAULT"
 LOG_LEVEL_AUDIT = 25
 LOG_LEVEL_AUDIT_STR = "AUDIT"
@@ -9,7 +9,6 @@ LOG_LEVEL_AUDIT_STR = "AUDIT"
 AUDIT_LOG_FORMAT = "send request method:{} path:{} headers:{} args:{}"
 
 logging.addLevelName(LOG_LEVEL_AUDIT, "AUDIT")
-logging.addLevelName(LOG_LEVEL_DEFAULT, "DEFAULT")
 
 
 def get_log_level(level=str) -> int:

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -28,7 +28,7 @@ class LoggerTest(TestCase):
         l.info("info")
         l.warning("warn")
         l.debug("debug")
-        self.assertEqual(mock_err.getvalue(), "")
+        self.assertEqual(mock_err.getvalue(), "WARNING:launchable:warn\n")
 
     @patch("sys.stderr", new_callable=StringIO)
     def test_log_level_audit(self, mock_err):


### PR DESCRIPTION
The current default logging level is too high and even warnings and errors do not show up to stdout by default. I believe it is a common practice in CLI that shows logs the level above warning by default. For example, [the Python logging library](https://docs.python.org/ja/3/howto/logging.html) sets the default log level to the warning. 

Also, the `--debug` option contradicts the `--log-level` option and I believe a user should control it by `--log-level` option.