### PR TITLE
Add commit option

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -111,8 +111,16 @@ def build(ctx, build_name, source, max_days, no_submodules,
                             (repo_name + "/" + name, repo_dist + "/" + name, commit_hash))
 
     if no_commit_collection and len(commits) != 0:
+        invalid = False
         for repo_name, hash in commits:
+            if not re.match("[0-9A-Fa-f]{5,40}$", hash):
+                click.echo(click.style(
+                    "{}'s commit hash `{}` is invalid.".format(repo_name, hash), fg="yellow"
+                ), err=True)
+                invalid = True
             submodules.append((repo_name, "", hash))
+        if invalid:
+            exit(1)
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -6,6 +6,7 @@ from .commit import commit
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from ...utils.session import clean_session_files
+from ...utils.click import KeyValueType
 from tabulate import tabulate
 from ...utils.authentication import get_org_workspace
 
@@ -50,9 +51,17 @@ from ...utils.authentication import get_org_workspace
     default=False
 )
 @click.option('--scrub-pii', is_flag=True, help='Scrub emails and names', hidden=True)
+@click.option(
+    '--commit',
+    'commits',
+    help="set repository name and commit hash when you use --no-commit-collection option",
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def build(ctx, build_name, source, max_days, no_submodules,
-          no_commit_collection, scrub_pii):
+          no_commit_collection, scrub_pii, commits):
     if "/" in build_name:
         exit("--name must not contain a slash")
 
@@ -100,6 +109,10 @@ def build(ctx, build_name, source, max_days, no_submodules,
                     if commit_hash and name:
                         submodules.append(
                             (repo_name + "/" + name, repo_dist + "/" + name, commit_hash))
+
+    if no_commit_collection and len(commits) != 0:
+        for repo_name, hash in commits:
+            submodules.append((repo_name, "", hash))
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -49,7 +49,7 @@ class DurationType(click.ParamType):
 
 
 class KeyValueType(click.Option):
-    error_message = "Expected key-value like --option kye=value or --option key value. but got '{}'"
+    error_message = "Expected key-value like --option kye=value, --option key:value or --option key value. but got '{}'"
 
     def __init__(self, *args, **kwargs):
         super(KeyValueType, self).__init__(*args, **kwargs)

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -66,6 +66,14 @@ class KeyValueType(click.Option):
                         self.error_message.format(value))
 
                 value = tuple([kv[0].strip(), kv[1].strip()])
+            # case: --option key:value
+            elif ':' in value:
+                kv = value.split(':')
+                if len(kv) != 2:
+                    raise ValueError(
+                        self.error_message.format(value))
+
+                value = tuple([kv[0].strip(), kv[1].strip()])
             # case: --option key value
             else:
                 rargs = state.rargs

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -49,7 +49,7 @@ class DurationType(click.ParamType):
 
 
 class KeyValueType(click.Option):
-    error_message = "Expected key-value like --option kye=value, --option key:value or --option key value. but got '{}'"
+    error_message = "Expected a key-value pair formatted as --option key=value, --option key:value, or --option key value, but got '{}'"
 
     def __init__(self, *args, **kwargs):
         super(KeyValueType, self).__init__(*args, **kwargs)


### PR DESCRIPTION
When the user uses `--no-commit-collection` option, the cli can't send commit hashes. 
So I add `--commit` option to be able to send repository name and commit hash.

```
$ launchable record build --name build1 --no-commit-collection --commit repoA:hash123456 --commit repoB:hash67890
Warning: Commit collection is turned off. The commit data must be collected separately.
Launchable recorded build build1 to workspace launchableinc/mothership with commits from 3 repositories:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 6bf701222e2b56a935862a78eb8b40e5a8fcaeb2 |
| repoA  |        | hash123456                               |
| repoB  |        | hash67890                                |
```