### PR TITLE
Enclose Jar path including white space with double quotes

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -53,7 +53,7 @@ def exec_jar(source, max_days):
     proxy_option = _build_proxy_option(https_proxy) if https_proxy else ""
 
     os.system(
-        "{} {} -jar {} ingest:commit -endpoint {} -max-days {} {}"
+        "{} {} -jar \"{}\" ingest:commit -endpoint {} -max-days {} {}"
         .format(java, proxy_option, jar_file_path, "{}/intake/".format(base_url), max_days, source))
 
 


### PR DESCRIPTION
In our customer's environment, a path for `exe_deploy.jar` contained white space such as `c:\program files\...`. It causes a failure in `launchable record commit` command. To resolve it, I enclose the path with double-quotes. 