### PR TITLE
Add inspect command

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -8,6 +8,7 @@ from glob import glob
 from .commands.record import record
 from .commands.subset import subset
 from .commands.split_subset import split_subset
+from .commands.inspect import inspect
 from .commands.verify import verify
 from .utils import logger
 
@@ -51,7 +52,7 @@ main.add_command(record)
 main.add_command(subset)
 main.add_command(split_subset)
 main.add_command(verify)
-
+main.add_command(inspect)
 
 if __name__ == '__main__':
     main()

--- a/launchable/commands/inspect/__init__.py
+++ b/launchable/commands/inspect/__init__.py
@@ -1,0 +1,11 @@
+import click
+from launchable.utils.click import GroupWithAlias
+from .subset import subset
+
+
+@click.group(cls=GroupWithAlias)
+def inspect():
+    pass
+
+
+inspect.add_command(subset)

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -1,0 +1,46 @@
+import os
+import click
+from ...utils.http_client import LaunchableClient
+from ...utils.env_keys import REPORT_ERROR_KEY
+from tabulate import tabulate
+
+
+@click.command()
+@click.option(
+    '--subset-id',
+    'subset_id',
+    help='subest id',
+    required=True,
+)
+def subset(subset_id):
+    subset = []
+    rest = []
+    try:
+        client = LaunchableClient()
+        res = client.request("get", "subset/{}".format(subset_id))
+        res.raise_for_status()
+        subset = res.json()["testPaths"]
+        rest = res.json()["rest"]
+    except Exception as e:
+        if os.getenv(REPORT_ERROR_KEY):
+            raise e
+        else:
+            click.echo(e, err=True)
+        click.echo(click.style(
+            "Warning: the failed to inspect subset", fg='yellow'),
+            err=True)
+
+    header = ["Order", "Test Path", "In Subset", "Estimated duration (min)"]
+    rows = []
+    order = 1
+    for s in subset:
+        rows.append([order, "#".join([path["type"] + "=" + path["name"]
+                                      for path in s["testPath"]]), "✔", "{:0.4f}".format(s["duration"] / 60 / 1000)])  # msec to min
+        order = order + 1
+
+    for s in rest:
+        rows.append([order, "#".join([path["type"] + "=" + path["name"]
+                                      for path in s["testPath"]]), "", "{:0.4f}".format(s["duration"] / 60 / 1000)])  # msec to min
+        order = order + 1
+
+    click.echo(tabulate(rows, header, tablefmt="github"))

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -46,10 +46,7 @@ def convert_row(list: List[Dict], order: int, is_subset: bool):
     order: start number of order
     is_subset: in subset or not
     """
-    rows = []
-    for l in list:
-        rows.append([order, "#".join([path["type"] + "=" + path["name"]
-                                      for path in l["testPath"]]), "✔" if is_subset else "", "{:0.4f}".format(l["duration"] / 1000)])  # msec to sec
-        order = order + 1
-
-    return rows
+    return [[order + i, "#".join([path["type"] + "=" + path["name"]
+                                  for path in l["testPath"]]), "✔"
+             if is_subset else "", "{:0.4f}".format(l["duration"] / 1000)]
+            for i, l in enumerate(list)]

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -31,7 +31,7 @@ def subset(subset_id):
             "Warning: the failed to inspect subset", fg='yellow'),
             err=True)
 
-    header = ["Order", "Test Path", "In Subset", "Estimated duration (min)"]
+    header = ["Order", "Test Path", "In Subset", "Estimated duration (sec)"]
 
     subset_row = convert_row(subset, 1, True)
     rest_row = convert_row(rest, len(subset) + 1, False)
@@ -49,7 +49,7 @@ def convert_row(list: List[Dict], order: int, is_subset: bool):
     rows = []
     for l in list:
         rows.append([order, "#".join([path["type"] + "=" + path["name"]
-                                      for path in l["testPath"]]), "✔" if is_subset else "", "{:0.4f}".format(l["duration"] / 60 / 1000)])  # msec to min
+                                      for path in l["testPath"]]), "✔" if is_subset else "", "{:0.4f}".format(l["duration"] / 1000)])  # msec to sec
         order = order + 1
 
     return rows

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -48,10 +48,16 @@ class CliTestCase(unittest.TestCase):
         clean_session_files()
 
     def cli(self, *args, **kwargs) -> click.testing.Result:
+        # for CliRunner kwargs
+        mix_stderr = True
+        if 'mix_stderr' in kwargs:
+            mix_stderr = kwargs['mix_stderr']
+            del kwargs['mix_stderr']
+
         """
         Invoke CLI command and returns its result
         """
-        return CliRunner().invoke(main, args, catch_exceptions=False, **kwargs)
+        return CliRunner(mix_stderr=mix_stderr).invoke(main, args, catch_exceptions=False, **kwargs)
 
     def load_json_from_file(self, file):
         try:

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -35,6 +35,8 @@ class CliTestCase(unittest.TestCase):
                       json={'testPaths': [], 'rest': [], 'subsettingId': 456}, status=200)
         responses.add(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
                       json={'testPaths': [], 'rest': [], 'subsettingId': 456}, status=200)
+        responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/subset/{}".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
+                      json={'testPaths': [], 'rest': [], 'subsettingId': 456}, status=200)
         responses.add(responses.POST, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/events".format(get_base_url(), self.organization, self.workspace, self.build_name, self.session_id),
                       json={}, status=200)
         responses.add(responses.PATCH, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/close".format(get_base_url(), self.organization, self.workspace, self.build_name, self.session_id),

--- a/tests/commands/inspect/test_subset.py
+++ b/tests/commands/inspect/test_subset.py
@@ -1,0 +1,40 @@
+import os
+import responses  # type: ignore
+from unittest import mock
+from tests.cli_test_case import CliTestCase
+from launchable.utils.http_client import get_base_url
+
+
+class SubsetTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset(self):
+        subset_id = 456
+        responses.replace(responses.GET, "{}/intake/organizations/{}/workspaces/{}/subset/{}".format(
+            get_base_url(), self.organization, self.workspace, subset_id), json={
+            "testPaths": [
+                {"testPath": [
+                    {"type": "file", "name": "test_file1.py"}], "duration": 1200},
+                {"testPath": [
+                    {"type": "file", "name": "test_file3.py"}], "duration": 600},
+            ],
+            "rest": [
+                {"testPath": [
+                    {"type": "file", "name": "test_file4.py"}], "duration": 1800},
+                {"testPath": [
+                    {"type": "file", "name": "test_file2.py"}], "duration": 100}
+
+            ]
+        }, status=200)
+
+        result = self.cli('inspect', 'subset', '--subset-id',
+                          subset_id, mix_stderr=False)
+        expect = """|   Order | Test Path          | In Subset   |   Estimated duration (min) |
+|---------|--------------------|-------------|----------------------------|
+|       1 | file=test_file1.py | ✔           |                     0.02   |
+|       2 | file=test_file3.py | ✔           |                     0.01   |
+|       3 | file=test_file4.py |             |                     0.03   |
+|       4 | file=test_file2.py |             |                     0.0017 |
+"""
+
+        self.assertEqual(result.stdout, expect)

--- a/tests/commands/inspect/test_subset.py
+++ b/tests/commands/inspect/test_subset.py
@@ -29,12 +29,12 @@ class SubsetTest(CliTestCase):
 
         result = self.cli('inspect', 'subset', '--subset-id',
                           subset_id, mix_stderr=False)
-        expect = """|   Order | Test Path          | In Subset   |   Estimated duration (min) |
+        expect = """|   Order | Test Path          | In Subset   |   Estimated duration (sec) |
 |---------|--------------------|-------------|----------------------------|
-|       1 | file=test_file1.py | ✔           |                     0.02   |
-|       2 | file=test_file3.py | ✔           |                     0.01   |
-|       3 | file=test_file4.py |             |                     0.03   |
-|       4 | file=test_file2.py |             |                     0.0017 |
+|       1 | file=test_file1.py | ✔           |                        1.2 |
+|       2 | file=test_file3.py | ✔           |                        0.6 |
+|       3 | file=test_file4.py |             |                        1.8 |
+|       4 | file=test_file2.py |             |                        0.1 |
 """
 
         self.assertEqual(result.stdout, expect)


### PR DESCRIPTION
Add `launchable inspect subset` command to check subset result.

e.g) launchable/cli 
```
$ launchable inspect subset --subset-id <subset-id>
|   Order | Test Path                                   | In Subset   |   Estimated duration (sec) |
|---------|---------------------------------------------|-------------|----------------------------|
|       1 | file=tests/test_plugin.py                   | ✔           |                      0.001 |
|       2 | file=tests/test_runners/test_bazel.py       | ✔           |                      0.001 |
|       3 | file=tests/test_runners/test_gradle.py      | ✔           |                      0.001 |
|       4 | file=tests/test_version.py                  | ✔           |                      0.001 |
|       5 | file=tests/utils/test_click.py              | ✔           |                      0.001 |
|       6 | file=tests/utils/test_logger.py             | ✔           |                      0.001 |
|       7 | file=tests/test_runners/test_rspec.py       | ✔           |                      0.001 |
|       8 | file=tests/test_session.py                  | ✔           |                      0.001 |
|       9 | file=tests/commands/test_verify.py          | ✔           |                      0.001 |
|      10 | file=tests/commands/record/test_tests.py    | ✔           |                      0.001 |
|      11 | file=tests/test_runners/test_robot.py       | ✔           |                      0.001 |
|      12 | file=tests/test_runners/test_minitest.py    | ✔           |                      0.001 |
|      13 | file=tests/test_runners/test_behave.py      | ✔           |                      0.001 |
|      14 | file=tests/commands/record/test_commit.py   | ✔           |                      0.001 |
|      15 | file=tests/test_runners/test_go_test.py     | ✔           |                      0.001 |
|      16 | file=tests/test_runners/test_ant.py         | ✔           |                      0.001 |
|      17 | file=tests/commands/record/test_session.py  |             |                      0.001 |
|      18 | file=tests/utils/test_authentication.py     |             |                      0.001 |
|      19 | file=tests/utils/test_http_client.py        |             |                      0.001 |
|      20 | file=tests/data/pytest/tests/test_funcs1.py |             |                      0.001 |
|      21 | file=tests/test_runners/test_ctest.py       |             |                      0.001 |
|      22 | file=tests/test_runners/test_maven.py       |             |                      0.001 |
|      23 | file=tests/test_runners/test_cypress.py     |             |                      0.001 |
|      24 | file=tests/utils/test_gzipgen.py            |             |                      0.001 |
|      25 | file=tests/utils/test_file_name_pattern.py  |             |                      0.001 |
|      26 | file=tests/test_runners/test_googletest.py  |             |                      0.001 |
|      27 | file=tests/data/pytest/tests/test_funcs2.py |             |                      0.001 |
|      28 | file=tests/test_runners/test_adb.py         |             |                      0.001 |
|      29 | file=tests/commands/test_helper.py          |             |                      0.001 |
|      30 | file=tests/test_testpath.py                 |             |                      0.001 |
|      31 | file=tests/test_runners/test_pytest.py      |             |                      0.001 |
|      32 | file=tests/test_runners/test_nunit.py       |             |                      0.001 |
```