### PR TITLE
fix: validate build name format not to include forward slash

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -53,7 +53,7 @@ from ...utils.authentication import get_org_workspace
 def build(ctx, build_name, source, max_days, no_submodules,
           no_commit_collection):
     if "/" in build_name:
-        exit("Please pass build name without forward slash '/' to --name.")
+        exit("--name must not contain a slash")
 
     clean_session_files(days_ago=14)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -52,6 +52,9 @@ from ...utils.authentication import get_org_workspace
 @click.pass_context
 def build(ctx, build_name, source, max_days, no_submodules,
           no_commit_collection):
+    if "/" in build_name:
+        exit("Please pass build name without forward slash '/' to --name.")
+
     clean_session_files(days_ago=14)
 
     # This command accepts REPO_NAME=REPO_DIST and REPO_DIST


### PR DESCRIPTION
## Background

`pipenv run launchable record tests --build 'build-including/slash' go-test report.xml` failed with `404 Client Error`. this cli uses the specified build name as a part of a request path as follows:

```
https://{API_ENDPOINT}/intake/organizations/{ORGANIZATION_NAME}/workspaces/{WORKSPACE_NAME}/builds/{BUILD_NAME}/{SESSION_NAME}
```

When specifying the build name including forward slashes, `GET build` requests fail due to an unexpected build name or session name.

```
$ pipenv run launchable record tests --build 'tw/my-build-name' go-test report.xml
Build tw/my-build-name was not found. Make sure to run `launchable record build --name tw/my-build-name` before
404 Client Error:  for url: https://{API_ENDPOINT}/intake/organizations/{ORGANIZATION_NAME}/workspaces/{WORKSPACE_NAME}/builds/tw/my-build-name/test_sessions
Build tw/my-build-name was not found. Make sure to run `launchable record build --name tw/my-build-name` before `launchable record tests`
Traceback (most recent call last):
  File "/Users/username/.local/share/virtualenvs/launchable-go-qooJbKhC/lib/python3.9/site-packages/launchable/commands/record/tests.py", line 283, in run
    send(p)
  File "/Users/username/.local/share/virtualenvs/launchable-go-qooJbKhC/lib/python3.9/site-packages/launchable/commands/record/tests.py", line 250, in send
    elif build_name:
NameError: free variable 'build_name' referenced before assignment in enclosing scope
```

This is because the request path is built by [joining strings](https://github.com/launchableinc/cli/blob/7cbf781d7f286fc4e52ef0980712c28f386e8d09/launchable/utils/http_client.py#L49). As a result, it seems like record tests [requests](https://github.com/launchableinc/cli/blob/7cbf781d7f286fc4e52ef0980712c28f386e8d09/launchable/commands/record/tests.py#L352) include unexpected paths for the API. To fix the 404 error on record tests API requests,  there are several options.

* Option1: build names should not include `/` 
* Option2: build names including `/` are converted other strings
* Option3: change the API behavior to detect forward slashes in build names

This PR implements Option 1 which is the simplest workaround not to cause the above error.

## Goal

* Fix 404 errors when we specify a build name including `/`.


## How to reproduce the error

### CLI version

```
$ pyenv version
3.6.15 (set by /Users/takanabe/src/github.com/takanabe/go-project/.python-version)

$ pipenv graph
launchable==1.27.0
  - click [required: ~=7.0, installed: 7.1.2]
  - junitparser [required: >=2.0.0, installed: 2.1.1]
    - future [required: Any, installed: 0.18.2]
  - more-itertools [required: >=7.1.0, installed: 8.9.0]
  - python-dateutil [required: Any, installed: 2.8.2]
    - six [required: >=1.5, installed: 1.16.0]
  - requests [required: Any, installed: 2.26.0]
    - certifi [required: >=2017.4.17, installed: 2021.5.30]
    - charset-normalizer [required: ~=2.0.0, installed: 2.0.4]
    - idna [required: >=2.5,<4, installed: 3.2]
    - urllib3 [required: >=1.21.1,<1.27, installed: 1.26.6]
  - setuptools [required: Any, installed: 57.4.0]
  - tabulate [required: Any, installed: 0.8.9]
```

### Steps

1. `pipenv run launchable record build --name build-including/slash --source src=.`
2. `go test -v ./... | go-junit-report > report.xml` with a go project
3. `pipenv run launchable record tests --build 'build-including/slash' go-test report.xml`