### PR TITLE
updated click version for >=python3.6

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -2,6 +2,7 @@ import re
 import click
 from ...utils import subprocess
 import os
+from typing import Sequence
 from .commit import commit
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
@@ -112,7 +113,15 @@ def build(ctx, build_name, source, max_days, no_submodules,
 
     if no_commit_collection and len(commits) != 0:
         invalid = False
-        for repo_name, hash in commits:
+        _commits = []
+        # TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
+        if isinstance(commits, str):
+            for c in commits:
+                k, v = c.replace("(", "").replace(")", "").replace("'","").split(",")
+                _commits.append((k.strip(), v.strip()))
+        else:
+            _commits = commits
+        for repo_name, hash in _commits:
             if not re.match("[0-9A-Fa-f]{5,40}$", hash):
                 click.echo(click.style(
                     "{}'s commit hash `{}` is invalid.".format(repo_name, hash), fg="yellow"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    click~=7.0
+    click>=7.0;python_version<'3.6'
+    click>=8.0;python_version>='3.6'
     requests>=2.25;python_version>='3.6'
 # requests dropped python 3.5 support since v2.26
     requests>=2.25,<2.26;python_version<'3.6'

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    click>=7.0;python_version<'3.6'
+    click~=7.0;python_version<'3.6'
     click>=8.0;python_version>='3.6'
     requests>=2.25;python_version>='3.6'
 # requests dropped python 3.5 support since v2.26

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -7,9 +7,9 @@ import types
 import unittest
 
 import click.testing
-import responses  # type: ignore
 from click.testing import CliRunner
 
+import responses  # type: ignore
 from launchable.__main__ import main
 from launchable.utils.http_client import get_base_url
 from launchable.utils.session import SESSION_DIR_KEY, clean_session_files


### PR DESCRIPTION
# What
- updated click version for >=python3.6 to use >=click8.0
- since click>=8.0 turns tuple to string in returning, as is in TODO, added some workarounds  https://github.com/launchableinc/cli/pull/363/commits/5171c1c362042eabd1dd44ab2c2d6c608a64a1c8

TODO:
- handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
    E.G. 
        <click8.0: 
            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.5` is parsed as build=aaa, flavor=(("os", "ubuntu"), ("python", "3.5"))
        >=click8.0: 
            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")        