### PR TITLE
Add no-submodules option to the record build command

### DIFF
--- a/docs/resources/cli-reference.md
+++ b/docs/resources/cli-reference.md
@@ -90,7 +90,13 @@ $ launchable record build [OPTIONS]
       <td style="text-align:left"><code>--max-days DAYS</code>
       </td>
       <td style="text-align:left">The maximum number of days to collect commits retroactively.</td>
-      <td style="text-align:left">No. Defaults to `30`</td>
+      <td style="text-align:left">No. Defaults to <code>30</code></td>
+    </tr>
+    <tr>
+      <td style="text-align:left"><code>--no-submodules</code>
+      </td>
+      <td style="text-align:left">Stop collecting build information from Git Submodules.</td>
+      <td style="text-align:left">No. Defaults to <code>False</code></td>
     </tr>
     <tr>
       <td style="text-align:left"><code>--source main=path/to/ws</code> (recommanded) or <code>--source path/to/ws</code>


### PR DESCRIPTION
One of our customers had trouble running the git submodule command due to their environmental problem. To circumvent the problem, I added a new `--no-submodules` option to the record build command to disable information collection from Git Submodules (and skip running the git submodule command internally).