### PR TITLE
rm validation

### DIFF
--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -64,15 +64,6 @@ def write_build(build_name: str) -> None:
 
 def write_session(build_name: str, session_id: str) -> None:
     try:
-        if not _session_file_path().exists():
-            raise Exception(
-                "Session file doesn't exist. Make sure to run `launchable record build --name {}` before".format(build_name))
-
-        if read_build() != build_name:
-            # TODO: change error message
-            raise Exception("Cannot write session because build name is different between saved and input. input: {} saved: {}".format(
-                build_name, read_build()))
-
         session = {}
         session["build"] = build_name
         session["session"] = session_id

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -28,33 +28,12 @@ class SessionTestClass(TestCase):
         self.assertEqual(read_build(), self.build_name)
 
     def test_write_read_remove_session(self):
-        # need to write_build before
-        with self.assertRaises(Exception):
-            write_session(self.build_name, self.session_id)
-
         write_build(self.build_name)
         write_session(self.build_name, self.session_id)
         self.assertEqual(read_session(self.build_name), self.session_id)
 
         remove_session()
         self.assertEqual(read_session(self.build_name), None)
-
-    def test_other_build(self):
-        write_build(self.build_name)
-        write_session(self.build_name, self.session_id)
-
-        next_build_name = '124'
-        next_session_id = '/intake/organizations/launchableinc/workspaces/mothership/builds/123/test_sessions/14'
-
-        # the cli doesn't allow overwrite session
-        with self.assertRaises(Exception):
-            write_session(next_build_name, next_session_id)
-
-        self.assertEqual(read_session(self.build_name), self.session_id)
-
-        # When load session use by another build name, it's invalid case so the cli raise Exception
-        with self.assertRaises(Exception):
-            read_session(next_build_name)
 
     def test_read_before_write(self):
         self.assertEqual(read_session(self.build_name), None)


### PR DESCRIPTION
Before this change, the cli requires to run `launchable record build` before executing `launchable record session`.
But, it is unintended behavior so I removed validation logic.