### PR TITLE
use allowed_method option instead of method_whitelist

### DIFF
--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -39,7 +39,7 @@ class LaunchableClient:
         if session is None:
             strategy = Retry(
                 total=3,
-                method_whitelist=["GET", "PUT", "PATCH", "DELETE"],
+                allowed_methods=["GET", "PUT", "PATCH", "DELETE"],
                 status_forcelist=[429, 500, 502, 503, 504],
                 backoff_factor=2
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ classifiers =
 packages = find:
 install_requires =
     click~=7.0
-    requests;python_version>='3.6'
+    requests>=2.25;python_version>='3.6'
 # requests dropped python 3.5 support since v2.26
-    requests<2.26;python_version<'3.6'
+    requests>=2.25,<2.26;python_version<'3.6'
+    urllib3>=1.26
     junitparser>=2.0.0
     setuptools
     more_itertools>=7.1.0;python_version>='3.6'

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -73,8 +73,7 @@ class JestTest(CliTestCase):
                           'jest', input=self.subset_input)
 
         self.assertEqual(result.exit_code, 0)
-        # to avoid "Using 'method_whitelist'..." warning message
-        self.assertIn('subset/123', result.output.rstrip("\n"))
+        self.assertIn('subset/123', result.output)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -71,8 +71,7 @@ class MinitestTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         output = Path(self.test_files_dir, "test", "example_test.rb")
-        # To ignore "Using 'method_whitelist'..." warning message
-        self.assertIn(str(output), result.output.rstrip("\n"))
+        self.assertIn(str(output), result.output)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -104,8 +103,7 @@ class MinitestTest(CliTestCase):
                           'minitest', str(self.test_files_dir) + "/test/**/*.rb")
 
         self.assertEqual(result.exit_code, 0)
-        # to avoid "Using 'method_whitelist'..." warning message
-        self.assertIn('subset/123', result.output.rstrip("\n"))
+        self.assertIn('subset/123', result.output)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -121,8 +119,7 @@ class MinitestTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         output = Path(self.test_files_dir, "test", "example_test.rb")
-        # To ignore "Using 'method_whitelist'..." warning message
-        self.assertIn(str(output), result.output.rstrip("\n"))
+        self.assertEqual(str(output), result.output.rstrip("\n"))
         self.assertEqual(rest.read().decode().rstrip("\n"), str(output))
         rest.close()
         os.unlink(rest.name)

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -55,8 +55,7 @@ class NUnitTest(CliTestCase):
         self.assert_json_orderless_equal(expected, payload)
 
         output = 'ParameterizedTests.MyTests.DivideTest(12,3)\ncalc.Tests1.Test1'
-        # To ignore "Using 'method_whitelist'..." warning message
-        self.assertIn(output, result.output.rstrip('\n'))
+        self.assertIn(output, result.output)
 
     @ignore_warnings
     @responses.activate
@@ -95,9 +94,8 @@ class NUnitTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-        # To ignore "Using 'method_whitelist'..." warning message
         self.assertIn('ParameterizedTests.MyTests.DivideTest(12,3)',
-                      result.output.rstrip("\n"))
+                      result.output)
 
         self.assertEqual(rest.read().decode(), 'calc.Tests1.Test1')
         rest.close()


### PR DESCRIPTION
To suppress DeprecationWarning.

I explicitly specify the version of urllib3 that the request package depends on as 1.26 or later. This is the version in which `allowed_methods` was introduced.

- https://github.com/urllib3/urllib3/blob/1dd0613b610df1269dbc11e9780b0fe7debaff3c/CHANGES.rst#1260-2020-11-10
- https://github.com/urllib3/urllib3/pull/2000

Also, the requests library has been updated to support urllib3 v1.26 since version 2.25, so I specify that as well.

https://github.com/psf/requests/blob/main/HISTORY.md#2250-2020-11-11

These changes meet our version requirements to support python 3.5.