### PR TITLE
Close the hint style

### DIFF
--- a/docs/resources/integrations/googletest.md
+++ b/docs/resources/integrations/googletest.md
@@ -22,8 +22,8 @@ launchable record tests --build <BUILD NAME> googletest ./report
 ```
 
 {% hint style="warning" %}
-
 You might need to take extra steps to make sure that `launchable record tests` always runs even if the build fails. See [Always record tests](../../sending-data-to-launchable/ensuring-record-tests-always-runs.md).
+{% endhint %}
 
 ## Subsetting your test runs
 


### PR DESCRIPTION
The document is broken because it's not closed.