### PR TITLE
create temp dir and use it for session dir in tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Install specific dependencies in 3.6
+      if: matrix.python-version == '3.6'
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv==2021.11.5
+        pipenv install --dev --python ${{ matrix.python-version }}
     - name: Install dependencies
+      if: matrix.python-version != '3.6'
       run: |
         python -m pip install --upgrade pip
         pip install pipenv

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -7,7 +7,7 @@ import responses  # type: ignore
 import tempfile
 import click.testing
 from click.testing import CliRunner
-
+import shutil
 from launchable.__main__ import main
 from launchable.utils.session import SESSION_DIR_KEY, clean_session_files
 from launchable.utils.http_client import get_base_url
@@ -27,8 +27,8 @@ class CliTestCase(unittest.TestCase):
     session = "builds/{}/test_sessions/{}".format(build_name, session_id)
 
     def setUp(self):
-        dir = tempfile.mkdtemp()
-        os.environ[SESSION_DIR_KEY] = dir
+        self.dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = self.dir
 
         self.maxDiff = None
 
@@ -52,6 +52,7 @@ class CliTestCase(unittest.TestCase):
     def tearDown(self):
         clean_session_files()
         del os.environ[SESSION_DIR_KEY]
+        shutil.rmtree(self.dir)
 
     def cli(self, *args, **kwargs) -> click.testing.Result:
         # for CliRunner kwargs

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -4,12 +4,12 @@ import os
 import unittest
 import types
 import responses  # type: ignore
-
+import tempfile
 import click.testing
 from click.testing import CliRunner
 
 from launchable.__main__ import main
-from launchable.utils.session import clean_session_files
+from launchable.utils.session import SESSION_DIR_KEY, clean_session_files
 from launchable.utils.http_client import get_base_url
 
 
@@ -27,6 +27,9 @@ class CliTestCase(unittest.TestCase):
     session = "builds/{}/test_sessions/{}".format(build_name, session_id)
 
     def setUp(self):
+        dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = dir
+
         self.maxDiff = None
 
         responses.add(responses.POST, "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions".format(get_base_url(), self.organization, self.workspace, self.build_name),
@@ -48,6 +51,7 @@ class CliTestCase(unittest.TestCase):
 
     def tearDown(self):
         clean_session_files()
+        del os.environ[SESSION_DIR_KEY]
 
     def cli(self, *args, **kwargs) -> click.testing.Result:
         # for CliRunner kwargs

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@ import tempfile
 from unittest import TestCase, mock
 from launchable.utils.session import SESSION_DIR_KEY, write_session, read_session, remove_session, clean_session_files, _get_session_id, parse_session
 import os
+import shutil
 
 
 class SessionTestClass(TestCase):
@@ -9,12 +10,13 @@ class SessionTestClass(TestCase):
     session_id = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/13'
 
     def setUp(self):
-        dir = tempfile.mkdtemp()
-        os.environ[SESSION_DIR_KEY] = dir
+        self.dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = self.dir
 
     def tearDown(self):
         clean_session_files()
         del os.environ[SESSION_DIR_KEY]
+        shutil.rmtree(self.dir)
 
     def test_write_read_remove(self):
         write_session(self.build_name, self.session_id)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,6 @@
+import tempfile
 from unittest import TestCase, mock
-from launchable.utils.session import write_session, read_session, remove_session, clean_session_files, _get_session_id, parse_session
+from launchable.utils.session import SESSION_DIR_KEY, write_session, read_session, remove_session, clean_session_files, _get_session_id, parse_session
 import os
 
 
@@ -7,8 +8,13 @@ class SessionTestClass(TestCase):
     build_name = '123'
     session_id = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/13'
 
+    def setUp(self):
+        dir = tempfile.mkdtemp()
+        os.environ[SESSION_DIR_KEY] = dir
+
     def tearDown(self):
         clean_session_files()
+        del os.environ[SESSION_DIR_KEY]
 
     def test_write_read_remove(self):
         write_session(self.build_name, self.session_id)


### PR DESCRIPTION
A session file that was created in this repo's CI was deleted by tests (by clean_test_session_files method)
Then, two test sessions were created 1) subset command, 2) record test command but it's not intented.

So I create a temp dir  and use it in test to avoid deleting a session file that this repository created in CI.