### PR TITLE
Use GIT_AUTHOR_EMAIL and GIT_COMMITTER_EMAIL

### DIFF
--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -157,10 +157,10 @@ class TestFilePathNormalizer(unittest.TestCase):
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True,
                                     env={
-                                        "GIT_AUTHOR_NAME":
-                                        "Test User <user@example.com>",
-                                        "GIT_COMMITTER_NAME":
-                                        "Test User <user@example.com>",
+                                        "GIT_AUTHOR_NAME": "Test User",
+                                        "GIT_AUTHOR_EMAIL": "user@example.com",
+                                        "GIT_COMMITTER_NAME": "Test User",
+                                        "GIT_COMMITTER_EMAIL": "user@example.com",
                                     })
         except subprocess.CalledProcessError as e:
             self.fail(


### PR DESCRIPTION
It seems that from a certain Git version the GIT_*_NAME parsing gets
strict and this fails at Git 2.34.1 at least. Use _EMAIL env var for
emails.