### PR TITLE
Add dependency caching on Github Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pipenv'
+        cache: 'pip'
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pipenv'
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Recently, GitHub Actions started to support dependency caching for `pip` and `pipenv` https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/ .