### PR TITLE
Do not show stack trace when session not found

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -54,6 +54,7 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
                 "Build {} was not found. Make sure to run `launchable record build --name {}` before".format(build_name, build_name), 'yellow'), err=True)
+            exit(1)
 
         res.raise_for_status()
         session_id = res.json()['id']


### PR DESCRIPTION
When there the Session was not found, the process was not stopped, so an error occurred in the following process. As a result, a stack trace was shown.

A message is now displayed to stop the process when the session is not found.