### PR TITLE
Change test session file format

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -5,7 +5,7 @@ import os
 from .commit import commit
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
-from ...utils.session import clean_session_files
+from ...utils.session import clean_session_files, write_build
 from tabulate import tabulate
 from ...utils.authentication import get_org_workspace
 
@@ -129,6 +129,8 @@ def build(ctx, build_name, source, max_days, no_submodules,
             raise e
         else:
             print(e)
+
+    write_build(build_name)
 
     org, workspace = get_org_workspace()
     click.echo(

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -8,8 +8,6 @@ from ...utils.session import write_session
 from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 
-LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
-
 
 @click.command()
 @click.option(

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -11,7 +11,7 @@ from more_itertools import ichunked
 from .case_event import CaseEvent, CaseEventType
 from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.session import parse_session, remove_session
+from ...utils.session import parse_session, read_session, remove_session
 from ...testpath import TestPathComponent, FilePathNormalizer
 from ..helper import find_or_create_session
 from http import HTTPStatus
@@ -89,8 +89,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         session_id = result["session"]
         record_start_at = result["start_at"]
     else:
-        session_id = find_or_create_session(
-            context, session, build_name, flavor)
+        session_id = session if session else read_session(build_name)
 
         record_start_at = get_record_start_at(build_name, session)
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -13,7 +13,7 @@ from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.session import parse_session, read_session, remove_session
 from ...testpath import TestPathComponent, FilePathNormalizer
-from ..helper import find_or_create_session
+from ..helper import _validate_session_and_build_name, find_or_create_session
 from http import HTTPStatus
 from ...utils.click import KeyValueType
 from ...utils.logger import Logger
@@ -89,8 +89,8 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         session_id = result["session"]
         record_start_at = result["start_at"]
     else:
-        session_id = session if session else read_session(build_name)
-
+        _validate_session_and_build_name(session, build_name)
+        session_id = session if session else read_session(str(build_name))
         record_start_at = get_record_start_at(build_name, session)
 
     logger = Logger()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -11,7 +11,7 @@ from more_itertools import ichunked
 from .case_event import CaseEvent, CaseEventType
 from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.session import parse_session
+from ...utils.session import parse_session, remove_session
 from ...testpath import TestPathComponent, FilePathNormalizer
 from ..helper import find_or_create_session
 from http import HTTPStatus
@@ -323,6 +323,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             click.echo(
                 "\nRun `launchable inspect tests --test-session-id {}` to view uploaded test results".format(test_session_id))
 
+            remove_session()
     context.obj = RecordTests()
 
 

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -15,38 +15,7 @@ def _session_file_dir() -> Path:
 
 
 def _session_file_path(build_name: str) -> Path:
-    return _session_file_dir() / (hashlib.sha1("{}:{}".format(build_name, _get_session_id()).encode()).hexdigest() + ".txt")
-
-
-def _get_session_id() -> str:
-    # CircleCI changes unix session id each steps, so set non change variable
-    # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-    if os.environ.get("CIRCLECI") is not None:
-        id = os.environ.get("CIRCLE_WORKFLOW_ID")
-        if id is not None:
-            return id
-        Logger().warning("CIRCLECI environment variable is set but not CIRCLE_WORKFLOW_ID")
-
-    # Jenkins pipeline also launches every process as a new session, so better to scope this to a particular build.
-    # For freestyle job types that do not do this, session IDs do not distinguish different builds, so that is a problem, too.
-    #
-    # See: https://github.com/jenkinsci/lib-durable-task/blob/6e020747205cb5aca5af757bc0d2a302c42bdb79/src/cmd/bash/durable_task_monitor.go#L41
-    # See: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-    if os.environ.get("JENKINS_URL") is not None:
-        id = os.environ.get("BUILD_URL")
-        if id is not None:
-            return id
-        Logger().warning("JENKINS_URL environment variable is set but not BUILD_URL")
-
-    if sys.platform == "win32":
-        import wmi  # type: ignore
-        c = wmi.WMI()
-        wql = "Associators of {{Win32_Process='{}'}} Where Resultclass = Win32_LogonSession Assocclass = Win32_SessionProcess".format(
-            os.getpid())
-        res = c.query(wql)
-        return str(res[0].LogonId)
-    else:
-        return str(os.getsid(os.getpid()))
+    return _session_file_dir() / "build={}".format(build_name)
 
 
 def read_session(build_name: str) -> Optional[str]:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -17,33 +17,6 @@ def _session_file_path() -> Path:
     return _session_file_dir() / ".launchable"
 
 
-def _parse_session_file(text: str):
-    try:
-        build, session = text.split("#")
-        _, build_name = build.split("=")
-        _, session_id = session.split("=")
-
-        return build_name, session_id
-    except Exception as e:
-        raise Exception("Can't parse session file: {}".format(text)) from e
-
-
-def read_session(build_name: str) -> Optional[str]:
-    f = _session_file_path()
-    try:
-        if not f.exists():
-            return None
-        build, session_id = _parse_session_file(f.read_text())
-
-        if build != build_name:
-            raise Exception("Build name is different between input:{} and saved:{}. Previous job might be failed.\nPlease confirm previous job result and run after removing {}".format(
-                build_name, build, f))
-
-        return session_id
-    except Exception as e:
-        raise Exception("Can't read {}".format(f)) from e
-
-
 def write_build(build_name: str) -> None:
     session = {}
     session["build"] = build_name
@@ -76,25 +49,52 @@ def read_build() -> str:
         raise Exception("Can't load build name from test session file.") from e
 
 
+def _parse_session_file():
+    try:
+        with open(_session_file_path()) as session_file:
+            session = json.load(session_file)
+
+        return session.get("build"), session.get("test_session", "")
+
+    except Exception as e:
+        raise Exception("Can't parse session file: {}".format(
+            _parse_session_file())) from e
+
+
+def read_session(build_name: str) -> Optional[str]:
+    f = _session_file_path()
+    try:
+        if not f.exists():
+            return None
+        build, session_id = _parse_session_file()
+
+        if build != build_name:
+            raise Exception("TODO: error message")
+
+        return session_id
+    except Exception as e:
+        raise Exception("Can't read {}".format(f)) from e
+
+
 def write_session(build_name: str, session_id: str) -> None:
     try:
-        if not _session_file_dir().exists():
-            _session_file_dir().mkdir(parents=True, exist_ok=True)
-
         f = _session_file_path()
-        if f.exists():
-            saved_build_name, saved_session_id = _parse_session_file(
-                f.read_text())
-            if saved_build_name != "" and saved_build_name != build_name:
-                raise Exception(
-                    "Session file already exists but different bettween input:{} and saved:{}\nMake sture to confirm previous job result and run after removing {}".format(saved_build_name, build_name, f))
+        if not f.exists():
+            raise Exception("TODO: session file doesn't exist")
 
-            if saved_session_id != session_id:
-                raise Exception(
-                    "Session file already exists but different session id bettween input:{} and saved:{}\nMake sture to confirm previous job result and run after removing {}".format(session_id, saved_session_id, f))
+        saved_build_name, saved_session_id = _parse_session_file()
+        if saved_build_name != "" and saved_build_name != build_name:
+            raise Exception("TODO: build name is different")
 
-        f.write_text(
-            "build={}#test_session={}".format(build_name, session_id))
+        if saved_session_id != "" and saved_session_id != session_id:
+            raise Exception(
+                "TODO: test session id is different")
+
+        session = {}
+        session["build"] = build_name
+        session["test_session"] = session_id
+        with open(_session_file_path(), 'w') as session_file:
+            json.dump(session, session_file)
     except Exception as e:
         raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(
             _session_file_path(), SESSION_DIR_KEY)) from e

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -17,38 +17,6 @@ def _session_file_path() -> Path:
     return _session_file_dir() / ".launchable"
 
 
-def write_build(build_name: str) -> None:
-    session = {}
-    session["build"] = build_name
-
-    try:
-        if not _session_file_dir().exists():
-            _session_file_dir().mkdir(parents=True, exist_ok=True)
-
-        if (_session_file_path().exists()):
-            exist_build_name = read_build()
-            if build_name != exist_build_name:
-                raise Exception(
-                    "You're going to save another build name. Make sure <TODO>")
-
-        with open(_session_file_path(), 'w') as session_file:
-            json.dump(session, session_file)
-
-    except Exception as e:
-        raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(
-            _session_file_path(), SESSION_DIR_KEY)) from e
-
-
-def read_build() -> str:
-    try:
-        with open(_session_file_path()) as session_file:
-            session = json.load(session_file)
-            return session["build"]
-
-    except Exception as e:
-        raise Exception("Can't load build name from test session file.") from e
-
-
 def _parse_session_file():
     try:
         with open(_session_file_path()) as session_file:
@@ -61,9 +29,41 @@ def _parse_session_file():
             _parse_session_file())) from e
 
 
-def read_session(build_name: str) -> Optional[str]:
-    f = _session_file_path()
+def write_build(build_name: str) -> None:
+
     try:
+        if not _session_file_dir().exists():
+            _session_file_dir().mkdir(parents=True, exist_ok=True)
+
+        if (_session_file_path().exists()):
+            exist_build_name = read_build()
+            if build_name != exist_build_name:
+                raise Exception(
+                    "You're going to save another build name. Make sure <TODO>")
+
+        session = {}
+        session["build"] = build_name
+        with open(_session_file_path(), 'w') as session_file:
+            json.dump(session, session_file)
+
+    except Exception as e:
+        raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(
+            _session_file_path(), SESSION_DIR_KEY)) from e
+
+
+def read_build() -> str:
+    try:
+        with open(_session_file_path()) as session_file:
+            session = json.load(session_file)
+            return session.get("build")
+
+    except Exception as e:
+        raise Exception("Can't load build name from test session file.") from e
+
+
+def read_session(build_name: str) -> Optional[str]:
+    try:
+        f = _session_file_path()
         if not f.exists():
             return None
         build, session_id = _parse_session_file()
@@ -80,9 +80,13 @@ def write_session(build_name: str, session_id: str) -> None:
     try:
         f = _session_file_path()
         if not f.exists():
-            raise Exception("TODO: session file doesn't exist")
+            raise Exception(
+                "TODO: session file doesn't exist. build name is needed to include")
 
         saved_build_name, saved_session_id = _parse_session_file()
+        if saved_build_name == "":
+            raise Exception("TODO: have to run recrod build before")
+
         if saved_build_name != "" and saved_build_name != build_name:
             raise Exception("TODO: build name is different")
 

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -30,7 +30,6 @@ def _parse_session_file():
 
 
 def write_build(build_name: str) -> None:
-
     try:
         if not _session_file_dir().exists():
             _session_file_dir().mkdir(parents=True, exist_ok=True)
@@ -69,7 +68,7 @@ def read_session(build_name: str) -> Optional[str]:
         build, session_id = _parse_session_file()
 
         if build != build_name:
-            raise Exception("TODO: error message")
+            raise Exception("TODO: set build name is different")
 
         return session_id
     except Exception as e:
@@ -104,7 +103,7 @@ def write_session(build_name: str, session_id: str) -> None:
             _session_file_path(), SESSION_DIR_KEY)) from e
 
 
-def remove_session(build_name: str) -> None:
+def remove_session() -> None:
     """
     Call it after closing a session
     """
@@ -116,21 +115,7 @@ def clean_session_files(days_ago: int = 0) -> None:
     """
     Call it each build start
     """
-    if _session_file_dir().exists():
-        for child in _session_file_dir().iterdir():
-            file_created = datetime.datetime.fromtimestamp(
-                child.stat().st_mtime)
-
-            if sys.platform == "win32":
-                # Windows sometimes misses to delete session files at Unit Test
-                microseconds = -10
-            else:
-                microseconds = 0
-
-            clean_date = datetime.datetime.now() - datetime.timedelta(days=days_ago,
-                                                                      microseconds=microseconds)
-            if file_created < clean_date:
-                child.unlink()
+    remove_session()
 
 
 def parse_session(session: str):

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -3,8 +3,6 @@ import sys
 from pathlib import Path
 from typing import Optional
 import datetime
-import hashlib
-from .logger import Logger
 
 SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 DEFAULT_SESSION_DIR = '~/.config/launchable/sessions/'
@@ -14,16 +12,33 @@ def _session_file_dir() -> Path:
     return Path(os.environ.get(SESSION_DIR_KEY) or DEFAULT_SESSION_DIR).expanduser()
 
 
-def _session_file_path(build_name: str) -> Path:
-    return _session_file_dir() / "build={}".format(build_name)
+def _session_file_path() -> Path:
+    return _session_file_dir() / ".launchable"
+
+
+def _parse_session_file(text: str):
+    try:
+        build, session = text.split("#")
+        _, build_name = build.split("=")
+        _, session_id = session.split("=")
+
+        return build_name, session_id
+    except Exception as e:
+        raise Exception("Can't parse session file: {}".format(text)) from e
 
 
 def read_session(build_name: str) -> Optional[str]:
-    f = _session_file_path(build_name)
+    f = _session_file_path()
     try:
         if not f.exists():
             return None
-        return f.read_text()
+        build, session_id = _parse_session_file(f.read_text())
+
+        if build != build_name:
+            raise Exception("Build name is different between input:{} and saved:{}. Previous job might be failed.\nPlease confirm previous job result and run after removing {}".format(
+                build_name, build, f))
+
+        return session_id
     except Exception as e:
         raise Exception("Can't read {}".format(f)) from e
 
@@ -33,18 +48,31 @@ def write_session(build_name: str, session_id: str) -> None:
         if not _session_file_dir().exists():
             _session_file_dir().mkdir(parents=True, exist_ok=True)
 
-        _session_file_path(build_name).write_text(session_id)
+        f = _session_file_path()
+        if f.exists():
+            saved_build_name, saved_session_id = _parse_session_file(
+                f.read_text())
+            if saved_build_name != "" and saved_build_name != build_name:
+                raise Exception(
+                    "Session file already exists but different bettween input:{} and saved:{}\nMake sture to confirm previous job result and run after removing {}".format(saved_build_name, build_name, f))
+
+            if saved_session_id != session_id:
+                raise Exception(
+                    "Session file already exists but different session id bettween input:{} and saved:{}\nMake sture to confirm previous job result and run after removing {}".format(session_id, saved_session_id, f))
+
+        f.write_text(
+            "build={}#test_session={}".format(build_name, session_id))
     except Exception as e:
         raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(
-            _session_file_path(build_name), SESSION_DIR_KEY)) from e
+            _session_file_path(), SESSION_DIR_KEY)) from e
 
 
 def remove_session(build_name: str) -> None:
     """
     Call it after closing a session
     """
-    if _session_file_path(build_name).exists():
-        _session_file_path(build_name).unlink()
+    if _session_file_path().exists():
+        _session_file_path().unlink()
 
 
 def clean_session_files(days_ago: int = 0) -> None:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -30,15 +30,15 @@ def _parse_session_file():
 
 
 def write_build(build_name: str) -> None:
+    if (_session_file_path().exists()):
+        exist_build_name = read_build()
+        if build_name != exist_build_name:
+            raise Exception(
+                "You're going to save another build name. Make sure <TODO>")
+
     try:
         if not _session_file_dir().exists():
             _session_file_dir().mkdir(parents=True, exist_ok=True)
-
-        if (_session_file_path().exists()):
-            exist_build_name = read_build()
-            if build_name != exist_build_name:
-                raise Exception(
-                    "You're going to save another build name. Make sure <TODO>")
 
         session = {}
         session["build"] = build_name
@@ -61,18 +61,18 @@ def read_build() -> str:
 
 
 def read_session(build_name: str) -> Optional[str]:
-    try:
-        f = _session_file_path()
-        if not f.exists():
-            return None
-        build, session_id = _parse_session_file()
+    f = _session_file_path()
+    if not f.exists():
+        return None
+    build, session_id = _parse_session_file()
 
-        if build != build_name:
-            raise Exception("TODO: set build name is different")
+    if build is None or build == "":
+        raise Exception("TODO: have to recrod build before")
 
-        return session_id
-    except Exception as e:
-        raise Exception("Can't read {}".format(f)) from e
+    if build != build_name:
+        raise Exception("TODO: set build name is different")
+
+    return session_id
 
 
 def write_session(build_name: str, session_id: str) -> None:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from pathlib import Path
 from typing import Optional
 import datetime
@@ -9,7 +10,7 @@ DEFAULT_SESSION_DIR = '~/.config/launchable/sessions/'
 
 
 def _session_file_dir() -> Path:
-    return Path(os.environ.get(SESSION_DIR_KEY) or DEFAULT_SESSION_DIR).expanduser()
+    return Path(os.environ.get(SESSION_DIR_KEY) or os.getcwd()).expanduser()
 
 
 def _session_file_path() -> Path:
@@ -41,6 +42,32 @@ def read_session(build_name: str) -> Optional[str]:
         return session_id
     except Exception as e:
         raise Exception("Can't read {}".format(f)) from e
+
+
+def write_build(build_name: str) -> None:
+    session = {}
+    session["build"] = build_name
+
+    try:
+        if not _session_file_dir().exists():
+            _session_file_dir().mkdir(parents=True, exist_ok=True)
+
+        with open(_session_file_path(), 'w') as session_file:
+            json.dump(session, session_file)
+
+    except Exception as e:
+        raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(
+            _session_file_path(), SESSION_DIR_KEY)) from e
+
+
+def read_build() -> str:
+    try:
+        with open(_session_file_path()) as session_file:
+            session = json.load(session_file)
+            return session["build"]
+
+    except Exception as e:
+        raise Exception("Can't load build name from test session file.") from e
 
 
 def write_session(build_name: str, session_id: str) -> None:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -19,7 +19,7 @@ def _session_file_path() -> Path:
 
 def _parse_session_file():
     try:
-        with open(_session_file_path()) as session_file:
+        with open(str(_session_file_path())) as session_file:
             session = json.load(session_file)
 
         return session.get("build"), session.get("test_session", "")
@@ -42,7 +42,7 @@ def write_build(build_name: str) -> None:
 
         session = {}
         session["build"] = build_name
-        with open(_session_file_path(), 'w') as session_file:
+        with open(str(_session_file_path()), 'w') as session_file:
             json.dump(session, session_file)
 
     except Exception as e:
@@ -52,7 +52,7 @@ def write_build(build_name: str) -> None:
 
 def read_build() -> str:
     try:
-        with open(_session_file_path()) as session_file:
+        with open(str(_session_file_path())) as session_file:
             session = json.load(session_file)
             return session.get("build")
 
@@ -96,7 +96,7 @@ def write_session(build_name: str, session_id: str) -> None:
         session = {}
         session["build"] = build_name
         session["test_session"] = session_id
-        with open(_session_file_path(), 'w') as session_file:
+        with open(str(_session_file_path()), 'w') as session_file:
             json.dump(session, session_file)
     except Exception as e:
         raise Exception("Can't write to {}. Perhaps set the {} environment variable to specify an alternative writable path?".format(

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -52,6 +52,12 @@ def write_build(build_name: str) -> None:
         if not _session_file_dir().exists():
             _session_file_dir().mkdir(parents=True, exist_ok=True)
 
+        if (_session_file_path().exists()):
+            exist_build_name = read_build()
+            if build_name != exist_build_name:
+                raise Exception(
+                    "You're going to save another build name. Make sure <TODO>")
+
         with open(_session_file_path(), 'w') as session_file:
             json.dump(session, session_file)
 

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import os
+import tempfile
 import unittest
 import types
 import responses  # type: ignore
@@ -9,7 +10,7 @@ import click.testing
 from click.testing import CliRunner
 
 from launchable.__main__ import main
-from launchable.utils.session import clean_session_files
+from launchable.utils.session import clean_session_files, SESSION_DIR_KEY
 from launchable.utils.http_client import get_base_url
 
 
@@ -27,6 +28,8 @@ class CliTestCase(unittest.TestCase):
     session = "builds/{}/test_sessions/{}".format(build_name, session_id)
 
     def setUp(self):
+        dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = dir
         self.maxDiff = None
 
         responses.add(responses.POST, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions".format(get_base_url(), self.organization, self.workspace, self.build_name),
@@ -48,6 +51,7 @@ class CliTestCase(unittest.TestCase):
 
     def tearDown(self):
         clean_session_files()
+        del os.environ[SESSION_DIR_KEY]
 
     def cli(self, *args, **kwargs) -> click.testing.Result:
         # for CliRunner kwargs

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -3,6 +3,7 @@ import responses  # type: ignore
 import gzip
 import sys
 import os
+from launchable.utils.session import write_build, write_session
 from tests.cli_test_case import CliTestCase
 from launchable.commands.record.tests import parse_launchable_timeformat, INVALID_TIMESTAMP
 from unittest import mock
@@ -17,6 +18,12 @@ class TestsTest(CliTestCase):
             '../../data/broken_xml/normal.xml').resolve())
         broken_xml = str(Path(__file__).parent.joinpath(
             '../../data/broken_xml/broken.xml').resolve())
+
+        # emulate record build
+        write_build(self.build_name)
+        # emulate subset
+        write_session(self.build_name, self.session)
+
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'file', normal_xml, broken_xml)
 
@@ -33,7 +40,7 @@ class TestsTest(CliTestCase):
 
         # normal.xml
         self.assertIn('open_class_user_test.rb', gzip.decompress(
-            responses.calls[2].request.body).decode())
+            responses.calls[1].request.body).decode())
 
     def test_parse_launchable_timeformat(self):
         t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,6 @@
 import os
+
+from launchable.utils.session import write_build, write_session
 from .cli_test_case import CliTestCase
 from pathlib import Path
 from unittest import mock
@@ -10,9 +12,14 @@ class PluginTest(CliTestCase):
         """
         Load plugins/foo.py as a plugin and execute its code
         """
+        # emulate record build
+        write_build(self.build_name)
+        # emulate subset
+        write_session(self.build_name, self.session)
+
         plugin_dir = Path(__file__).parent.joinpath('plugins').resolve()
         result = self.cli('--plugins', str(plugin_dir), 'record', 'tests',
-                          '--session', 'builds/dummy/test_sessions/123', 'foo', 'alpha', 'bravo', 'charlie')
+                          '--session', 'builds/123/test_sessions/16', 'foo', 'alpha', 'bravo', 'charlie')
         self.assertTrue("foo:alpha" in result.stdout, result.stdout)
         self.assertTrue("foo:bravo" in result.stdout, result.stdout)
         self.assertTrue("foo:charlie" in result.stdout, result.stdout)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,8 +14,6 @@ class PluginTest(CliTestCase):
         """
         # emulate record build
         write_build(self.build_name)
-        # emulate subset
-        write_session(self.build_name, self.session)
 
         plugin_dir = Path(__file__).parent.joinpath('plugins').resolve()
         result = self.cli('--plugins', str(plugin_dir), 'record', 'tests',

--- a/tests/test_runners/test_adb.py
+++ b/tests/test_runners/test_adb.py
@@ -3,7 +3,7 @@ import responses  # type: ignore
 import json
 import gzip
 import os
-from launchable.utils.session import read_session
+from launchable.utils.session import read_session, write_build
 from tests.cli_test_case import CliTestCase
 from unittest import mock
 
@@ -54,6 +54,9 @@ INSTRUMENTATION_CODE: -1
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('subset', '--target', '10%',
                           '--build', self.build_name, 'adb', input=self.subset_input)
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -5,6 +5,7 @@ import os
 import gzip
 from tests.cli_test_case import CliTestCase
 from unittest import mock
+from launchable.utils.session import write_build, write_session
 
 
 class AntTest(CliTestCase):
@@ -29,6 +30,9 @@ class AntTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_ant(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('record', 'tests',  '--session', self.session,
                           'ant', str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -4,7 +4,7 @@ import json
 import os
 import gzip
 import itertools
-from launchable.utils.session import read_session
+from launchable.utils.session import read_session, write_build, write_session
 from tests.cli_test_case import CliTestCase
 from unittest import mock
 
@@ -28,6 +28,9 @@ Loading: 2 packages loaded
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('subset', '--target', '10%',
                           '--build', self.build_name, 'bazel', input=self.subset_input)
         self.assertEqual(result.exit_code, 0)
@@ -42,6 +45,9 @@ Loading: 2 packages loaded
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
@@ -60,6 +66,9 @@ Loading: 2 packages loaded
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_with_build_event_json_file(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', '--build-event-json', str(self.test_files_dir.joinpath("build_event.json")), str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
@@ -78,6 +87,9 @@ Loading: 2 packages loaded
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_with_multiple_build_event_json_files(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', '--build-event-json', str(self.test_files_dir.joinpath("build_event.json")), '--build-event-json', str(self.test_files_dir.joinpath("build_event_rest.json")), str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
@@ -99,6 +111,9 @@ Loading: 2 packages loaded
         """
         Test recorded test results contain subset's test path
         """
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('subset', '--target', '10%',
                           '--build', self.build_name, 'bazel', input=self.subset_input)
 

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -47,14 +47,18 @@ Loading: 2 packages loaded
     def test_record_test(self):
         # emulate record build
         write_build(self.build_name)
+        # emulate subset
+        write_session(self.build_name, self.session)
 
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(read_session(self.build_name), self.session)
+
+        # delete session file after record tests command
+        self.assertEqual(read_session(self.build_name), None)
 
         payload = json.loads(gzip.decompress(
-            responses.calls[2].request.body).decode())
+            responses.calls[1].request.body).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_result.json'))
 
@@ -68,14 +72,17 @@ Loading: 2 packages loaded
     def test_record_test_with_build_event_json_file(self):
         # emulate record build
         write_build(self.build_name)
+        # emulate subset
+        write_session(self.build_name, self.session)
 
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', '--build-event-json', str(self.test_files_dir.joinpath("build_event.json")), str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(read_session(self.build_name), self.session)
+        # delete session file after record tests command
+        self.assertEqual(read_session(self.build_name), None)
 
         payload = json.loads(gzip.decompress(
-            responses.calls[2].request.body).decode())
+            responses.calls[1].request.body).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_with_build_event_json_result.json'))
 
@@ -89,14 +96,18 @@ Loading: 2 packages loaded
     def test_record_test_with_multiple_build_event_json_files(self):
         # emulate record build
         write_build(self.build_name)
+        # emulate subset
+        write_session(self.build_name, self.session)
 
         result = self.cli('record', 'tests', '--build',
                           self.build_name, 'bazel', '--build-event-json', str(self.test_files_dir.joinpath("build_event.json")), '--build-event-json', str(self.test_files_dir.joinpath("build_event_rest.json")), str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(read_session(self.build_name), self.session)
+
+        # delete session file after record tests command
+        self.assertEqual(read_session(self.build_name), None)
 
         payload = json.loads(gzip.decompress(
-            responses.calls[2].request.body).decode())
+            responses.calls[1].request.body).decode())
         expected = self.load_json_from_file(
             self.test_files_dir.joinpath('record_test_with_multiple_build_event_json_result.json'))
 

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -5,7 +5,7 @@ import gzip
 import os
 import sys
 import tempfile
-from launchable.utils.session import read_session
+from launchable.utils.session import read_session, write_build
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 from unittest import mock
@@ -18,6 +18,9 @@ class CTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_multiple_files(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(
@@ -77,6 +80,9 @@ class CTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_without_session(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('subset', '--target', '10%', '--build',
                           self.build_name, 'ctest', str(self.test_files_dir.joinpath("ctest_list.json")))
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -3,7 +3,7 @@ import responses  # type: ignore
 import json
 import gzip
 import os
-from launchable.utils.session import read_session
+from launchable.utils.session import read_session, write_build
 from tests.cli_test_case import CliTestCase
 from unittest import mock
 
@@ -15,6 +15,9 @@ class GoTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_with_session(self):
+        # emulate record build
+        write_build(self.build_name)
+
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\nok      github.com/launchableinc/rocket-car-gotest      0.268s"
         result = self.cli('subset', '--target', '10%',
                           '--session', self.session, 'go-test', input=pipe)
@@ -29,6 +32,9 @@ class GoTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_without_session(self):
+        # emulate record build
+        write_build(self.build_name)
+
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\nok      github.com/launchableinc/rocket-car-gotest      0.268s"
         result = self.cli('subset', '--target', '10%', '--build',
                           self.build_name, 'go-test', input=pipe)

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -3,6 +3,7 @@ from unittest import mock
 import responses  # type: ignore
 import json
 import gzip
+from launchable.utils.session import write_build
 from tests.cli_test_case import CliTestCase
 from launchable.utils.http_client import get_base_url
 import tempfile
@@ -19,6 +20,9 @@ class GradleTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_without_session(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
                           json={
                               "testPaths": [[{'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'name': 'com.launchableinc.rocket_car_gradle.sub.App3Test'}], [{'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]],
@@ -40,6 +44,9 @@ class GradleTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_rest(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace), json={
             "testPaths": [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]],
             "rest": [[{'name': 'com.launchableinc.rocket_car_gradle.sub.App3Test'}]],
@@ -65,6 +72,9 @@ class GradleTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_split(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace), json={
             "testPaths": [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]],
             "rest": [[{'name': 'com.launchableinc.rocket_car_gradle.sub.App3Test'}]],
@@ -86,6 +96,9 @@ class GradleTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_split_subset(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/456/slice".format(get_base_url(), self.organization, self.workspace),
                           json={'testPaths': [[{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.App2Test'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.AppTest'}], [{'type': 'class', 'name': 'com.launchableinc.rocket_car_gradle.utils.UtilsTest'}]], "rest": [[{'name': 'com.launchableinc.rocket_car_gradle.sub.App3Test'}]]}, status=200)
 

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -5,6 +5,7 @@ import gzip
 import os
 from pathlib import Path
 from unittest import mock
+from launchable.utils.session import write_build
 from tests.cli_test_case import CliTestCase
 from launchable.utils.http_client import get_base_url
 import tempfile
@@ -34,9 +35,12 @@ class JestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('subset', '--target', '10%',
                           '--build', self.build_name, '--base', os.getcwd(), 'jest', input=self.subset_input)
-        print(result.output)
+
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(
@@ -49,6 +53,9 @@ class JestTest(CliTestCase):
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     @ignore_warnings
     def test_subset_split(self):
+        # emulate record build
+        write_build(self.build_name)
+
         test_path = Path(
             "{}/components/layouts/modal/snapshot.test.tsx".format(os.getcwd()))
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace), json={
@@ -72,6 +79,9 @@ class JestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test(self):
+        # emulate record build
+        write_build(self.build_name)
+
         result = self.cli('record', 'tests', '--build', self.build_name,
                           'jest', str(self.test_files_dir.joinpath("junit.xml")))
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -5,7 +5,7 @@ import gzip
 import os
 import sys
 import tempfile
-from launchable.utils.session import write_build
+from launchable.utils.session import write_build, write_session
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 from unittest import mock
@@ -89,13 +89,19 @@ class RawTest(CliTestCase):
                     '  ]',
                     '}',
                 ]) + '\n')
+
+             # emulate record build
+            write_build(self.build_name)
+            # emulate subset
+            write_session(self.build_name, self.session)
+
             result = self.cli('record', 'tests', '--build',
                               self.build_name, 'raw', test_path_file, mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
 
             # Check request body
             payload = json.loads(gzip.decompress(
-                responses.calls[2].request.body).decode())
+                responses.calls[1].request.body).decode())
             self.assert_json_orderless_equal(payload, {
                 'events': [
                     {

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -5,7 +5,7 @@ import gzip
 import os
 import sys
 import tempfile
-from launchable.utils.session import read_session
+from launchable.utils.session import write_build
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 from unittest import mock
@@ -15,6 +15,9 @@ class RawTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):
+        # emulate record build
+        write_build(self.build_name)
+
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,14 +1,20 @@
 from unittest import TestCase, mock
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, parse_session
+from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, parse_session, SESSION_DIR_KEY
 import os
+import tempfile
 
 
 class SessionTestClass(TestCase):
     build_name = '123'
     session_id = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/13'
 
+    def setUp(self):
+        dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = dir
+
     def tearDown(self):
         clean_session_files()
+        del os.environ[SESSION_DIR_KEY]
 
     def test_write_read_remove(self):
         write_session(self.build_name, self.session_id)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -28,6 +28,7 @@ class SessionTestClass(TestCase):
             write_build('234')
 
     def test_write_read_remove(self):
+        write_build(self.build_name)
         write_session(self.build_name, self.session_id)
         self.assertEqual(read_session(self.build_name), self.session_id)
 
@@ -35,6 +36,7 @@ class SessionTestClass(TestCase):
         self.assertEqual(read_session(self.build_name), None)
 
     def test_other_build(self):
+        write_build(self.build_name)
         write_session(self.build_name, self.session_id)
 
         next_build_name = '124'
@@ -47,6 +49,7 @@ class SessionTestClass(TestCase):
         # mock record tests command to delete session file
         clean_session_files()
 
+        write_build(next_build_name)
         write_session(next_build_name, next_session_id)
         self.assertEqual(read_session(next_build_name), next_session_id)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -20,6 +20,13 @@ class SessionTestClass(TestCase):
         write_build(self.build_name)
         self.assertEqual(read_build(), self.build_name)
 
+        write_build(self.build_name)
+        self.assertEqual(read_build(), self.build_name)
+
+        # got wrror when test session file that another build name is already exists
+        with self.assertRaises(Exception):
+            write_build('234')
+
     def test_write_read_remove(self):
         write_session(self.build_name, self.session_id)
         self.assertEqual(read_session(self.build_name), self.session_id)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -28,10 +28,16 @@ class SessionTestClass(TestCase):
 
         next_build_name = '124'
         next_session_id = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/14'
-        write_session(next_build_name, next_session_id)
 
+        # Can't write session if the session file already exists
+        with self.assertRaises(Exception):
+            write_session(next_build_name, next_session_id)
+
+        # mock record tests command to delete session file
+        clean_session_files()
+
+        write_session(next_build_name, next_session_id)
         self.assertEqual(read_session(next_build_name), next_session_id)
-        self.assertEqual(read_session(self.build_name), self.session_id)
 
     def test_read_before_write(self):
         self.assertEqual(read_session(self.build_name), None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,7 +32,7 @@ class SessionTestClass(TestCase):
         write_session(self.build_name, self.session_id)
         self.assertEqual(read_session(self.build_name), self.session_id)
 
-        remove_session(self.build_name)
+        remove_session()
         self.assertEqual(read_session(self.build_name), None)
 
     def test_other_build(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, mock
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, _get_session_id, parse_session
+from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, parse_session
 import os
 
 
@@ -33,15 +33,6 @@ class SessionTestClass(TestCase):
     def test_different_pid(self):
         # TODO
         pass
-
-    def test_get_session_id(self):
-        id = _get_session_id()
-
-        with mock.patch.dict(os.environ, {"CIRCLECI": "TRUE", "CIRCLE_WORKFLOW_ID": "abc-123"}):
-            id_in_circleci = _get_session_id()
-
-            self.assertEqual(id_in_circleci, "abc-123")
-            self.assertNotEqual(id, id_in_circleci)
 
     def test_parse_session(self):
         session = "builds/build-name/test_sessions/123"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, mock
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, parse_session, SESSION_DIR_KEY
+from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, parse_session, write_build, read_build, SESSION_DIR_KEY
 import os
 import tempfile
 
@@ -15,6 +15,10 @@ class SessionTestClass(TestCase):
     def tearDown(self):
         clean_session_files()
         del os.environ[SESSION_DIR_KEY]
+
+    def test_write_and_read_build(self):
+        write_build(self.build_name)
+        self.assertEqual(read_build(), self.build_name)
 
     def test_write_read_remove(self):
         write_session(self.build_name, self.session_id)


### PR DESCRIPTION
We had used a UNIX process id as a hash key to saving a test session. But we sometimes couldn't get the same UNIX process id through a CI job in some environments. IOW, a UNIX process id was changed each step in a certain environment. 
Also, the cli has been created a new test session file when the UNIX process id changes, missing introduce the cli, don't need to create a new one but create and etc.

![image](https://user-images.githubusercontent.com/536667/139806694-f35fea07-93ee-4817-b2c3-eb9a3620a6a4.png)


So I changed to stop using a UNIX process id and to use `<SESSION DIR>/.launchable` file to avoid miss integration.

If the user tries to create a new build after didn't run record tests due to an error or misconfiguration, the user will get an error.
It may not have been a problem in the previous version, but since this version, it is an error to make it easier to detect misconfigurations.

![image](https://user-images.githubusercontent.com/536667/139806801-da6bb85c-b18a-4342-84a5-707a82fb6815.png)

And tests of the cli has deleted test session files that was created in CI pipeline, so I changed to avoid deleting test session file.
