### PR TITLE
Specify `more_itertools` version lower than v8.6 in Python 3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,9 @@ install_requires =
     requests
     junitparser>=2.0.0
     setuptools
-    more_itertools>=7.1.0
+    more_itertools>=7.1.0;python_version<='3.6'
+# more_itertools dropped python 3.5 support since v8.6
+    more_itertools>=7.1.0,<8.6;python_version<'3.6'
     wmi;platform_system=='Windows'
     python-dateutil
     tabulate

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     requests
     junitparser>=2.0.0
     setuptools
-    more_itertools>=7.1.0;python_version<='3.6'
+    more_itertools>=7.1.0;python_version>='3.6'
 # more_itertools dropped python 3.5 support since v8.6
     more_itertools>=7.1.0,<8.6;python_version<'3.6'
     wmi;platform_system=='Windows'


### PR DESCRIPTION
[more_itertools](https://more-itertools.readthedocs.io/en/stable/versions.html) dropped python 3.5 support since v8.6.