### PR TITLE
[ENG-334] add error handling

### DIFF
--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from tabulate import tabulate
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
@@ -19,6 +20,12 @@ def subset(subset_id):
     try:
         client = LaunchableClient()
         res = client.request("get", "subset/{}".format(subset_id))
+
+        if res.status_code == HTTPStatus.NOT_FOUND:
+            click.echo(click.style(
+                "Subset id is {} was not found. Make sure to check subset id before".format(subset_id), 'yellow'), err=True)
+            exit(1)
+
         res.raise_for_status()
         subset = res.json()["testPaths"]
         rest = res.json()["rest"]

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -3,6 +3,7 @@ import os
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from tabulate import tabulate
+from http import HTTPStatus
 
 
 @click.command()
@@ -17,6 +18,12 @@ def tests(test_session_id):
         client = LaunchableClient()
         res = client.request(
             "get", "/test_sessions/{}/events".format(test_session_id))
+
+        if res.status_code == HTTPStatus.NOT_FOUND:
+            click.echo(click.style(
+                "Uploaded test which test session id is {} was not found. Make sure to check test session id before".format(test_session_id), 'yellow'), err=True)
+            exit(1)
+
         res.raise_for_status()
         results = res.json()
     except Exception as e:


### PR DESCRIPTION
the cli shows an empty table if the target subset or tests doesn't exist. So, I changed to show error message when the data doesn't exist.

### Before
```
$ launchable inspect subset --subset-id 10
404 Client Error:  for url: http://xxx
Warning: the failed to inspect subset
| Order   | Test Path   | In Subset   | Estimated duration (sec)   |
|---------|-------------|-------------|----------------------------|

$ launchable inspect tests --test-session-id 10
| Test Path   | Duration (sec)   | Status   | Uploaded At   |
|-------------|------------------|----------|---------------|
```

### After 
```
$ launchable inspect tests --test-session-id 999
Uploaded test which test session id is 999 was not found. Make sure to check test session id before

$ launchable inspect subset --subset-id 999
Subset id is 999 was not found. Make sure to check subset id before
```