### PR TITLE
Specify `requests` version in Python 3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     requests<2.26;python_version<'3.6'
     junitparser>=2.0.0
     setuptools
-    more_itertools>=7.1.0
+    more_itertools>=7.1.0;python_version>='3.6'
 # more_itertools dropped python 3.5 support since v8.6
     more_itertools>=7.1.0,<8.6;python_version<'3.6'
     wmi;platform_system=='Windows'

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 packages = find:
 install_requires =
     click~=7.0
-    requests
+    requests;python_version>='3.6'
 # requests dropped python 3.5 support since v2.26
     requests<2.26;python_version<'3.6'
     junitparser>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     requests<2.26;python_version<'3.6'
     junitparser>=2.0.0
     setuptools
-    more_itertools>=7.1.0;python_version>='3.6'
+    more_itertools>=7.1.0
 # more_itertools dropped python 3.5 support since v8.6
     more_itertools>=7.1.0,<8.6;python_version<'3.6'
     wmi;platform_system=='Windows'

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ packages = find:
 install_requires =
     click~=7.0
     requests
+# requests dropped python 3.5 support since v2.26
+    requests<2.26;python_version<'3.6'
     junitparser>=2.0.0
     setuptools
     more_itertools>=7.1.0;python_version>='3.6'


### PR DESCRIPTION
Since https://github.com/launchableinc/cli/pull/331, I read up on all dependency module's changelogs in `setup.cfg`. As a result, I found `requests` 2.26 and `click` 8.0 dropped Python 3.5. We already specified `~= 7.0` to `click`. So, I specified `requests<2.26` in Python 3.5.