### PR TITLE
[ENG-315] Change pytest from class base to file name base

### DIFF
--- a/tests/data/pytest/subset_result.json
+++ b/tests/data/pytest/subset_result.json
@@ -2,26 +2,26 @@
   "testPaths":[
     [
       {
-        "type":"class",
-        "name":"tests.test_funcs1"
+        "type":"file",
+        "name":"tests/test_funcs1.py"
       }
     ],
     [
       {
-        "type":"class",
-        "name":"tests.test_funcs2"
+        "type":"file",
+        "name":"tests/test_funcs2.py"
       }
     ],
     [
       {
-        "type":"class",
-        "name":"tests.funcs3_test"
+        "type":"file",
+        "name":"tests/funcs3_test.py"
       }
     ],
     [
       {
-        "type":"class",
-        "name":"tests.fooo.func4_test"
+        "type":"file",
+        "name":"tests/fooo/func4_test.py"
       }
     ]
   ],

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -22,7 +22,8 @@ class PytestTest(CliTestCase):
             responses.calls[0].request.body).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('subset_result.json'))
-
+        for test_path in expected["testPaths"]:
+            test_path[0]['name'] = os.path.normpath(test_path[0]['name'])
         self.assert_json_orderless_equal(expected, payload)
 
     @responses.activate


### PR DESCRIPTION
- pytest has changed its default test report format from **xunit1** to **xunit2** since version 6.
  -  https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2
- The **xunit2** format no longer includes file names.
  - The **xunit1** format includes the file name.
  - It is possible to output in xunit1 format by specifying `junit_family=legacy`.

I chose to generate the class name from the file name so that I wouldn't have to change the format. However, it was not possible to create a complete class name from a file name. So I'm going to change it to file name based.
