### PR TITLE
Check if commits item is a str

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -115,7 +115,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
         invalid = False
         _commits = []
         # TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
-        if isinstance(commits, str):
+        if isinstance(commits[0], str):
             for c in commits:
                 k, v = c.replace("(", "").replace(
                     ")", "").replace("'", "").split(",")

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -65,3 +65,35 @@ class BuildTest(CliTestCase):
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @mock.patch('launchable.utils.subprocess.check_output')
+    def test_no_git_directory(self, mock_check_output):
+        # TODO(draftcode) The implementation has a bug that it calls git command
+        # even if commit is specified. This will be fixed in
+        # https://github.com/launchableinc/cli/pull/366.
+        mock_check_output.side_effect = [
+            ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2').encode(),
+        ]
+        self.assertEqual(read_build(), None)
+
+        result = self.cli("record", "build",
+                          "--no-commit-collection",
+                          "--no-submodules",
+                          "--commit", ".=c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
+                          "--name", self.build_name)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {
+                "buildNumber": "123",
+                "commitHashes": [
+                    {
+                        "repositoryName": ".",
+                        "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
+                    },
+                ]
+            }, payload)
+
+        self.assertEqual(read_build(), self.build_name)


### PR DESCRIPTION
Found in https://github.com/launchableinc/cli/pull/366. It should check
if the item is a str instead of commits itself is a str. Added a test,
but it indicates the cli is calling git command even if --commit is
specified, this should be fixed in the forementioned PR.