### PR TITLE
Contains test runner name to User Agent

### DIFF
--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -75,7 +75,8 @@ class LaunchableClient:
             h["Content-Encoding"] = "gzip"
 
         if self.test_runner != "":
-            h["launchable-test-runner"] = self.test_runner
+            h["User-Agent"] = h["User-Agent"] + \
+                " (TestRunner: {})".format(self.test_runner)
 
         return {**h, **authentication_headers()}
 

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -76,7 +76,7 @@ class LaunchableClient:
 
         if self.test_runner != "":
             h["User-Agent"] = h["User-Agent"] + \
-                " (TestRunner: {})".format(self.test_runner)
+                " (TestRunner {})".format(self.test_runner)
 
         return {**h, **authentication_headers()}
 

--- a/tests/utils/test_http_client.py
+++ b/tests/utils/test_http_client.py
@@ -23,6 +23,5 @@ class LaunchableClientTest(TestCase):
         cli = LaunchableClient("/test", test_runner="dummy")
         self.assertEqual(cli._headers(False), {
             'Content-Type': 'application/json',
-            "User-Agent": "Launchable/{} (Python {}, {})".format(__version__, platform.python_version(), platform.platform()),
-            "launchable-test-runner": "dummy"
+            "User-Agent": "Launchable/{} (Python {}, {}) (TestRunner: {})".format(__version__, platform.python_version(), platform.platform(), "dummy"),
         })

--- a/tests/utils/test_http_client.py
+++ b/tests/utils/test_http_client.py
@@ -23,5 +23,5 @@ class LaunchableClientTest(TestCase):
         cli = LaunchableClient("/test", test_runner="dummy")
         self.assertEqual(cli._headers(False), {
             'Content-Type': 'application/json',
-            "User-Agent": "Launchable/{} (Python {}, {}) (TestRunner: {})".format(__version__, platform.python_version(), platform.platform(), "dummy"),
+            "User-Agent": "Launchable/{} (Python {}, {}) (TestRunner {})".format(__version__, platform.python_version(), platform.platform(), "dummy"),
         })


### PR DESCRIPTION
Now, it is difficult to check that which test runner is used. This change helps us to resolve it.