### PR TITLE
fix error message order

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -18,17 +18,18 @@ def find_or_create_session(context, session: Optional[str], build_name: Optional
     """
     from .record.session import session as session_command
 
-    saved_build_name = read_build()
-    if build_name and saved_build_name != build_name:
-        raise click.UsageError(click.style(
-            "Given build name ({}) is different from when you ran `launchable record build --name {}`.\nMake sure to run `launchable record build --name {}` before.".format(build_name, saved_build_name, build_name), fg="yellow"))
-
     if session:
         return session
+
+    saved_build_name = read_build()
+    if not saved_build_name:
+        raise click.UsageError(click.style(
+            "Have you run `launchable record build`?\nIf not, please do. If it was run elsewhere/earlier, please use the --session option", fg="yellow"))
+
     else:
-        if not saved_build_name:
+        if build_name and saved_build_name != build_name:
             raise click.UsageError(click.style(
-                "Have you run `launchable record build`?\nIf not, please do. If it was run elsewhere/earlier, please use the --session option", fg="yellow"))
+                "Given build name ({}) is different from when you ran `launchable record build --name {}`.\nMake sure to run `launchable record build --name {}` before.".format(build_name, saved_build_name, build_name), fg="yellow"))
 
         session_id = read_session(saved_build_name)
         if session_id:

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -70,7 +70,7 @@ def write_session(build_name: str, session_id: str) -> None:
 
         if read_build() != build_name:
             # TODO: change error message
-            raise Exception("Canot write session because build name is different between saved and input. input: {} saved: {}".format(
+            raise Exception("Cannot write session because build name is different between saved and input. input: {} saved: {}".format(
                 build_name, read_build()))
 
         session = {}


### PR DESCRIPTION
We want to show this message when the user can't read a build name that is saved.

> "Have you run `launchable record build`?\nIf not, please do. If it was run elsewhere/earlier, please use the --session option",

However, now this message is printed first so I changed validation orderes

> Given build name ({}) is different from when you ran `launchable record build --name {}`.\nMake sure to run `launchable record build --name {}` before."

