### PR TITLE
drop --executable docker option

### DIFF
--- a/docs/resources/cli-reference.md
+++ b/docs/resources/cli-reference.md
@@ -78,15 +78,11 @@ launchable record commit --source src=.
 
 | Option                   | Description                                                                                                         | Required               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `--executable jar`       | Run commit collection using Java.                                                                                   | No (default)           |
-| `--executable docker`    | Run commit collection using Docker.                                                                                 | No                     |
 | `--max-days DAYS`        | The maximum number of days to collect commits retroactively.                                                        | No. Defaults to `30`   |
 | `--source REPO_NAME=DIR` | Name and path of a local Git repository.                                                                            | No. Defaults to `$PWD` |
 | `--scrub-pii`            | No-op. Previously disabled collection of user full names and enabled user email address hashing. Now on by default. | No. No-op              |
 
 Commit collection happens automatically as a part of `record build`, so normally this command need not be invoked separately.
-
-`--executable jar` is faster as the Java version of the commit collector is bundled with the CLI, but it requires that your system has Java installed. `--executable docker` allows you to run the equivalent commit collector packaged as a Docker image. You may choose to do this if your system allows you to run Docker containers but not Java. Containers will be downloaded on demand. This option is more of an escape hatch.
 
 ### record build
 

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -18,7 +18,7 @@ jar_file_path = os.path.normpath(os.path.join(
               type=click.Path(exists=True, file_okay=False),
               )
 @click.option('--executable',
-              help="[Deprecated] collect commits with Jar or Docker",
+              help="[Obsolete] it was to specify how to perform commit collection but has been removed",
               type=click.Choice(['jar', 'docker']),
               default='jar',
               hidden=True

--- a/launchable/utils/ingester_image.py
+++ b/launchable/utils/ingester_image.py
@@ -1,8 +1,0 @@
-# Launchable's ingester Docker image with tag
-# If you need up-to-date image, please replace the image tag
-# You can see the docker image tags at
-# https://hub.docker.com/repository/registry-1.docker.io/launchableinc/ingester/tags
-ingester_image = (
-    'launchableinc/ingester:'
-    '976171f4005f8a1c6d0e706d20760890b44c5373'
-)


### PR DESCRIPTION
It may be that no one uses the docker option. And the docker image is old, not following up with the recent new features of the cli such as audit and dry-run.

So, how about deleting it?

I leave the option as a hidden flag for now. I plan to remove it completely in the future.