### PR TITLE
fix to use sys.exit

### DIFF
--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -3,6 +3,7 @@ from tabulate import tabulate
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 import os
+import sys
 import click
 from typing import Dict, List
 
@@ -24,7 +25,7 @@ def subset(subset_id):
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
                 "Subset {} not found. Check subset ID and try again.".format(subset_id), 'yellow'), err=True)
-            exit(1)
+            sys.exit(1)
 
         res.raise_for_status()
         subset = res.json()["testPaths"]

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -4,6 +4,7 @@ from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from tabulate import tabulate
 from http import HTTPStatus
+import sys
 
 
 @click.command()
@@ -22,7 +23,7 @@ def tests(test_session_id):
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
                 "Test session {} not found. Check test session ID and try again.".format(test_session_id), 'yellow'), err=True)
-            exit(1)
+            sys.exit(1)
 
         res.raise_for_status()
         results = res.json()

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import click
 from ...utils import subprocess
 import os
@@ -64,7 +65,7 @@ from ...utils.authentication import get_org_workspace
 def build(ctx, build_name, source, max_days, no_submodules,
           no_commit_collection, scrub_pii, commits):
     if "/" in build_name:
-        exit("--name must not contain a slash")
+        sys.exit("--name must not contain a slash")
 
     clean_session_files(days_ago=14)
 
@@ -130,7 +131,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
                 invalid = True
             submodules.append((repo_name, "", hash))
         if invalid:
-            exit(1)
+            sys.exit(1)
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.
@@ -145,7 +146,7 @@ def build(ctx, build_name, source, max_days, no_submodules,
 
         if not (commitHashes[0]['repositoryName']
                 and commitHashes[0]['commitHash']):
-            exit('Please specify --source as --source .')
+            sys.exit('Please specify --source as --source .')
 
         payload = {
             "buildNumber": build_name,

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -1,5 +1,6 @@
 import os
 import click
+import sys
 from urllib.parse import urlparse
 
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -31,7 +32,7 @@ jar_file_path = os.path.normpath(os.path.join(
 @click.pass_context
 def commit(ctx, source, executable, max_days, scrub_pii):
     if executable == 'docker':
-        exit("--executable docker is no longer supported")
+        sys.exit("--executable docker is no longer supported")
 
     try:
         exec_jar(os.path.abspath(source), max_days, ctx.obj.dry_run)
@@ -46,7 +47,7 @@ def exec_jar(source, max_days, dry_run):
     java = get_java_command()
 
     if not java:
-        exit("You need to install Java")
+        sys.exit("You need to install Java")
 
     base_url = get_base_url()
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,6 +1,6 @@
 import click
 import os
-import json
+import sys
 from typing import Sequence
 from http import HTTPStatus
 from ...utils.http_client import LaunchableClient
@@ -70,7 +70,7 @@ def session(ctx, build_name: str, save_session_file: bool, print_session: bool =
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
                 "Build {} was not found. Make sure to run `launchable record build --name {}` before".format(build_name, build_name), 'yellow'), err=True)
-            exit(1)
+            sys.exit(1)
 
         res.raise_for_status()
         session_id = res.json()['id']

--- a/launchable/test_runners/bazel.py
+++ b/launchable/test_runners/bazel.py
@@ -1,5 +1,5 @@
 import os
-from os.path import join
+import sys
 from pathlib import Path
 import click
 from junitparser import TestCase, TestSuite  # type: ignore
@@ -42,7 +42,7 @@ def record_tests(client, workspace, build_event_json_files):
     """
     base = Path(workspace).joinpath('bazel-testlogs').resolve()
     if not base.exists():
-        exit("No such directory: %s" % str(base))
+        sys.exit("No such directory: %s" % str(base))
 
     default_path_builder = client.path_builder
 

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -3,7 +3,7 @@ import click
 import datetime
 import dateutil.parser
 import json
-import urllib.parse
+import sys
 
 from . import launchable
 from ..testpath import TestPath, parse_test_path, unparse_test_path
@@ -26,7 +26,7 @@ def subset(client, test_path_file):
         try:
             tp = parse_test_path(tp_str)
         except ValueError as e:
-            exit(e.args[0])
+            sys.exit(e.args[0])
         client.test_path(tp)
 
     client.formatter = unparse_test_path

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -5,7 +5,7 @@ import platform
 
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry # type: ignore
+from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
 from launchable.version import __version__
 from .authentication import get_org_workspace, authentication_headers


### PR DESCRIPTION
# What
- use sys.exit() instead of exit() in Python program to exit.

