### PR TITLE
fix the dependent version of more_itertools to higher than 7.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     requests
     junitparser>=2.0.0
     setuptools
-    more_itertools
+    more_itertools>=7.1.0
     wmi;platform_system=='Windows'
     python-dateutil
 python_requires = >=3.4


### PR DESCRIPTION
I got the following error on GitHub Actions when executing launchable cli.

> ImportError: cannot import name 'ichunked' from 'more_itertools' (/usr/lib/python3/dist-packages/more_itertools/__init__.py)
>  -- https://github.com/x-motemen/ghq/runs/2932241995?check_suite_focus=true

I upgraded `more_itertools` and resolved the problem.

I checked and found that the `ichunked` was introduced in version 7.1.0, so we need to specify a dependent version in higher versions.

ref. https://more-itertools.readthedocs.io/en/stable/versions.html#id13