### PR TITLE
[ENG-308] Inspect tests command

### DIFF
--- a/launchable/commands/inspect/__init__.py
+++ b/launchable/commands/inspect/__init__.py
@@ -1,6 +1,7 @@
 import click
 from launchable.utils.click import GroupWithAlias
 from .subset import subset
+from .tests import tests
 
 
 @click.group(cls=GroupWithAlias)
@@ -9,3 +10,4 @@ def inspect():
 
 
 inspect.add_command(subset)
+inspect.add_command(tests)

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -31,7 +31,7 @@ def tests(test_session_id):
         return
 
     header = ["Test Path",
-              "duration (sec)", "Status",  "Uploaded At"]
+              "Duration (sec)", "Status",  "Uploaded At"]
 
     rows = [["#".join([path["type"] + "=" + path["name"] for path in result["testPath"]]),
              "{:0.4f}".format(result["duration"]), result["status"], result["createdAt"]] for result in results]

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -1,0 +1,39 @@
+import click
+import os
+from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.http_client import LaunchableClient
+from tabulate import tabulate
+
+
+@click.command()
+@click.option(
+    '--test-session-id',
+    'test_session_id',
+    help='test session id',
+    required=True
+)
+def tests(test_session_id):
+    try:
+        client = LaunchableClient()
+        res = client.request(
+            "get", "/test_sessions/{}/events".format(test_session_id))
+        res.raise_for_status()
+        results = res.json()
+    except Exception as e:
+        if os.getenv(REPORT_ERROR_KEY):
+            raise e
+        else:
+            click.echo(e, err=True)
+        click.echo(click.style(
+            "Warning: the failed to inspect tests", fg='yellow'),
+            err=True)
+
+        return
+
+    header = ["Test Path",
+              "Estimated duration (sec)", "Status", "Stdout", "Stderr", "Uploaded At"]
+
+    rows = [["#".join([path["type"] + "=" + path["name"] for path in result["testPath"]]),
+             "{:0.4f}".format(result["duration"]), result["status"], result["stdout"], result["stderr"], result["createdAt"]] for result in results]
+
+    click.echo(tabulate(rows, header, tablefmt="github"))

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -31,9 +31,9 @@ def tests(test_session_id):
         return
 
     header = ["Test Path",
-              "Estimated duration (sec)", "Status", "Stdout", "Stderr", "Uploaded At"]
+              "duration (sec)", "Status",  "Uploaded At"]
 
     rows = [["#".join([path["type"] + "=" + path["name"] for path in result["testPath"]]),
-             "{:0.4f}".format(result["duration"]), result["status"], result["stdout"], result["stderr"], result["createdAt"]] for result in results]
+             "{:0.4f}".format(result["duration"]), result["status"], result["createdAt"]] for result in results]
 
     click.echo(tabulate(rows, header, tablefmt="github"))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -323,6 +323,9 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
                      success_count, fail_count, "{:0.4f}".format(duration)]]
             click.echo(tabulate(rows, header, tablefmt="github"))
 
+            click.echo(
+                "\nRun `launchable inspect tests --test-session-id {}` to view upload test results".format(test_session_id))
+
     context.obj = RecordTests()
 
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -291,4 +291,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
 
             click.echo(tabulate(rows, header, tablefmt="github"), err=True)
 
+            click.echo(
+                "\nRun `launchable inspect subset --subset-id {}` to view full subset details".format(subset_id), err=True)
+
     context.obj = Optimize()

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -39,6 +39,8 @@ class CliTestCase(unittest.TestCase):
                       json={'testPaths': [], 'rest': [], 'subsettingId': 456}, status=200)
         responses.add(responses.POST, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/events".format(get_base_url(), self.organization, self.workspace, self.build_name, self.session_id),
                       json={}, status=200)
+        responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/test_sessions/{}/events".format(get_base_url(), self.organization, self.workspace, self.session_id),
+                      json=[], status=200)
         responses.add(responses.PATCH, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/close".format(get_base_url(), self.organization, self.workspace, self.build_name, self.session_id),
                       json={}, status=200)
         responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/builds/{}".format(get_base_url(), self.organization, self.workspace, self.build_name),

--- a/tests/commands/inspect/test_tests.py
+++ b/tests/commands/inspect/test_tests.py
@@ -26,7 +26,7 @@ class SubsetTest(CliTestCase):
 
         result = self.cli('inspect', 'tests', '--test-session-id',
                           test_session_id, mix_stderr=False)
-        expect = """| Test Path          |   duration (sec) | Status   | Uploaded At                   |
+        expect = """| Test Path          |   Duration (sec) | Status   | Uploaded At                   |
 |--------------------|------------------|----------|-------------------------------|
 | file=test_file1.py |              1.2 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
 | file=test_file3.py |              0.6 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |

--- a/tests/commands/inspect/test_tests.py
+++ b/tests/commands/inspect/test_tests.py
@@ -1,0 +1,37 @@
+import os
+import responses  # type: ignore
+from unittest import mock
+from tests.cli_test_case import CliTestCase
+from launchable.utils.http_client import get_base_url
+
+
+class SubsetTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset(self):
+        test_session_id = 16
+        responses.replace(responses.GET, "{}/intake/organizations/{}/workspaces/{}/test_sessions/{}/events".format(
+            get_base_url(), self.organization, self.workspace, test_session_id), json=[
+                {"testPath": [
+                    {"type": "file", "name": "test_file1.py"}], "duration": 1.2, "stderr": "", "stdout": "", "createdAt":  "2021-01-02T03:04:05.000+00:00", "status": "SUCCESS"},
+                {"testPath": [
+                    {"type": "file", "name": "test_file3.py"}], "duration": 0.6,  "stderr": "", "stdout": "", "createdAt":  "2021-01-02T03:04:05.000+00:00", "status": "SUCCESS"},
+
+
+                {"testPath": [
+                    {"type": "file", "name": "test_file4.py"}], "duration": 1.8,  "stderr": "", "stdout": "", "createdAt":  "2021-01-02T03:04:05.000+00:00", "status": "FAILURE"},
+                {"testPath": [
+                    {"type": "file", "name": "test_file2.py"}], "duration": 0.1,  "stderr": "", "stdout": "", "createdAt":  "2021-01-02T03:04:05.000+00:00", "status": "FAILURE"},
+        ], status=200)
+
+        result = self.cli('inspect', 'tests', '--test-session-id',
+                          test_session_id, mix_stderr=False)
+        expect = """| Test Path          |   Estimated duration (sec) | Status   | Stdout   | Stderr   | Uploaded At                   |
+|--------------------|----------------------------|----------|----------|----------|-------------------------------|
+| file=test_file1.py |                        1.2 | SUCCESS  |          |          | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file3.py |                        0.6 | SUCCESS  |          |          | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file4.py |                        1.8 | FAILURE  |          |          | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file2.py |                        0.1 | FAILURE  |          |          | 2021-01-02T03:04:05.000+00:00 |
+"""
+
+        self.assertEqual(result.stdout, expect)

--- a/tests/commands/inspect/test_tests.py
+++ b/tests/commands/inspect/test_tests.py
@@ -26,12 +26,12 @@ class SubsetTest(CliTestCase):
 
         result = self.cli('inspect', 'tests', '--test-session-id',
                           test_session_id, mix_stderr=False)
-        expect = """| Test Path          |   Estimated duration (sec) | Status   | Stdout   | Stderr   | Uploaded At                   |
-|--------------------|----------------------------|----------|----------|----------|-------------------------------|
-| file=test_file1.py |                        1.2 | SUCCESS  |          |          | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file3.py |                        0.6 | SUCCESS  |          |          | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file4.py |                        1.8 | FAILURE  |          |          | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file2.py |                        0.1 | FAILURE  |          |          | 2021-01-02T03:04:05.000+00:00 |
+        expect = """| Test Path          |   duration (sec) | Status   | Uploaded At                   |
+|--------------------|------------------|----------|-------------------------------|
+| file=test_file1.py |              1.2 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file3.py |              0.6 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file4.py |              1.8 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file2.py |              0.1 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
 """
 
         self.assertEqual(result.stdout, expect)


### PR DESCRIPTION
I implemented `launchable inspect tests --test-session-id <id>` command

<details>
<summary> output of launchable inspect tests in cli </summary>

```
$ launchable inspect tests --test-session-id <id>
| Test Path                                                                                                                                                                                                  |   duration (sec) | Status   | Uploaded At                   |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|-------------------------------|
| file=tests/utils/test_logger.py#testsuite=tests.utils.test_logger.LoggerTest#testcase=test_logging_default                                                                                                 |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_logger.py#testsuite=tests.utils.test_logger.LoggerTest#testcase=test_log_level_audit                                                                                                 |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_http_client.py#testsuite=tests.utils.test_http_client.LaunchableClientTest#testcase=test_header                                                                                      |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_gzipgen.py#testsuite=tests.utils.test_gzipgen.GzippenTest#testcase=test_compress                                                                                                     |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_file_name_pattern.py#testsuite=tests.utils.test_file_name_pattern.FileNameHeuristicTest#testcase=test_jvm_file_name                                                                  |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_click.py#testsuite=tests.utils.test_click.DurationTypeTest#testcase=test_convert_to_seconds                                                                                          |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_get_org_workspace_valid_LAUNCHABLE_TOKEN                                                |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_get_org_workspace_no_environment_variables                                              |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_get_org_workspace_invalid_LAUNCHABLE_TOKEN                                              |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_get_org_workspace_LAUNCHABLE_TOKEN_and_LAUNCHABLE_ORGANIZATION_and_LAUNCHABLE_WORKSPACE |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_get_org_workspace_LAUNCHABLE_ORGANIZATION_and_LAUNCHABLE_WORKSPACE                      |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_authentication_headers_empty                                                            |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_authentication_headers_LAUNCHABLE_TOKEN_and_GitHub_Actions                              |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_authentication_headers_LAUNCHABLE_TOKEN                                                 |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_authentication_headers_GitHub_Actions_without_PR_head                                   |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/utils/test_authentication.py#testsuite=tests.utils.test_authentication.AuthenticationTest#testcase=test_authentication_headers_GitHub_Actions_with_PR_head                                      |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_version.py#testsuite=tests.test_version.VersionTest#testcase=test_version                                                                                                                  |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_inference_git_submodule                                                                                     |            0.284 | FAILURE  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_inference_git                                                                                               |            0.142 | FAILURE  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_relative_path                                                                                               |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_normalize_path                                                                                              |            0     | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_no_base_path_inference                                                                                      |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_testpath.py#testsuite=tests.test_testpath.TestFilePathNormalizer#testcase=test_base_path                                                                                                   |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_write_read_remove                                                                                                   |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_read_before_write                                                                                                   |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_parse_session                                                                                                       |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_other_build                                                                                                         |            0.002 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_get_session_id                                                                                                      |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_session.py#testsuite=tests.test_session.SessionTestClass#testcase=test_different_pid                                                                                                       |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_rspec.py#testsuite=tests.test_runners.test_rspec.RspecTest#testcase=test_record_test_rspec                                                                                    |            0.025 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_robot.py#testsuite=tests.test_runners.test_robot.RobotTest#testcase=test_subset                                                                                               |            0.011 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_robot.py#testsuite=tests.test_runners.test_robot.RobotTest#testcase=test_record_test                                                                                          |            0.02  | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_pytest.py#testsuite=tests.test_runners.test_pytest.PytestTest#testcase=test_subset                                                                                            |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_pytest.py#testsuite=tests.test_runners.test_pytest.PytestTest#testcase=test_record_test_pytest                                                                                |            0.015 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_nunit.py#testsuite=tests.test_runners.test_nunit.NUnitTest#testcase=test_subset                                                                                               |            0.01  | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_nunit.py#testsuite=tests.test_runners.test_nunit.NUnitTest#testcase=test_split_subset                                                                                         |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_nunit.py#testsuite=tests.test_runners.test_nunit.NUnitTest#testcase=test_record_test_on_windows                                                                               |            0.014 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_nunit.py#testsuite=tests.test_runners.test_nunit.NUnitTest#testcase=test_record_test_on_linux                                                                                 |            0.018 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_subset_with_invalid_path                                                                    |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_subset_split                                                                                |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_subset                                                                                      |            0.008 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_split_subset                                                                                |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_record_test_minitest_chunked                                                                |            0.019 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_minitest.py#testsuite=tests.test_runners.test_minitest.MinitestTest#testcase=test_record_test_minitest                                                                        |            0.023 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_maven.py#testsuite=tests.test_runners.test_maven.MavenTest#testcase=test_subset_by_confidence                                                                                 |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_maven.py#testsuite=tests.test_runners.test_maven.MavenTest#testcase=test_subset_by_absolute_time                                                                              |            0.008 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_maven.py#testsuite=tests.test_runners.test_maven.MavenTest#testcase=test_subset                                                                                               |            0.008 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_maven.py#testsuite=tests.test_runners.test_maven.MavenTest#testcase=test_record_test_maven                                                                                    |            0.017 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_gradle.py#testsuite=tests.test_runners.test_gradle.GradleTest#testcase=test_subset_without_session                                                                            |            0.013 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_gradle.py#testsuite=tests.test_runners.test_gradle.GradleTest#testcase=test_subset_split                                                                                      |            0.013 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_gradle.py#testsuite=tests.test_runners.test_gradle.GradleTest#testcase=test_subset_rest                                                                                       |            0.012 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_gradle.py#testsuite=tests.test_runners.test_gradle.GradleTest#testcase=test_split_subset                                                                                      |            0.008 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_gradle.py#testsuite=tests.test_runners.test_gradle.GradleTest#testcase=test_record_test_gradle                                                                                |            0.015 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_googletest.py#testsuite=tests.test_runners.test_googletest.GoogleTestTest#testcase=test_subset                                                                                |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_googletest.py#testsuite=tests.test_runners.test_googletest.GoogleTestTest#testcase=test_record_test_googletest                                                                |            0.016 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_googletest.py#testsuite=tests.test_runners.test_googletest.GoogleTestTest#testcase=test_record_failed_test_googletest                                                         |            0.014 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_googletest.py#testsuite=tests.test_runners.test_googletest.GoogleTestTest#testcase=test_record_empty_dir                                                                      |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_go_test.py#testsuite=tests.test_runners.test_go_test.GoTestTest#testcase=test_subset_without_session                                                                          |            0.012 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_go_test.py#testsuite=tests.test_runners.test_go_test.GoTestTest#testcase=test_subset_with_session                                                                             |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_go_test.py#testsuite=tests.test_runners.test_go_test.GoTestTest#testcase=test_record_tests_without_session                                                                    |            0.018 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_go_test.py#testsuite=tests.test_runners.test_go_test.GoTestTest#testcase=test_record_tests_with_session                                                                       |            0.016 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_cypress.py#testsuite=tests.test_runners.test_cypress.CypressTest#testcase=test_subset_cypress                                                                                 |            0.006 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_cypress.py#testsuite=tests.test_runners.test_cypress.CypressTest#testcase=test_record_test_cypress                                                                            |            0.017 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_cypress.py#testsuite=tests.test_runners.test_cypress.CypressTest#testcase=test_empty_xml                                                                                      |            0.01  | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_ctest.py#testsuite=tests.test_runners.test_ctest.CTestTest#testcase=test_subset_without_session                                                                               |            0.011 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_ctest.py#testsuite=tests.test_runners.test_ctest.CTestTest#testcase=test_record_test                                                                                          |            0.021 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_behave.py#testsuite=tests.test_runners.test_behave.BehaveTest#testcase=test_subset                                                                                            |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_behave.py#testsuite=tests.test_runners.test_behave.BehaveTest#testcase=test_record_test                                                                                       |            0.014 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_bazel.py#testsuite=tests.test_runners.test_bazel.BazelTest#testcase=test_subset_record_key_match                                                                              |            0.025 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_bazel.py#testsuite=tests.test_runners.test_bazel.BazelTest#testcase=test_subset                                                                                               |            0.014 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_bazel.py#testsuite=tests.test_runners.test_bazel.BazelTest#testcase=test_record_test_with_multiple_build_event_json_files                                                     |            0.021 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_bazel.py#testsuite=tests.test_runners.test_bazel.BazelTest#testcase=test_record_test_with_build_event_json_file                                                               |            0.023 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_bazel.py#testsuite=tests.test_runners.test_bazel.BazelTest#testcase=test_record_test                                                                                          |            0.027 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_ant.py#testsuite=tests.test_runners.test_ant.AntTest#testcase=test_subset                                                                                                     |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_ant.py#testsuite=tests.test_runners.test_ant.AntTest#testcase=test_record_test_ant                                                                                            |            0.022 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_runners/test_adb.py#testsuite=tests.test_runners.test_adb.AdbTest#testcase=test_subset                                                                                                     |            0.023 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/test_plugin.py#testsuite=tests.test_plugin.PluginTest#testcase=test_plugin_loading                                                                                                              |            0.553 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/test_verify.py#testsuite=tests.commands.test_verify.VersionTest#testcase=test_java_version                                                                                             |            0     | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/test_verify.py#testsuite=tests.commands.test_verify.VersionTest#testcase=test_compare_version                                                                                          |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/test_helper.py#testsuite=tests.commands.test_helper.TestHelper#testcase=test__validate_session_and_build_name                                                                          |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_tests.py#testsuite=tests.commands.record.test_tests.TestsTest#testcase=test_parse_launchable_timeformat                                                                    |            0.001 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_tests.py#testsuite=tests.commands.record.test_tests.TestsTest#testcase=test_filename_in_error_message                                                                      |            0.024 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_session.py#testsuite=tests.commands.record.test_session.SessionTest#testcase=test_run_session_without_flavor                                                               |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_session.py#testsuite=tests.commands.record.test_session.SessionTest#testcase=test_run_session_with_flavor                                                                  |            0.03  | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_commit.py#testsuite=tests.commands.record.test_commit.CommitTest#testcase=test_run_commit                                                                                  |            1.888 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |
| file=tests/commands/record/test_commit.py#testsuite=tests.commands.record.test_commit.CommitTest#testcase=test_proxy_options                                                                               |            0.007 | SUCCESS  | 2021-08-23T00:47:57.773+00:00 |


```
</details>