### PR TITLE
Add the dry-run option globally

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -35,7 +35,8 @@ from .utils import logger
          'GET requests without payload data or side effects could be sent.',
     is_flag=True,
 )
-def main(log_level, plugin_dir, dry_run):
+@click.pass_context
+def main(ctx, log_level, plugin_dir, dry_run):
     level = logger.get_log_level(log_level)
     logging.basicConfig(level=level)
 
@@ -53,6 +54,10 @@ def main(log_level, plugin_dir, dry_run):
                 "launchable.plugins.{}".format(basename(f)[:-3]), f)
             plugin = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(plugin)
+
+    ctx.obj = {
+        "dry_run": dry_run,
+    }
 
 
 main.add_command(record)

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -28,7 +28,14 @@ from .utils import logger
     help='Directory to load plugins from',
     type=click.Path(exists=True, file_okay=False)
 )
-def main(log_level, plugin_dir):
+@click.option(
+    '--dry-run',
+    'dry_run',
+    help='Dry-run mode. No data is sent to the server. However, sometimes '
+         'GET requests without payload data or side effects could be sent.',
+    is_flag=True,
+)
+def main(log_level, plugin_dir, dry_run):
     level = logger.get_log_level(log_level)
     logging.basicConfig(level=level)
 

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -13,6 +13,11 @@ from .commands.verify import verify
 from .utils import logger
 
 
+class AppBase(object):
+    def __init__(self, dry_run: bool):
+        self.dry_run = dry_run
+
+
 @click.group()
 @click.version_option(version=__version__, prog_name='launchable-cli')
 @click.option(
@@ -63,9 +68,7 @@ def main(ctx, log_level, plugin_dir, dry_run):
             plugin = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(plugin)
 
-    ctx.obj = {
-        "dry_run": dry_run,
-    }
+    ctx.obj = AppBase(dry_run=dry_run)
 
 
 main.add_command(record)

--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -32,12 +32,20 @@ from .utils import logger
     '--dry-run',
     'dry_run',
     help='Dry-run mode. No data is sent to the server. However, sometimes '
-         'GET requests without payload data or side effects could be sent.',
+         'GET requests without payload data or side effects could be sent.'
+         'note: Since the dry run log is output together with the AUDIT log, '
+         'even if the log-level is set to warning or higher, the log level will '
+         'be forced to be set to AUDIT.',
     is_flag=True,
 )
 @click.pass_context
 def main(ctx, log_level, plugin_dir, dry_run):
     level = logger.get_log_level(log_level)
+    # In the case of dry-run, it is forced to set the level below the AUDIT.
+    # This is because the dry-run log will be output along with the audit log.
+    if dry_run and level > logger.LOG_LEVEL_AUDIT:
+        level = logger.LOG_LEVEL_AUDIT
+
     logging.basicConfig(level=level)
 
     # load all test runners

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -121,7 +121,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
             "commitHashes": commitHashes
         }
 
-        client = LaunchableClient()
+        client = LaunchableClient(dry_run=ctx.obj["dry_run"])
 
         res = client.request("post", "builds", payload=payload)
         res.raise_for_status()

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -121,7 +121,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
             "commitHashes": commitHashes
         }
 
-        client = LaunchableClient(dry_run=ctx.obj["dry_run"])
+        client = LaunchableClient(dry_run=ctx.obj.dry_run)
 
         res = client.request("post", "builds", payload=payload)
         res.raise_for_status()

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -34,7 +34,7 @@ def commit(ctx, source, executable, max_days, scrub_pii):
 
     if executable == 'jar':
         try:
-            exec_jar(source, max_days, ctx.obj["dry_run"])
+            exec_jar(source, max_days, ctx.obj.dry_run)
         except Exception as e:
             if os.getenv(REPORT_ERROR_KEY):
                 raise e

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -34,7 +34,8 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     cls=KeyValueType,
     multiple=True,
 )
-def session(build_name: str, save_session_file: bool, print_session: bool = True, flavor=[]):
+@click.pass_context
+def session(ctx, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[]):
     """
     print_session is for barckward compatibility.
     If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.
@@ -45,7 +46,7 @@ def session(build_name: str, save_session_file: bool, print_session: bool = True
     for (k, v) in flavor:
         flavor_dict[k] = v
 
-    client = LaunchableClient()
+    client = LaunchableClient(dry_run=ctx.obj["dry_run"])
     try:
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -46,7 +46,7 @@ def session(ctx, build_name: str, save_session_file: bool, print_session: bool =
     for (k, v) in flavor:
         flavor_dict[k] = v
 
-    client = LaunchableClient(dry_run=ctx.obj["dry_run"])
+    client = LaunchableClient(dry_run=ctx.obj.dry_run)
     try:
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -205,7 +205,8 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
 
         def run(self):
             count = 0  # count number of test cases sent
-            client = LaunchableClient(test_runner=context.invoked_subcommand)
+            client = LaunchableClient(test_runner=context.invoked_subcommand,
+                                      dry_run=context.obj["dry_run"])
 
             def testcases(reports: List[str]) -> Generator[CaseEventType, None, None]:
                 exceptions = []

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -165,7 +165,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         def check_timestamp(self, enable: bool):
             self._check_timestamp = enable
 
-        def __init__(self):
+        def __init__(self, dry_run: bool = False):
             self.reports = []
             self.skipped_reports = []
             self.path_builder = CaseEvent.default_path_builder(
@@ -173,6 +173,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             self.junitxml_parse_func = None
             self.check_timestamp = True
             self.base_path = base_path
+            self.dry_run = dry_run
 
         def make_file_path_component(self, filepath) -> TestPathComponent:
             """Create a single TestPathComponent from the given file path"""
@@ -206,7 +207,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         def run(self):
             count = 0  # count number of test cases sent
             client = LaunchableClient(test_runner=context.invoked_subcommand,
-                                      dry_run=context.obj["dry_run"])
+                                      dry_run=context.obj.dry_run)
 
             def testcases(reports: List[str]) -> Generator[CaseEventType, None, None]:
                 exceptions = []
@@ -325,7 +326,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
             click.echo(
                 "\nRun `launchable inspect tests --test-session-id {}` to view uploaded test results".format(test_session_id))
 
-    context.obj = RecordTests()
+    context.obj = RecordTests(dry_run=context.obj.dry_run)
 
 
 # if we fail to determine the timestamp of the build, we err on the side of collecting more test reports

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -1,12 +1,11 @@
 import glob
 from launchable.utils.authentication import get_org_workspace
-from launchable.commands.record.build import build
 import os
 import traceback
 import click
 from junitparser import JUnitXml, TestSuite, TestCase  # type: ignore
 import xml.etree.ElementTree as ET
-from typing import Callable, Dict, Generator,  List, Optional
+from typing import Callable, Dict, Generator, List, Optional
 from more_itertools import ichunked
 from .case_event import CaseEvent, CaseEventType
 from ...utils.http_client import LaunchableClient

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -165,7 +165,7 @@ def tests(context, base_path: str, session: Optional[str], build_name: Optional[
         def check_timestamp(self, enable: bool):
             self._check_timestamp = enable
 
-        def __init__(self, dry_run: bool = False):
+        def __init__(self, dry_run=False):
             self.reports = []
             self.skipped_reports = []
             self.path_builder = CaseEvent.default_path_builder(

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -36,13 +36,13 @@ from .test_path_writer import TestPathWriter
     metavar="DIR",
 )
 @click.pass_context
-def split_subset(context, subset_id: str,  bin, rest: str, base_path: str):
+def split_subset(context, subset_id: str, bin, rest: str, base_path: str):
 
     TestPathWriter.base_path = base_path
 
     class SplitSubset(TestPathWriter):
-        def __init__(self):
-            super(SplitSubset, self).__init__()
+        def __init__(self, dry_run: bool = False):
+            super(SplitSubset, self).__init__(dry_run=dry_run)
 
         def run(self):
             index = bin[0]
@@ -64,7 +64,7 @@ def split_subset(context, subset_id: str,  bin, rest: str, base_path: str):
             try:
                 client = LaunchableClient(
                     test_runner=context.invoked_subcommand,
-                    dry_run=context.obj["dry_run"])
+                    dry_run=context.obj.dry_run)
 
                 payload = {
                     "sliceCount": count,
@@ -101,4 +101,4 @@ def split_subset(context, subset_id: str,  bin, rest: str, base_path: str):
 
             self.print(output)
 
-    context.obj = SplitSubset()
+    context.obj = SplitSubset(dry_run=context.obj.dry_run)

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -63,7 +63,8 @@ def split_subset(context, subset_id: str,  bin, rest: str, base_path: str):
 
             try:
                 client = LaunchableClient(
-                    test_runner=context.invoked_subcommand)
+                    test_runner=context.invoked_subcommand,
+                    dry_run=context.obj["dry_run"])
 
                 payload = {
                     "sliceCount": count,

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -3,7 +3,7 @@ from launchable.utils.session import parse_session
 import click
 import os
 import sys
-from os.path import join, relpath, normpath
+from os.path import join, relpath
 import pathlib
 import glob
 from typing import Callable, Union, Optional, List

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -238,7 +238,8 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             else:
                 try:
                     client = LaunchableClient(
-                        test_runner=context.invoked_subcommand)
+                        test_runner=context.invoked_subcommand,
+                        dry_run=context.obj["dry_run"])
 
                     # temporarily extend the timeout because subset API response has become slow
                     # TODO: remove this line when API response return respose within 60 sec

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -112,7 +112,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
         # output_handler: Callable[[
         #   List[TestPathLike], List[TestPathLike]], None]
 
-        def __init__(self, dry_run: bool = False):
+        def __init__(self, dry_run=False):
             self.test_paths = []
             self.output_handler = self._default_output_handler
             super(Optimize, self).__init__(dry_run=dry_run)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -112,10 +112,10 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
         # output_handler: Callable[[
         #   List[TestPathLike], List[TestPathLike]], None]
 
-        def __init__(self):
+        def __init__(self, dry_run: bool = False):
             self.test_paths = []
             self.output_handler = self._default_output_handler
-            super(Optimize, self).__init__()
+            super(Optimize, self).__init__(dry_run=dry_run)
 
         def _default_output_handler(self, output, rests):
             # regardless of whether we managed to talk to the service we produce
@@ -239,7 +239,7 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
                 try:
                     client = LaunchableClient(
                         test_runner=context.invoked_subcommand,
-                        dry_run=context.obj["dry_run"])
+                        dry_run=context.obj.dry_run)
 
                     # temporarily extend the timeout because subset API response has become slow
                     # TODO: remove this line when API response return respose within 60 sec
@@ -302,4 +302,4 @@ def subset(context, target, session: Optional[str], base_path: Optional[str], bu
             click.echo(
                 "\nRun `launchable inspect subset --subset-id {}` to view full subset details".format(subset_id), err=True)
 
-    context.obj = Optimize()
+    context.obj = Optimize(dry_run=context.obj.dry_run)

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -7,7 +7,7 @@ from os.path import join
 class TestPathWriter(object):
     base_path = Optional[str]
 
-    def __init__(self, dry_run: bool = False):
+    def __init__(self, dry_run=False):
         self._formatter = TestPathWriter.default_formatter
         self._separator = "\n"
         self.dry_run = dry_run

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -7,9 +7,10 @@ from os.path import join
 class TestPathWriter(object):
     base_path = Optional[str]
 
-    def __init__(self):
+    def __init__(self, dry_run: bool = False):
         self._formatter = TestPathWriter.default_formatter
         self._separator = "\n"
+        self.dry_run = dry_run
 
     @classmethod
     def default_formatter(cls, x: TestPath):

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -41,7 +41,7 @@ class TestPathWriter(object):
     def separator(self, s: str):
         self._separator = s
 
-    def write_file(self, file: str, test_paths:  List[TestPath]):
+    def write_file(self, file: str, test_paths: List[TestPath]):
         open(file, "w+", encoding="utf-8").write(
             self.separator.join(self.formatter(t) for t in test_paths))
 

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -22,6 +22,7 @@ def get_base_url():
 class LaunchableClient:
     def __init__(self, base_url: str = "", session: Session = None, test_runner: str = "", dry_run: bool = False):
         self.base_url = base_url or get_base_url()
+        self.dry_run = dry_run
 
         if session is None:
             strategy = Retry(
@@ -51,7 +52,11 @@ class LaunchableClient:
 
         headers = self._headers(compress)
 
-        Logger().audit(AUDIT_LOG_FORMAT.format(method, url, headers, payload))
+        Logger().audit(AUDIT_LOG_FORMAT.format(
+            "(dry run) " if self.dry_run else "", method, url, headers, payload))
+
+        if self.dry_run and method.upper() not in ["HEAD", "GET"]:
+            pass
 
         data = _build_data(payload, compress)
 

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -20,7 +20,7 @@ def get_base_url():
 
 
 class LaunchableClient:
-    def __init__(self, base_url: str = "", session: Session = None, test_runner: str = ""):
+    def __init__(self, base_url: str = "", session: Session = None, test_runner: str = "", dry_run: bool = False):
         self.base_url = base_url or get_base_url()
 
         if session is None:

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -65,7 +65,7 @@ class LaunchableClient:
         headers = self._headers(compress)
 
         Logger().audit(AUDIT_LOG_FORMAT.format(
-            "(dry run) " if self.dry_run else "", method, url, headers, payload))
+            "(DRY RUN) " if self.dry_run else "", method, url, headers, payload))
 
         if self.dry_run and method.upper() not in ["HEAD", "GET"]:
             return DryRunResponse(status_code=200, payload={

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -69,9 +69,10 @@ class LaunchableClient:
 
         if self.dry_run and method.upper() not in ["HEAD", "GET"]:
             return DryRunResponse(status_code=200, payload={
-                "id": "dry-run-session",
-                "testPaths": [],
-                "rest": []})
+                "id": "dry-run-session",  # `record session` use this
+                "testPaths": [],  # `split_subset` use this
+                "rest": [],  # `split_subset` use this
+            })
 
         data = _build_data(payload, compress)
 

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -19,6 +19,18 @@ def get_base_url():
     return os.getenv(BASE_URL_KEY) or DEFAULT_BASE_URL
 
 
+class DryRunResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self.payload = payload
+
+    def raise_for_status(self):
+        return
+
+    def json(self):
+        return self.payload
+
+
 class LaunchableClient:
     def __init__(self, base_url: str = "", session: Session = None, test_runner: str = "", dry_run: bool = False):
         self.base_url = base_url or get_base_url()
@@ -56,7 +68,10 @@ class LaunchableClient:
             "(dry run) " if self.dry_run else "", method, url, headers, payload))
 
         if self.dry_run and method.upper() not in ["HEAD", "GET"]:
-            pass
+            return DryRunResponse(status_code=200, payload={
+                "id": "dry-run-session",
+                "testPaths": [],
+                "rest": []})
 
         data = _build_data(payload, compress)
 

--- a/launchable/utils/logger.py
+++ b/launchable/utils/logger.py
@@ -6,7 +6,7 @@ LOG_LEVEL_DEFAULT_STR = "DEFAULT"
 LOG_LEVEL_AUDIT = 25
 LOG_LEVEL_AUDIT_STR = "AUDIT"
 
-AUDIT_LOG_FORMAT = "send request method:{} path:{} headers:{} args:{}"
+AUDIT_LOG_FORMAT = "{}send request method:{} path:{} headers:{} args:{}"
 
 logging.addLevelName(LOG_LEVEL_AUDIT, "AUDIT")
 


### PR DESCRIPTION
To realize it, I Added dry_run mode to LaunchableClient so that it will refrain from making actual requests in case of HTTP methods with side effects. I also changed it so that no request is made inside the jar.

Here is how it works in my environment.

```console
$ launchable --dry-run --log-level=info record build --name "test-$(date)" --source .
AUDIT:launchable:(DRY RUN) send request method:get path: https://api.mercury.launchableinc.com/intake/organizations/{maskxxx}/workspaces/{maskxxx}/commits/latest
AUDIT:launchable:(DRY RUN) send request method:post path:https://api.mercury.launchableinc.com/intake/organizations/{maskxxx}/workspaces/{maskxxx}/commits/collect headers:{"Content-Type":"application/json","Content-Encoding":"gzip"} args:{
  "commits" : [ {
    "id" : 0,
    "workspaceId" : 0,
    "commitHash" : "42df4f650fe210b02dffd017f67ca17f4aa9b44c",
    "authorName" : "Songmu",
    "authorEmailAddress" : "y.songmu@gmail.com",
    "authorWhen" : 1638180736000,
    "authorTimezoneOffset" : 540,
    "committerName" : "Songmu",
    "committerEmailAddress" : "y.songmu@gmail.com",
    "committerWhen" : 1638180736000,
    "committerTimezoneOffset" : 540,
    "message" : "",
    "organizationId" : 0,
    "parentHashes" : {
      "dd139fb46cb7c1a3b19bca7a0c3762090c7c522f" : [ {
        "id" : 0,
        "commitRelationId" : 0,
        "linesAdded" : 1,
        "linesDeleted" : 1,
        "status" : "MODIFY",
        "path" : "go_import.go",
        "pathTo" : "go_import.go",
        "organizationId" : 0
      } ]
    }
  } ]
}
Launchable recorded 1 commit from repository /Users/Songmu/dev/src/github.com/x-motemen/ghq
AUDIT:launchable:(DRY RUN) send request method:post path:https://api.mercury.launchableinc.com/intake/organizations/{maskxxx}/workspaces/{maskxxx}/builds headers:{'User-Agent': 'Launchable/1.33.1.dev11+g7860378 (Python 3.9.7, macOS-12.0.1-arm64-arm-64bit)', 'Content-Type': 'application/json', 'Authorization': 'Bearer (maskxxx)'} args:{'buildNumber': 'test-Thu Dec  2 18:58:04 JST 2021', 'commitHashes': [{'repositoryName': '.', 'commitHash': '42df4f650fe210b02dffd017f67ca17f4aa9b44c'}]}
Launchable recorded build test-Thu Dec  2 18:58:04 JST 2021 to workspace {maskxxx}/{maskxxx} with commits from 1 repository:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 42df4f650fe210b02dffd017f67ca17f4aa9b44c |
```