### PR TITLE
Scope a session to a Jenkins build if we are running in one.

### DIFF
--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -43,12 +43,9 @@ def _get_session_id() -> str:
         c = wmi.WMI()
         wql = "Associators of {{Win32_Process='{}'}} Where Resultclass = Win32_LogonSession Assocclass = Win32_SessionProcess".format(os.getpid())
         res = c.query(wql)
-        id = res[0].LogonId
+        return str(res[0].LogonId)
     else:
-        id = str(os.getsid(os.getpid()))
-
-
-    return id
+        return str(os.getsid(os.getpid()))
 
 
 def read_session(build_name: str) -> Optional[str]:


### PR DESCRIPTION
We just found out that Jenkins pipeline assigns a new Unix session for every process it launches.