### PR TITLE
Replace subprocess.check_output with a wrapper

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -1,6 +1,6 @@
 import re
 import click
-import subprocess
+from ...utils import subprocess
 import os
 from .commit import commit
 from ...utils.env_keys import REPORT_ERROR_KEY

--- a/launchable/utils/subprocess.py
+++ b/launchable/utils/subprocess.py
@@ -1,0 +1,12 @@
+import subprocess
+
+
+def check_output(*args, **kwargs):
+    """A wrapper for subprocess.check_output
+
+    In Windows, subprocess.check_output is used internally in one of those
+    dependencies. If we mock out subprocess.check_output, it also traps those
+    internall calls, making tests fail. This wrapper is a point to mock only
+    launchable CLI initiated calls.
+    """
+    return subprocess.check_output(*args, **kwargs)

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -11,7 +11,7 @@ class BuildTest(CliTestCase):
     # make sure the output of git-submodule is properly parsed
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    @mock.patch('subprocess.check_output')
+    @mock.patch('launchable.utils.subprocess.check_output')
     def test_submodule(self, mock_check_output):
         mock_check_output.side_effect = [
             # the first call is git rev-parse HEAD
@@ -22,11 +22,13 @@ class BuildTest(CliTestCase):
                 ' 8bccab48338219e73c3118ad71c8c98fbd32a4be bar-zot (v1.32.0-516-g8bccab4)\n'
             ).encode()
         ]
-        result = self.cli("record", "build", "--no-commit-collection", "--name", self.build_name)
+        result = self.cli("record", "build",
+                          "--no-commit-collection", "--name", self.build_name)
         self.assertEqual(result.exit_code, 0)
 
         # Name & Path should both reflect the submodule path
-        self.assertTrue("| ./bar-zot | ./bar-zot | 8bccab48338219e73c3118ad71c8c98fbd32a4be |" in result.stdout)
+        self.assertTrue(
+            "| ./bar-zot | ./bar-zot | 8bccab48338219e73c3118ad71c8c98fbd32a4be |" in result.stdout)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(


### PR DESCRIPTION
See the comment in launchable.utils.subprocess. This fixes Windows
build.