### PR TITLE
Set GitHub-Pr-Head-Sha header only when it exists

### DIFF
--- a/launchable/utils/authentication.py
+++ b/launchable/utils/authentication.py
@@ -21,15 +21,20 @@ def authentication_headers():
         return {'Authorization': 'Bearer {}'.format(token)}
 
     if os.getenv('GITHUB_ACTIONS'):
-        return {
+        headers = {
             'GitHub-Actions': os.environ['GITHUB_ACTIONS'],
             'GitHub-Run-Id': os.environ['GITHUB_RUN_ID'],
             'GitHub-Repository': os.environ['GITHUB_REPOSITORY'],
             'GitHub-Workflow': os.environ['GITHUB_WORKFLOW'],
             'GitHub-Run-Number': os.environ['GITHUB_RUN_NUMBER'],
             'GitHub-Event-Name': os.environ['GITHUB_EVENT_NAME'],
-            # GITHUB_PR_HEAD_SHA might not exist
-            'GitHub-Pr-Head-Sha': os.getenv('GITHUB_PR_HEAD_SHA'),
             'GitHub-Sha': os.environ['GITHUB_SHA'],
         }
+
+        # GITHUB_PR_HEAD_SHA might not exist
+        pr_head_sha = os.getenv('GITHUB_PR_HEAD_SHA')
+        if pr_head_sha:
+            headers['GitHub-Pr-Head-Sha'] = pr_head_sha
+
+        return headers
     return {}

--- a/tests/utils/test_authentication.py
+++ b/tests/utils/test_authentication.py
@@ -50,8 +50,8 @@ class AuthenticationTest(TestCase):
     @mock.patch.dict(os.environ,
                      {"GITHUB_ACTIONS": "true", "GITHUB_RUN_ID": "1", "GITHUB_REPOSITORY": "launchableinc/test",
                       "GITHUB_WORKFLOW": "build", "GITHUB_RUN_NUMBER": "1", "GITHUB_EVENT_NAME": "push",
-                      "GITHUB_SHA": "test"}, clear=True)
-    def test_authentication_headers_GitHub_Actions(self):
+                      "GITHUB_PR_HEAD_SHA": "test0", "GITHUB_SHA": "test1"}, clear=True)
+    def test_authentication_headers_GitHub_Actions_with_PR_head(self):
         header = authentication_headers()
         self.assertEqual(len(header), 8)
         self.assertEqual(header["GitHub-Actions"], "true")
@@ -60,7 +60,22 @@ class AuthenticationTest(TestCase):
         self.assertEqual(header["GitHub-Workflow"], "build")
         self.assertEqual(header["GitHub-Run-Number"], "1")
         self.assertEqual(header["GitHub-Event-Name"], "push")
-        self.assertIsNone(header["GitHub-Pr-Head-Sha"])
+        self.assertEqual(header["GitHub-Pr-Head-Sha"], "test0")
+        self.assertEqual(header["GitHub-Sha"], "test1")
+
+    @mock.patch.dict(os.environ,
+                     {"GITHUB_ACTIONS": "true", "GITHUB_RUN_ID": "1", "GITHUB_REPOSITORY": "launchableinc/test",
+                      "GITHUB_WORKFLOW": "build", "GITHUB_RUN_NUMBER": "1", "GITHUB_EVENT_NAME": "push",
+                      "GITHUB_SHA": "test"}, clear=True)
+    def test_authentication_headers_GitHub_Actions_without_PR_head(self):
+        header = authentication_headers()
+        self.assertEqual(len(header), 7)
+        self.assertEqual(header["GitHub-Actions"], "true")
+        self.assertEqual(header["GitHub-Run-Id"], "1")
+        self.assertEqual(header["GitHub-Repository"], "launchableinc/test")
+        self.assertEqual(header["GitHub-Workflow"], "build")
+        self.assertEqual(header["GitHub-Run-Number"], "1")
+        self.assertEqual(header["GitHub-Event-Name"], "push")
         self.assertEqual(header["GitHub-Sha"], "test")
 
     @mock.patch.dict(os.environ,


### PR DESCRIPTION
I've changed the authentication_headers method and set the `GitHub-Pr-Head-Sha` header only when it exists in the environment. Otherwise, the method sets an empty string to the `GitHub-Pr-Head-Sha` header and that could be confusing to the API. 