### PR TITLE
disable traceback without --log-level debug

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -3,6 +3,7 @@ import click
 import importlib
 import importlib.util
 import logging
+import sys
 from os.path import dirname, basename, join
 from glob import glob
 from .commands.record import record
@@ -31,6 +32,8 @@ from .utils import logger
 def main(log_level, plugin_dir):
     level = logger.get_log_level(log_level)
     logging.basicConfig(level=level)
+    if level > logging.DEBUG:
+        sys.tracebacklimit = 0
 
     # load all test runners
     for f in glob(join(dirname(__file__), 'test_runners', "*.py")):


### PR DESCRIPTION
Before this changes if the cli catch exception, the cli print Traceback like below
Traceback is usually useful however, the user wants to see only error messages that we output.
Also, the all users aren't familiar with Python and Python traceback so traceback sometimes noisy for users.
```
$ find -f tests/**/test_*.py  | launchable --log-level debug subset --build launchableinc-cli-test-11 --target 10% --rest rest.txt file
Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/utils/session.py", line 38, in read_session
    raise Exception("Build name is different between input:{} and saved:{}. Previous job might be failed.\nPlease confirm previous job result and run after removing {}".format(
Exception: Build name is different between input:launchableinc-cli-test-11 and saved:launchableinc-cli-test-10. Previous job might be failed.
Please confirm previous job result and run after removing /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/.brew/bin/launchable", line 33, in <module>
    sys.exit(load_entry_point('launchable', 'console_scripts', 'launchable')())
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1256, in invoke
    Command.invoke(self, ctx)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/subset.py", line 97, in subset
    session_id = find_or_create_session(context, session, build_name, flavor)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 23, in find_or_create_session
    session_id = read_session(build_name)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/utils/session.py", line 43, in read_session
    raise Exception("Can't read {}".format(f)) from e
Exception: Can't read /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable
```

So I changed to show traceback when the user only set `--log-level debug` 

If the user doesn't set `--log-level debug` option, the cli prints only error messages that we set 

```
$ find -f tests/**/test_*.py  | launchable subset --build launchableinc-cli-test-11 --target 10% --rest rest.txt file
Exception: Build name is different between input:launchableinc-cli-test-11 and saved:launchableinc-cli-test-10. Previous job might be failed.
Please confirm previous job result and run after removing /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable

The above exception was the direct cause of the following exception:

Exception: Can't read /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable
```

When the user set `--log-level debug`, the cli prints error messages with Traceback
```
$ find -f tests/**/test_*.py  | launchable --log-level debug subset --build launchableinc-cli-test-11 --target 10% --rest rest.txt file
Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/utils/session.py", line 38, in read_session
    raise Exception("Build name is different between input:{} and saved:{}. Previous job might be failed.\nPlease confirm previous job result and run after removing {}".format(
Exception: Build name is different between input:launchableinc-cli-test-11 and saved:launchableinc-cli-test-10. Previous job might be failed.
Please confirm previous job result and run after removing /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/.brew/bin/launchable", line 33, in <module>
    sys.exit(load_entry_point('launchable', 'console_scripts', 'launchable')())
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1256, in invoke
    Command.invoke(self, ctx)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/yabuki-ryosuke/Library/Python/3.9/lib/python/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/subset.py", line 97, in subset
    session_id = find_or_create_session(context, session, build_name, flavor)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 23, in find_or_create_session
    session_id = read_session(build_name)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/utils/session.py", line 43, in read_session
    raise Exception("Can't read {}".format(f)) from e
Exception: Can't read /Users/yabuki-ryosuke/.config/launchable/sessions/.launchable
```