### PR TITLE
Guess the base path for relativizing test file paths 

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -3,7 +3,7 @@ import os
 import sys
 from typing import Callable, Dict
 from junitparser import Failure, Error, Skipped, TestCase, TestSuite  # type: ignore
-from ...testpath import TestPath
+from ...testpath import TestPath, FilePathNormalizer
 
 
 class CaseEvent:
@@ -17,7 +17,7 @@ class CaseEvent:
     TestPathBuilder = Callable[[TestCase, TestSuite, str], TestPath]
 
     @staticmethod
-    def default_path_builder(base_path) -> TestPathBuilder:
+    def default_path_builder(file_path_normalizer: FilePathNormalizer) -> TestPathBuilder:
         """
         Obtains a default TestPathBuilder that uses a base directory to relativize the file name
         """
@@ -27,7 +27,7 @@ class CaseEvent:
             filepath = case._elem.attrib.get(
                 "file") or suite._elem.attrib.get("filepath")
             if filepath:
-                filepath = os.path.relpath(filepath, start=base_path)
+                filepath = file_path_normalizer.relativize(filepath)
 
             test_path = []
             if filepath:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -7,7 +7,7 @@ from typing import Callable, Union, Optional
 from ..utils.click import PERCENTAGE, DURATION
 from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.http_client import LaunchableClient
-from ..testpath import TestPath
+from ..testpath import TestPath, FilePathNormalizer
 from .helper import find_or_create_session
 from ..utils.click import KeyValueType
 from .test_path_writer import TestPathWriter
@@ -72,10 +72,27 @@ from .test_path_writer import TestPathWriter
     help='split',
     is_flag=True
 )
+@click.option(
+    "--no_base_path_inference",
+    "no_base_path_inference",
+    help="""Do not guess the base path to relativize the test file paths.
+
+    By default, if the test file paths are absolute file paths, it automatically
+    guesses the repository root directory and relativize the paths. With this
+    option, the command doesn't do this guess work.
+
+    If --base_path is specified, the absolute file paths are relativized to the
+    specified path irrelevant to this option. Use it if the guessed base path is
+    incorrect.
+    """,
+    is_flag=True
+)
 @click.pass_context
 def subset(context, target, session: Optional[str], base_path: Optional[str], build_name: Optional[str], rest: str,
-           duration, flavor, confidence, split):
+           duration, flavor, confidence, split, no_base_path_inference: bool):
     session_id = find_or_create_session(context, session, build_name, flavor)
+    file_path_normalizer = FilePathNormalizer(
+        base_path, no_base_path_inference=no_base_path_inference)
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class
@@ -94,8 +111,8 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
 
         def test_path(self, path: TestPathLike):
             def rel_base_path(path):
-                if isinstance(path, str) and base_path:
-                    return normpath(relpath(path, start=base_path))
+                if isinstance(path, str):
+                    return file_path_normalizer.relativize(path)
                 else:
                     return path
 
@@ -151,12 +168,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                 # default implementation of path_builder creates a file name relative to `source` so as not
                 # to be affected by the path
                 def default_path_builder(file_name):
-                    file_name = join(base, file_name)
-                    if base_path:
-                        # relativize against `base_path` to make the path name portable
-                        file_name = normpath(
-                            relpath(file_name, start=base_path))
-                    return file_name
+                    return file_path_normalizer.relativize(join(base, file_name))
 
                 path_builder = default_path_builder
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -2,6 +2,7 @@ import click
 import os
 import sys
 from os.path import join, relpath, normpath
+import pathlib
 import glob
 from typing import Callable, Union, Optional
 from ..utils.click import PERCENTAGE, DURATION
@@ -112,7 +113,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
         def test_path(self, path: TestPathLike):
             def rel_base_path(path):
                 if isinstance(path, str):
-                    return file_path_normalizer.relativize(path)
+                    return pathlib.Path(file_path_normalizer.relativize(path)).as_posix()
                 else:
                     return path
 
@@ -168,7 +169,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                 # default implementation of path_builder creates a file name relative to `source` so as not
                 # to be affected by the path
                 def default_path_builder(file_name):
-                    return file_path_normalizer.relativize(join(base, file_name))
+                    return pathlib.Path(file_path_normalizer.relativize(join(base, file_name))).as_posix()
 
                 path_builder = default_path_builder
 

--- a/launchable/testpath.py
+++ b/launchable/testpath.py
@@ -1,4 +1,8 @@
-from typing import Dict, List
+import os.path
+import pathlib
+import subprocess
+import sys
+from typing import Dict, List, Optional
 
 # Path component is a node in a tree.
 # It's the equivalent of a short file/directory name in a file system.
@@ -8,3 +12,61 @@ TestPathComponent = Dict[str, str]
 # TestPath is a full path to a node in a tree from the root
 # It's the equivalent of an absolute file name in a file system
 TestPath = List[TestPathComponent]
+
+
+class FilePathNormalizer:
+    """Normalize file paths based on the Git repository root
+
+    Some test runners output absolute file paths. This is not preferrable when
+    making statistical data on tests as the absolute paths can vary per machine
+    or per run. FilePathNormalizer guesses the relative paths based on the Git
+    repository root.
+    """
+    def __init__(self,
+                 base_path: Optional[str] = None,
+                 no_base_path_inference: bool = False):
+        self._base_path = base_path
+        self._no_base_path_inference = no_base_path_inference
+        self._inferred_base_path = None  # type: Optional[str]
+
+    def relativize(self, p: str) -> str:
+        return str(self._relativize(pathlib.Path(os.path.normpath(p))))
+
+    def _relativize(self, p: pathlib.Path) -> pathlib.Path:
+        if not p.is_absolute():
+            return p
+
+        if self._base_path:
+            return p.relative_to(self._base_path)
+
+        if self._no_base_path_inference:
+            return p
+
+        if not self._inferred_base_path:
+            self._inferred_base_path = self._auto_infer_base_path(p)
+
+        if self._inferred_base_path:
+            return p.relative_to(self._inferred_base_path)
+
+        return p
+
+    def _auto_infer_base_path(self, p: pathlib.Path) -> Optional[str]:
+        p = p.parent
+        while p != p.root and not p.exists():
+            p = p.parent
+        try:
+            toplevel = subprocess.check_output(
+                ['git', 'rev-parse', '--show-superproject-working-tree'],
+                cwd=str(p),
+                stderr=subprocess.DEVNULL,
+                universal_newlines=True).strip()
+            if toplevel:
+                return toplevel
+            return subprocess.check_output(
+                ['git', 'rev-parse', '--show-toplevel'],
+                cwd=str(p),
+                stderr=subprocess.DEVNULL,
+                universal_newlines=True).strip()
+        except subprocess.CalledProcessError as e:
+            # Cannot infer the Git repo. Continue with the abs path...
+            return None

--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -43,9 +43,10 @@ class TestFilePathNormalizer(unittest.TestCase):
         self.assertEqual(relpath, n.relativize(relpath))
         self.assertEqual(relpath, n.relativize(abspath))
 
-    @unittest.skipIf(
-            sys.platform.startswith("win"),
-            "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed.")
+    @unittest.skipIf(sys.platform.startswith(
+        "win"
+    ), "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed."
+                     )
     def test_inference_git(self):
         with tempfile.TemporaryDirectory() as tempdirname:
             temppath = pathlib.PurePath(tempdirname)
@@ -58,9 +59,10 @@ class TestFilePathNormalizer(unittest.TestCase):
             n = FilePathNormalizer()
             self.assertEqual(relpath, n.relativize(abspath))
 
-    @unittest.skipIf(
-            sys.platform.startswith("win"),
-            "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed. Also when this runs on Windows, GIT_AUTHOR_NAME etc. is ignored and fails.")
+    @unittest.skipIf(sys.platform.startswith(
+        "win"
+    ), "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed. Also when this runs on Windows, GIT_AUTHOR_NAME etc. is ignored and fails."
+                     )
     def test_inference_git_submodule(self):
         with tempfile.TemporaryDirectory() as tempdirname:
             temppath = pathlib.PurePath(tempdirname)

--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -1,0 +1,96 @@
+from launchable.testpath import FilePathNormalizer
+
+import subprocess
+import tempfile
+import unittest
+import pathlib
+
+
+class TestFilePathNormalizer(unittest.TestCase):
+    def test_relative_path(self):
+        n = FilePathNormalizer()
+        self.assertEqual('some/relative/path',
+                         n.relativize('some/relative/path'))
+
+    def test_base_path(self):
+        n = FilePathNormalizer(base_path='/some')
+        self.assertEqual('relative/path', n.relativize('relative/path'))
+        self.assertEqual('absolute/path', n.relativize('/some/absolute/path'))
+
+    def test_normalize_path(self):
+        n = FilePathNormalizer()
+        self.assertEqual('some/relative/path',
+                         n.relativize('some/relative/omit/../path'))
+
+    def test_no_base_path_inference(self):
+        n = FilePathNormalizer(no_base_path_inference=True)
+        self.assertEqual('some/relative/path',
+                         n.relativize('some/relative/path'))
+        self.assertEqual('/some/absolute/path',
+                         n.relativize('/some/absolute/path'))
+
+        n = FilePathNormalizer(base_path='/some', no_base_path_inference=True)
+        self.assertEqual('relative/path', n.relativize('relative/path'))
+        self.assertEqual('absolute/path', n.relativize('/some/absolute/path'))
+
+    def test_inference_git(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            temppath = pathlib.PurePath(tempdirname)
+            self._run_command(
+                ['git', 'init',
+                 str(temppath.joinpath("gitrepo"))])
+
+            n = FilePathNormalizer()
+            self.assertEqual(
+                'some/relative/path',
+                n.relativize(
+                    str(temppath.joinpath('gitrepo', 'some/relative/path'))))
+
+    def test_inference_git_submodule(self):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            temppath = pathlib.PurePath(tempdirname)
+            self._run_command(
+                ['git', 'init',
+                 str(temppath.joinpath("submod"))])
+            self._run_command(
+                ['git', 'commit', '--allow-empty', '--message', 'test commit'],
+                cwd=str(temppath.joinpath("submod")))
+
+            self._run_command(
+                ['git', 'init',
+                 str(temppath.joinpath("gitrepo"))])
+            self._run_command([
+                'git', 'submodule', 'add',
+                str(temppath.joinpath("submod")), 'submod'
+            ],
+                              cwd=str(temppath.joinpath("gitrepo")))
+
+            n = FilePathNormalizer()
+            self.assertEqual(
+                'submod/some/relative/path',
+                n.relativize(
+                    str(
+                        temppath.joinpath('gitrepo',
+                                          'submod/some/relative/path'))))
+
+    def _run_command(self, args, cwd=None):
+        # Use check_output here to capture stderr for a better error message.
+        try:
+            subprocess.check_output(args,
+                                    cwd=cwd,
+                                    stderr=subprocess.PIPE,
+                                    universal_newlines=True,
+                                    env={
+                                        "GIT_AUTHOR_NAME":
+                                        "Test User <user@example.com>",
+                                        "GIT_COMMITTER_NAME":
+                                        "Test User <user@example.com>",
+                                    })
+        except subprocess.CalledProcessError as e:
+            self.fail(
+                "Failed to execute a command: {}\nSTDOUT: {}\nSTDERR: {}\n".
+                format(e, e.stdout, e.stderr))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -1,10 +1,11 @@
 from launchable.testpath import FilePathNormalizer
 
+import os.path
+import pathlib
 import subprocess
+import sys
 import tempfile
 import unittest
-import pathlib
-import os.path
 
 
 class TestFilePathNormalizer(unittest.TestCase):
@@ -42,6 +43,9 @@ class TestFilePathNormalizer(unittest.TestCase):
         self.assertEqual(relpath, n.relativize(relpath))
         self.assertEqual(relpath, n.relativize(abspath))
 
+    @unittest.skipIf(
+            sys.platform.startswith("win"),
+            "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed.")
     def test_inference_git(self):
         with tempfile.TemporaryDirectory() as tempdirname:
             temppath = pathlib.PurePath(tempdirname)
@@ -54,6 +58,9 @@ class TestFilePathNormalizer(unittest.TestCase):
             n = FilePathNormalizer()
             self.assertEqual(relpath, n.relativize(abspath))
 
+    @unittest.skipIf(
+            sys.platform.startswith("win"),
+            "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed. Also when this runs on Windows, GIT_AUTHOR_NAME etc. is ignored and fails.")
     def test_inference_git_submodule(self):
         with tempfile.TemporaryDirectory() as tempdirname:
             temppath = pathlib.PurePath(tempdirname)


### PR DESCRIPTION
Some test runners produce absolute paths. This makes a problem when we make statistical data for tests as those absolute paths can vary per machine or per run.

The CLI has an option to specify a base path to make a relative path from those absolute paths. This change teaches the CLI to guess the base path based on the Git repository root directory.