### PR TITLE
Fix testpath tests on macOS

### DIFF
--- a/launchable/testpath.py
+++ b/launchable/testpath.py
@@ -85,6 +85,17 @@ def _encode_str(s: str) -> str:
     return s.replace('%', '%25').replace('=', '%3D').replace('#', '%23').replace('&', '%26')
 
 
+def _relative_to(p: pathlib.Path, base: str) -> pathlib.Path:
+    if sys.version_info[0:2] >= (3, 6):
+        return p.resolve(strict=False).relative_to(base)
+    else:
+        try:
+            resolved = p.resolve()
+        except:
+            resolved = p
+        return resolved.relative_to(base)
+
+
 class FilePathNormalizer:
     """Normalize file paths based on the Git repository root
 
@@ -109,14 +120,7 @@ class FilePathNormalizer:
             return p
 
         if self._base_path:
-            if sys.version_info[0:2] >= (3, 6):
-                return p.resolve(strict=False).relative_to(self._base_path)
-            else:
-                try:
-                    resolved = p.resolve()
-                except:
-                    resolved = p
-                return resolved.relative_to(self._base_path)
+            return _relative_to(p, self._base_path)
 
         if self._no_base_path_inference:
             return p
@@ -125,14 +129,7 @@ class FilePathNormalizer:
             self._inferred_base_path = self._auto_infer_base_path(p)
 
         if self._inferred_base_path:
-            if sys.version_info[0:2] >= (3, 6):
-                return p.resolve(strict=False).relative_to(self._inferred_base_path)
-            else:
-                try:
-                    resolved = p.resolve()
-                except:
-                    resolved = p
-                return resolved.relative_to(self._inferred_base_path)
+            return _relative_to(p, self._inferred_base_path)
 
         return p
 


### PR DESCRIPTION
Some tests in `test_testpath.py` failed on macOS. This is because `tempfile` creates files into `/var/folders/…` but `/var` is a simlink to `/private/var` on macOS, and `git rev-parse --show-toplevel` returns resolved `/private/var` paths. To resolve it, I added `.resolve()` into `testpath.py`. I think it will help in some other situations.

```shell
ERROR: test_inference_git_submodule (tests.test_testpath.TestFilePathNormalizer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ninjin/src/github.com/launchableinc/cli/tests/test_testpath.py", line 150, in test_inference_git_submodule
    self.assertEqual(relpath, n.relativize(abspath))
  File "/Users/ninjin/src/github.com/launchableinc/cli/launchable/testpath.py", line 105, in relativize
    return str(self._relativize(pathlib.Path(os.path.normpath(p))))
  File "/Users/ninjin/src/github.com/launchableinc/cli/launchable/testpath.py", line 121, in _relativize
    return p.relative_to(self._inferred_base_path)
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 907, in relative_to
    raise ValueError("{!r} does not start with {!r}"
ValueError: '/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/tmp5hdanhgv/gitrepo/submod/foo/bar/baz' does not start with '/private/var/folders/bn/lp8m234j6dj_d22z2cntkjn40000gn/T/tmp
```