### PR TITLE
Fix Nunit plugin

### DIFF
--- a/tests/data/nunit/record_test_result.json
+++ b/tests/data/nunit/record_test_result.json
@@ -6,7 +6,7 @@
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "calc" },
         { "type": "TestSuite",   "name": "sub" },
-        { "type": "TestFixture", "name": "Tests2" },
+        { "type": "TestSuite", "name": "Tests2" },
         { "type": "TestCase",    "name": "Foo" }
       ],
       "created_at": "2021-05-25T01:24:39.5030637Z",
@@ -21,7 +21,7 @@
       "testPath": [
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "calc" },
-        { "type": "TestFixture", "name": "Tests1" },
+        { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test1" }
       ],
       "created_at": "2021-05-25T01:24:39.5082923Z",
@@ -36,7 +36,7 @@
       "testPath": [
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "calc" },
-        { "type": "TestFixture", "name": "Tests1" },
+        { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test2" }
       ],
       "created_at": "2021-05-25T01:24:39.5196489Z",
@@ -52,7 +52,7 @@
       "testPath": [
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "ParameterizedTests" },
-        { "type": "TestFixture", "name": "MyTests" },
+        { "type": "TestSuite", "name": "MyTests" },
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,3)" }
       ],
@@ -68,7 +68,7 @@
       "testPath": [
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "ParameterizedTests" },
-        { "type": "TestFixture", "name": "MyTests" },
+        { "type": "TestSuite", "name": "MyTests" },
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,2)" }
       ],
@@ -84,7 +84,7 @@
       "testPath": [
         { "type": "Assembly",    "name": "calc.dll" },
         { "type": "TestSuite",   "name": "ParameterizedTests" },
-        { "type": "TestFixture", "name": "MyTests" },
+        { "type": "TestSuite", "name": "MyTests" },
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,4)" }
       ],

--- a/tests/data/nunit/subset_result.json
+++ b/tests/data/nunit/subset_result.json
@@ -4,40 +4,40 @@
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "calc" },
       { "type": "TestSuite",   "name": "sub" },
-      { "type": "TestFixture", "name": "Tests2" },
+      { "type": "TestSuite", "name": "Tests2" },
       { "type": "TestCase",    "name": "Foo" }
     ],
     [
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "calc" },
-      { "type": "TestFixture", "name": "Tests1" },
+      { "type": "TestSuite", "name": "Tests1" },
       { "type": "TestCase",    "name": "Test1" }
     ],
     [
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "calc" },
-      { "type": "TestFixture", "name": "Tests1" },
+      { "type": "TestSuite", "name": "Tests1" },
       { "type": "TestCase",    "name": "Test2" }
     ],
 
     [
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "ParameterizedTests" },
-      { "type": "TestFixture", "name": "MyTests" },
+      { "type": "TestSuite", "name": "MyTests" },
       { "type": "ParameterizedMethod", "name":  "DivideTest" },
       { "type": "TestCase",    "name": "DivideTest(12,3)" }
     ],
     [
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "ParameterizedTests" },
-      { "type": "TestFixture", "name": "MyTests" },
+      { "type": "TestSuite", "name": "MyTests" },
       { "type": "ParameterizedMethod", "name":  "DivideTest" },
       { "type": "TestCase",    "name": "DivideTest(12,2)" }
     ],
     [
       { "type": "Assembly",    "name": "calc.dll" },
       { "type": "TestSuite",   "name": "ParameterizedTests" },
-      { "type": "TestFixture", "name": "MyTests" },
+      { "type": "TestSuite", "name": "MyTests" },
       { "type": "ParameterizedMethod", "name":  "DivideTest" },
       { "type": "TestCase",    "name": "DivideTest(12,4)" }
     ]


### PR DESCRIPTION
I changed to replace `TestFixture` to `TestSuite`. Because  I found out Nunit produces a different XML attributes report file between with `--explore` option and without it.



