### PR TITLE
Add a constraint on more_itertools in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ types-requests = "*"
 types-pkg_resources = "*"
 types-tabulate = "*"
 unittest-xml-reporting = "*"
+more_itertools = "<8.6"
 
 [packages]
 launchable = {editable = true, path = "."}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Usage
 
-See https://docs.launchableinc.com/cli-reference and https://docs.launchableinc.com/getting-started.
+See https://docs.launchableinc.com/cli-reference and
+https://docs.launchableinc.com/getting-started.
 
 # Development
+
 ## Preparation
+
 We recommend Pipenv
+
 ```shell
-pip install pipenv
+pip install pipenv==2021.5.29
 pipenv install --dev
 ```
+
+Note that you will need to use 2021.5.29 as the Python version is fixed at 3.5,
+and the Pipenv beyond that version won't support Python 3.5 or below.
+
 If you mess up your local pipenv, `pipenv --rm` will revert the operation above.
 
 In order to automatically format files with autopep8, this repository contains a
@@ -16,24 +24,30 @@ configuration for [pre-commit](https://pre-commit.com). Install the hook with
 `pipenv run pre-commit install`.
 
 ## Load development environment
+
 ```shell
 pipenv shell
 ```
 
 ## Run tests
+
 ```shell
 pipenv run test
 ```
 
 ## Add dependency
+
 ```shell
 pipenv install --dev some-what-module
 ```
 
 # How to release
-Create new release on Github, then Github Actions automatically uploads the module to PyPI.
+
+Create new release on Github, then Github Actions automatically uploads the
+module to PyPI.
 
 ## Versioning
+
 This module follows [Semantic versioning](https://semver.org/) such as X.Y.Z.
 
 * Major (X)


### PR DESCRIPTION
Apparently, one of those dev dependencies pulls latest more_itertools,
which conflicts with the main app's dependency. Pin the version in the
dev dependencies as well.