### PR TITLE
Improve cli outputs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ types-click = "*"
 types-python-dateutil = "*"
 types-requests = "*"
 types-pkg_resources = "*"
+types-tabulate = "*"
 unittest-xml-reporting = "*"
 
 [packages]

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -6,6 +6,8 @@ from .commit import commit
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from ...utils.session import clean_session_files
+from tabulate import tabulate
+from ...utils.authentication import get_org_workspace
 
 
 @click.command()
@@ -124,3 +126,12 @@ def build(ctx, build_name, source, max_days, no_submodules,
             raise e
         else:
             print(e)
+
+    org, workspace = get_org_workspace()
+    click.echo(
+        "Launchable recorded build {} to workspace {}/{} with commits {} repositories\n".format(build_name, org, workspace, len(uniq_submodules)))
+
+    header = ["Name", "Path", "HEAD Commit"]
+    rows = [[name, repo_dist, hash]
+            for name, repo_dist, hash in uniq_submodules]
+    click.echo(tabulate(rows, header, tablefmt="github"))

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -90,22 +90,22 @@ def build(ctx, build_name, source, max_days, no_submodules,
                     submodule_stdout
                 )
                 if matched:
-                    hash = matched.group('hash')
+                    commit_hash = matched.group('hash')
                     name = matched.group('name')
-                    if hash and name:
+                    if commit_hash and name:
                         submodules.append(
-                            (repo_name + "/" + name, repo_dist, hash))
+                            (repo_name + "/" + name, repo_dist, commit_hash))
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.
-    uniq_submodules = {hash: (name, repo_dist, hash)
-                       for name, repo_dist, hash, in sources + submodules}.values()
+    uniq_submodules = {commit_hash: (name, repo_dist, commit_hash)
+                       for name, repo_dist, commit_hash, in sources + submodules}.values()
 
     try:
         commitHashes = [{
             'repositoryName': name,
-            'commitHash': hash
-        } for name, _, hash in uniq_submodules]
+            'commitHash': commit_hash
+        } for name, _, commit_hash in uniq_submodules]
 
         if not (commitHashes[0]['repositoryName']
                 and commitHashes[0]['commitHash']):
@@ -132,6 +132,6 @@ def build(ctx, build_name, source, max_days, no_submodules,
         "Launchable recorded build {} to workspace {}/{} with commits {} repositories\n".format(build_name, org, workspace, len(uniq_submodules)))
 
     header = ["Name", "Path", "HEAD Commit"]
-    rows = [[name, repo_dist, hash]
-            for name, repo_dist, hash in uniq_submodules]
+    rows = [[name, repo_dist, commit_hash]
+            for name, repo_dist, commit_hash in uniq_submodules]
     click.echo(tabulate(rows, header, tablefmt="github"))

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -129,7 +129,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
 
     org, workspace = get_org_workspace()
     click.echo(
-        "Launchable recorded build {} to workspace {}/{} with commits {} repositories\n".format(build_name, org, workspace, len(uniq_submodules)))
+        "Launchable recorded build {} to workspace {}/{} with commits from {} {}\n".format(build_name, org, workspace, len(uniq_submodules), ("repositories" if len(uniq_submodules) > 1 else "repository")))
 
     header = ["Name", "Path", "HEAD Commit"]
     rows = [[name, repo_dist, commit_hash]

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -25,16 +25,19 @@ from ...utils.session import clean_session_files
     metavar="REPO_NAME",
     multiple=True
 )
-@click.option('--max-days',
+@click.option(
+    '--max-days',
     help="the maximum number of days to collect commits retroactively",
     default=30
 )
-@click.option('--no-submodules',
+@click.option(
+    '--no-submodules',
     is_flag=True,
     help="stop collecting information from Git Submodules",
     default=False
 )
-@click.option('--no-commit-collection',
+@click.option(
+    '--no-commit-collection',
     is_flag=True,
     help="""do not collect commit data.
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -64,9 +64,10 @@ def build(ctx, build_name, source, max_days, no_submodules,
 
     sources = [(
         name,
+        repo_dist,
         subprocess.check_output(
             "git rev-parse HEAD".split(), cwd=repo_dist
-        ).decode().replace("\n", "")
+        ).decode().replace("\n", ""),
     ) for name, repo_dist in repos]
 
     submodules = []
@@ -87,18 +88,19 @@ def build(ctx, build_name, source, max_days, no_submodules,
                     hash = matched.group('hash')
                     name = matched.group('name')
                     if hash and name:
-                        submodules.append((repo_name + "/" + name, hash))
+                        submodules.append(
+                            (repo_name + "/" + name, repo_dist, hash))
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.
-    uniq_submodules = {hash: (name, hash)
-                       for name, hash in sources + submodules}.values()
+    uniq_submodules = {hash: (name, repo_dist, hash)
+                       for name, repo_dist, hash, in sources + submodules}.values()
 
     try:
         commitHashes = [{
             'repositoryName': name,
             'commitHash': hash
-        } for name, hash in uniq_submodules]
+        } for name, _, hash in uniq_submodules]
 
         if not (commitHashes[0]['repositoryName']
                 and commitHashes[0]['commitHash']):

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -218,7 +218,8 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                 return {"events": cs}, exs
 
             def send(payload: Dict[str, List]) -> None:
-                res = client.request("post", "{}/events".format(session_id), payload=payload, compress=True)
+                res = client.request(
+                    "post", "{}/events".format(session_id), payload=payload, compress=True)
 
                 if res.status_code == HTTPStatus.NOT_FOUND:
                     if session:
@@ -271,6 +272,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
 # if we fail to determine the timestamp of the build, we err on the side of collecting more test reports
 # than no test reports, so we use the 'epoch' timestamp
 INVALID_TIMESTAMP = datetime.datetime.fromtimestamp(0)
+
 
 def get_record_start_at(build_name: Optional[str], session: Optional[str]):
     """

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -293,7 +293,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             org, workspace = get_org_workspace()
 
             file_count = len(self.reports)
-            test_count, success_count, fail_count, duration,  = recorded_result()
+            test_count, success_count, fail_count, duration = recorded_result()
 
             click.echo(
                 "Launchable recorded tests for build {} (test session {}) to workspace {}/{} from {} files:\n".format(build_name, test_session_id, org, workspace, file_count))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -252,7 +252,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                         elif status == 1:
                             success_count += 1
                     if "duration" in tc:
-                        duration += tc["duration"]  # sec
+                        duration += float(tc["duration"])  # sec
 
                 return test_count, success_count, fail_count, duration/60   # sec to min
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -369,7 +369,7 @@ def get_session_and_record_start_at_from_subsetting_id(subsetting_id):
 
     res = LaunchableClient().request("get", subsetting_id)
     if res.status_code != 200:
-        raise click.echo(click.style("Unable to get subset information from subset id {}".format(
+        raise click.UsageError(click.style("Unable to get subset information from subset id {}".format(
             subsetting_id), 'yellow'), err=True)
 
     build_number = res.json()["build"]["buildNumber"]

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -260,7 +260,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             if count == 0:
                 if len(self.skipped_reports) != 0:
                     click.echo(click.style(
-                        "{} test reports were skipped because they were created before `launchable record build`.\nMake sure to run test after `launchable record build`.".format(len(self.skip_reports)), 'yellow'))
+                        "{} test reports were skipped because they were created before `launchable record build`.\nMake sure to run test after `launchable record build`.".format(len(self.skipped_reports)), 'yellow'))
                 else:
                     click.echo(click.style(
                         "Looks like tests didn't run? If not, make sure the right files/directories are passed", 'yellow'))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -289,8 +289,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                         "Looks like tests didn't run? If not, make sure the right files/directories are passed", 'yellow'))
                     return
 
-            build_name, test_session_id = get_build_and_test_session_id_from_session_id(
-                session_id)
+            build_name, test_session_id = parse_session(session_id)
             org, workspace = get_org_workspace()
 
             file_count = len(self.reports)
@@ -381,13 +380,3 @@ def get_session_and_record_start_at_from_subsetting_id(subsetting_id):
         "session": "builds/{}/test_sessions/{}".format(build_number, test_session_id),
         "start_at": parse_launchable_timeformat(created_at)
     }
-
-
-def get_build_and_test_session_id_from_session_id(session_id: str) -> (str, str):
-    # builds/<build name>/test_sessions/<test session id>
-    s = session_id.split("/")
-    if len(s) != 4:
-        raise click.UsageError(
-            'Invalid session_id. like `builds/:build_name/test_sessions/:test_session_id` but got {}'.format(session_id))
-
-    return s[1], s[3]

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -282,7 +282,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             if count == 0:
                 if len(self.skipped_reports) != 0:
                     click.echo(click.style(
-                        "{} test reports were skipped because they were created before `launchable record build`.\nMake sure to run test after `launchable record build`.".format(len(self.skipped_reports)), 'yellow'))
+                        "{} test reports were skipped because they were created before `launchable record build`.\nMake sure to run tests after `launchable record build`.".format(len(self.skipped_reports)), 'yellow'))
                     return
                 else:
                     click.echo(click.style(

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -302,7 +302,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                       "Test failed", "Total duration(min)"]
 
             rows = [[file_count, test_count,
-                     success_count, fail_count, duration]]
+                     success_count, fail_count, "{:0.4f}".format(duration)]]
             click.echo(tabulate(rows, header, tablefmt="github"))
 
     context.obj = RecordTests()

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -1,3 +1,5 @@
+from launchable.utils.authentication import get_org_workspace
+from launchable.utils.session import parse_session
 import click
 import os
 import sys
@@ -11,6 +13,7 @@ from ..testpath import TestPath
 from .helper import find_or_create_session
 from ..utils.click import KeyValueType
 from .test_path_writer import TestPathWriter
+from tabulate import tabulate
 # TODO: rename files and function accordingly once the PR landscape
 
 
@@ -197,6 +200,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             # When Error occurs, return the test name as it is passed.
             output = self.test_paths
             rests = []
+            summary = {}
             subset_id = ""
 
             if not session_id:
@@ -219,6 +223,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     output = res.json()["testPaths"]
                     rests = res.json()["rest"]
                     subset_id = res.json()["subsettingId"]
+                    summary = res.json()["summary"]
 
                 except Exception as e:
                     if os.getenv(REPORT_ERROR_KEY):
@@ -246,5 +251,25 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     self.write_file(rest, rests)
 
                 self.print(output)
+
+            build_name, test_session_id = parse_session(session_id)
+            org, workspace = get_org_workspace()
+
+            header = ["", "Candidates",
+                      "Estimated duration (%)", "Estimated duration (min)"]
+            rows = [
+                ["Subset", len(output), summary["subset"]["rate"],
+                 summary["subset"]["duration"]],
+                ["Remainder", len(rests), summary["rest"]
+                 ["rate"], summary["rest"]["duration"]],
+                [],
+                ["Total", len(output) + len(rests), summary["subset"]["rate"] + summary["rest"]
+                 ["rate"], summary["subset"]["duration"] + summary["rest"]["duration"]],
+            ]
+
+            click.echo(
+                "Launchable created subset {} for build {} (test session {}) to workspace {}/{}\n".format(subset_id, build_name, test_session_id, org, workspace), err=True)
+
+            click.echo(tabulate(rows, header, tablefmt="github"), err=True)
 
     context.obj = Optimize()

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -202,6 +202,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             rests = []
             summary = {}
             subset_id = ""
+            is_brainless = False
 
             if not session_id:
                 # Session ID in --session is missing. It might be caused by Launchable API errors.
@@ -224,6 +225,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                     rests = res.json()["rest"]
                     subset_id = res.json()["subsettingId"]
                     summary = res.json()["summary"]
+                    is_brainless = res.json()["isBrainless"]
 
                 except Exception as e:
                     if os.getenv(REPORT_ERROR_KEY):
@@ -266,6 +268,10 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                 ["Total", len(output) + len(rests), summary["subset"]["rate"] + summary["rest"]
                  ["rate"], summary["subset"]["duration"] + summary["rest"]["duration"]],
             ]
+
+            if is_brainless:
+                click.echo(
+                    "INFO: Your model is currently training", err=True)
 
             click.echo(
                 "Launchable created subset {} for build {} (test session {}) to workspace {}/{}\n".format(subset_id, build_name, test_session_id, org, workspace), err=True)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -271,10 +271,10 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
 
             if is_brainless:
                 click.echo(
-                    "INFO: Your model is currently training", err=True)
+                    "Your model is currently in training", err=True)
 
             click.echo(
-                "Launchable created subset {} for build {} (test session {}) to workspace {}/{}\n".format(subset_id, build_name, test_session_id, org, workspace), err=True)
+                "Launchable created subset {} for build {} (test session {}) in workspace {}/{}\n".format(subset_id, build_name, test_session_id, org, workspace), err=True)
 
             click.echo(tabulate(rows, header, tablefmt="github"), err=True)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     more_itertools>=7.1.0
     wmi;platform_system=='Windows'
     python-dateutil
+    tabulate
 python_requires = >=3.4
 
 [options.entry_points]

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -23,7 +23,8 @@ class MinitestTest(CliTestCase):
                           self.session, 'minitest', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        payload = json.loads(gzip.decompress(
+            responses.calls[1].request.body).decode())
 
         expected = self.load_json_from_file(self.result_file_path)
         self.assert_json_orderless_equal(expected, payload)
@@ -35,11 +36,13 @@ class MinitestTest(CliTestCase):
                           '--post-chunk', 5, 'minitest', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
-        payload1 = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        payload1 = json.loads(gzip.decompress(
+            responses.calls[1].request.body).decode())
         expected1 = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result_chunk1.json'))
 
-        payload2 = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
+        payload2 = json.loads(gzip.decompress(
+            responses.calls[2].request.body).decode())
         expected2 = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result_chunk2.json'))
 
@@ -52,8 +55,16 @@ class MinitestTest(CliTestCase):
     @ignore_warnings
     def test_subset(self):
         test_path = Path("test", "example_test.rb")
-        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
-                          json={'testPaths': [[{'name': str(test_path)}]], 'rest': [], 'subsettingId': 123}, status=200)
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace), json={
+            'testPaths': [[{'name': str(test_path)}]],
+            'rest': [],
+            'subsettingId': 123,
+            'summary': {
+                'subset': {'duration': 10, 'candidates': 1, 'rate': 100},
+                'rest': {'duration': 0, 'candidates': 0, 'rate': 0}
+            },
+            "isBrainless": False,
+        }, status=200)
 
         result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir),
                           'minitest', str(self.test_files_dir) + "/test/**/*.rb")
@@ -78,8 +89,16 @@ class MinitestTest(CliTestCase):
     @ignore_warnings
     def test_subset_split(self):
         test_path = Path("test", "example_test.rb")
-        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
-                          json={'testPaths': [[{'name': str(test_path)}]], 'rest': [], 'subsettingId': 123}, status=200)
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace), json={
+            'testPaths': [[{'name': str(test_path)}]],
+            'rest': [],
+            'subsettingId': 123,
+            'summary': {
+                'subset': {'duration': 10, 'candidates': 1, 'rate': 100},
+                'rest': {'duration': 0, 'candidates': 0, 'rate': 0}
+            },
+            "isBrainless": False,
+        }, status=200)
 
         result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir), '--split',
                           'minitest', str(self.test_files_dir) + "/test/**/*.rb")

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -22,8 +22,10 @@ class NUnitTest(CliTestCase):
                                   {"type": "Assembly", "name": "calc.dll"},
                                   {"type": "TestSuite", "name": "ParameterizedTests"},
                                   {"type": "TestFixture", "name": "MyTests"},
-                                  {"type": "ParameterizedMethod", "name": "DivideTest"},
-                                  {"type": "TestCase", "name": "DivideTest(12,3)"}
+                                  {"type": "ParameterizedMethod",
+                                      "name": "DivideTest"},
+                                  {"type": "TestCase",
+                                      "name": "DivideTest(12,3)"}
                               ],
                               [
                                   {"type": "Assembly", "name": "calc.dll"},
@@ -33,7 +35,11 @@ class NUnitTest(CliTestCase):
                               ]
                           ],
             'rest': [],
-            'subsettingId': 123
+            'subsettingId': 123,
+            'summary': {
+                'subset': {'duration': 15, 'candidates': 2, 'rate': 100},
+                'rest': {'duration': 0, 'candidates': 0, 'rate': 0}
+                          },
         }, status=200)
 
         result = self.cli('subset', '--target', '10%', '--session', self.session,
@@ -76,7 +82,11 @@ class NUnitTest(CliTestCase):
                 {"type": "TestFixture", "name": "Tests1"},
                 {"type": "TestCase", "name": "Test1"}
             ]],
-            'subsettingId': 456
+            'subsettingId': 456,
+            'summary': {
+                'subset': {'duration': 8, 'candidates': 1, 'rate': 50},
+                'rest': {'duration': 7, 'candidates': 1, 'rate': 50}
+                              },
         }, status=200)
 
         rest = tempfile.NamedTemporaryFile(delete=False)
@@ -100,7 +110,8 @@ class NUnitTest(CliTestCase):
                           'nunit', str(self.test_files_dir) + "/output-linux.xml")
         self.assertEqual(result.exit_code, 0)
 
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        payload = json.loads(gzip.decompress(
+            responses.calls[1].request.body).decode())
 
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath("record_test_result.json"))
@@ -114,7 +125,8 @@ class NUnitTest(CliTestCase):
                           'nunit', str(self.test_files_dir) + "/output-windows.xml")
         self.assertEqual(result.exit_code, 0)
 
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        payload = json.loads(gzip.decompress(
+            responses.calls[1].request.body).decode())
 
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath("record_test_result.json"))


### PR DESCRIPTION
I changed some outputs to understand easily 

### record build

```
$ launchable record build --name cli
Processed 22 commits
Launchable recorded build cli to workspace launchableinc/mothership with commits 1 repositories

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 4d6098b73d1f848b2b5f2b3ff6a0cd270c757ed4 |
```

## subset

```
$ find -f tests/**/test_*.py | launchable subset --build cli --confidence 80% file  > subset.txt
Launchable created subset 1374 for build cli (test session 300) to workspace launchableinc/cli

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |           29 |                  59.3561 |                  0.0344167 |
| Remainder |            2 |                  40.6439 |                  0.0235667 |
|           |              |                          |                            |
| Total     |           31 |                 100      |                  0.0579833 |
```

if the model hasn't promoted yet, print notice message

```
$ find -f tests/**/test_*.py  | launchable subset --build cli --target 50% file  > subset.txt
NOTICE: Your model is currently training
Launchable created subset 1378 for build cli (test session 303) to workspace launchableinc/mothership

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |           15 |                  48.3871 |                0.00025     |
| Remainder |           16 |                  51.6129 |                0.000266667 |
|           |              |                          |                            |
| Total     |           31 |                 100      |                0.000516667 |
```

## record tests

```
$ launchable record tests --build cli file ./test-results/*.xml
Launchable recorded tests for build cli (test session 303) to workspace launchableinc/cli from 29 files:

|   File found |   Tests found |   Test passed |   Test failed |   Total duration(min) |
|--------------|---------------|---------------|---------------|-----------------------|
|           29 |            80 |            80 |             0 |                0.0515 |
```