### PR TITLE
rescue file::testcase case

### DIFF
--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -72,7 +72,7 @@ def _parse_pytest_nodeid(nodeid: str) -> TestPath:
             {"type": "file", "name": os.path.normpath(file)},
             {"type": "testcase", "name": testcase}
         ]
-    elif len(data)==3:
+    elif len(data) == 3:
         # tests/test_mod.py::TestClass::test_can_print_aaa -> tests.test_mod.TestClass
         return [
             {"type": "file", "name": os.path.normpath(file)},
@@ -91,18 +91,20 @@ def _path_to_class_name(path):
 
 
 def _pytest_formatter(test_path):
+    cls_name = ""
     for path in test_path:
         t = path['type']
+        n = path['name']
         if t == 'class':
-            cls_name = path['name']
-        if t == 'testcase':
-            case = path['name']
-        if t == 'file':
-            file = path['name']
+            cls_name = n
+        elif t == 'testcase':
+            case = n
+        elif t == 'file':
+            file = n
     # If there is no class, junitformat use package name, but pytest will be omitted
     # pytest -> tests/fooo/func4_test.py::test_func6
     # junitformat -> <testcase classname="tests.fooo.func4_test" name="test_func6" file="tests/fooo/func4_test.py" line="0" time="0.000" />
-    if cls_name == _path_to_class_name(file):
+    if cls_name == "":
         return "{}::{}".format(file, case)
 
     # junitformat's class name includes package, but pytest does not

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -64,11 +64,12 @@ def _parse_pytest_nodeid(nodeid: str) -> TestPath:
     data = nodeid.split("::")
     file = data[0]
     class_name = _path_to_class_name(file)
+    normalized_file = os.path.normpath(file)
     
     # file name only
     if len(data) == 1:
         return [
-            {"type": "file", "name": os.path.normpath(data[0])},
+            {"type": "file", "name": normalized_file},
             {"type": "class", "name": class_name},
         ]
     # file + testcase, or file + class + testcase
@@ -78,7 +79,7 @@ def _parse_pytest_nodeid(nodeid: str) -> TestPath:
             class_name += "." + data[1]
 
         return [
-            {"type": "file", "name": os.path.normpath(data[0])},
+            {"type": "file", "name": normalized_file},
             {"type": "class", "name": class_name},
             {"type": "testcase", "name": testcase},
         ]
@@ -93,8 +94,8 @@ def _path_to_class_name(path):
 
 def _pytest_formatter(test_path):
     for path in test_path:
-        t = path['type']
-        n = path['name']
+        t = path.get('type', '')
+        n = path.get('name', '')
         if t == 'class':
             cls_name = n
         elif t == 'testcase':

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -80,7 +80,7 @@ def _parse_pytest_nodeid(nodeid: str) -> TestPath:
             {"type": "testcase", "name": testcase}
         ]
     else:
-        raise "unexpected node id: %s" % str
+        raise ValueError("unexpected node id: %s" % str)
 
 
 def _path_to_class_name(path):
@@ -106,11 +106,11 @@ def _pytest_formatter(test_path):
     # junitformat -> <testcase classname="tests.fooo.func4_test" name="test_func6" file="tests/fooo/func4_test.py" line="0" time="0.000" />
     if cls_name == "":
         return "{}::{}".format(file, case)
-
+    else:
     # junitformat's class name includes package, but pytest does not
     # pytest -> tests/test_mod.py::TestClass::test__can_print_aaa
     # junitformat -> <testcase classname="tests.test_mod.TestClass" name="test__can_print_aaa" file="tests/test_mod.py" line="3" time="0.001" />
-    return "{}::{}::{}".format(file, cls_name.split(".")[-1], case)
+        return "{}::{}::{}".format(file, cls_name.split(".")[-1], case)
 
 
 split_subset = launchable.CommonSplitSubsetImpls(

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -62,16 +62,25 @@ def subset(client, source_roots: List[str]):
 
 def _parse_pytest_nodeid(nodeid: str) -> TestPath:
     data = nodeid.split("::")
-    class_name = _path_to_class_name(data[0])
-    if len(data) == 3:
+    file = data[0]
+    testcase = data[-1]
+    class_name = _path_to_class_name(file)
+    
+    if len(data) == 2:
+        # tests/test_mod.py::test_can_print_aaa -> tests.test_mod
+        return [
+            {"type": "file", "name": os.path.normpath(file)},
+            {"type": "testcase", "name": testcase}
+        ]
+    elif len(data)==3:
         # tests/test_mod.py::TestClass::test_can_print_aaa -> tests.test_mod.TestClass
-        class_name += "." + data[1]
-
-    return [
-        {"type": "file", "name": os.path.normpath(data[0])},
-        {"type": "class", "name": class_name},
-        {"type": "testcase", "name": data[-1]},
-    ]
+        return [
+            {"type": "file", "name": os.path.normpath(file)},
+            {"type": "class", "name": class_name + "." + data[1]},
+            {"type": "testcase", "name": testcase}
+        ]
+    else:
+        raise "unexpected node id: %s" % str
 
 
 def _path_to_class_name(path):

--- a/tests/data/pytest/subset_result.json
+++ b/tests/data/pytest/subset_result.json
@@ -6,10 +6,6 @@
         "name": "tests/funcs3_test.py"
       },
       {
-        "type": "class",
-        "name": "tests.funcs3_test"
-      },
-      {
         "type": "testcase",
         "name": "test_func4"
       }
@@ -18,10 +14,6 @@
       {
         "type": "file",
         "name": "tests/funcs3_test.py"
-      },
-      {
-        "type": "class",
-        "name": "tests.funcs3_test"
       },
       {
         "type": "testcase",
@@ -34,10 +26,6 @@
         "name": "tests/test_funcs1.py"
       },
       {
-        "type": "class",
-        "name": "tests.test_funcs1"
-      },
-      {
         "type": "testcase",
         "name": "test_func1"
       }
@@ -46,10 +34,6 @@
       {
         "type": "file",
         "name": "tests/test_funcs1.py"
-      },
-      {
-        "type": "class",
-        "name": "tests.test_funcs1"
       },
       {
         "type": "testcase",
@@ -62,10 +46,6 @@
         "name": "tests/test_funcs2.py"
       },
       {
-        "type": "class",
-        "name": "tests.test_funcs2"
-      },
-      {
         "type": "testcase",
         "name": "test_func3"
       }
@@ -74,10 +54,6 @@
       {
         "type": "file",
         "name": "tests/test_funcs2.py"
-      },
-      {
-        "type": "class",
-        "name": "tests.test_funcs2"
       },
       {
         "type": "testcase",
@@ -102,10 +78,6 @@
       {
         "type": "file",
         "name": "tests/fooo/func4_test.py"
-      },
-      {
-        "type": "class",
-        "name": "tests.fooo.func4_test"
       },
       {
         "type": "testcase",

--- a/tests/data/pytest/subset_result.json
+++ b/tests/data/pytest/subset_result.json
@@ -6,6 +6,10 @@
         "name": "tests/funcs3_test.py"
       },
       {
+        "type": "class",
+        "name": "tests.funcs3_test"
+      },
+      {
         "type": "testcase",
         "name": "test_func4"
       }
@@ -14,6 +18,10 @@
       {
         "type": "file",
         "name": "tests/funcs3_test.py"
+      },
+      {
+        "type": "class",
+        "name": "tests.funcs3_test"
       },
       {
         "type": "testcase",
@@ -26,6 +34,10 @@
         "name": "tests/test_funcs1.py"
       },
       {
+        "type": "class",
+        "name": "tests.test_funcs1"
+      },
+      {
         "type": "testcase",
         "name": "test_func1"
       }
@@ -34,6 +46,10 @@
       {
         "type": "file",
         "name": "tests/test_funcs1.py"
+      },
+      {
+        "type": "class",
+        "name": "tests.test_funcs1"
       },
       {
         "type": "testcase",
@@ -46,6 +62,10 @@
         "name": "tests/test_funcs2.py"
       },
       {
+        "type": "class",
+        "name": "tests.test_funcs2"
+      },
+      {
         "type": "testcase",
         "name": "test_func3"
       }
@@ -54,6 +74,10 @@
       {
         "type": "file",
         "name": "tests/test_funcs2.py"
+      },
+      {
+        "type": "class",
+        "name": "tests.test_funcs2"
       },
       {
         "type": "testcase",
@@ -80,8 +104,22 @@
         "name": "tests/fooo/func4_test.py"
       },
       {
+        "type": "class",
+        "name": "tests.fooo.func4_test"
+      },
+      {
         "type": "testcase",
         "name": "test_func6"
+      }
+    ],
+    [
+      {
+        "type": "file",
+        "name": "tests/fooo/filenameonly_test.py"
+      },
+      {
+        "type": "class",
+        "name": "tests.fooo.filenameonly_test"
       }
     ]
   ],

--- a/tests/data/pytest/tests/fooo/filenameonly_test.py
+++ b/tests/data/pytest/tests/fooo/filenameonly_test.py
@@ -1,0 +1,2 @@
+def test_x():
+    assert 4 * 2 == 8

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -21,8 +21,9 @@ tests/test_funcs2.py::test_func3
 tests/test_funcs2.py::test_func4
 tests/test_mod.py::TestClass::test__can_print_aaa
 tests/fooo/func4_test.py::test_func6
+tests/fooo/filenameonly_test.py
 
-8 tests collected in 0.02s
+9 tests collected in 0.02s
 '''
 
     @responses.activate


### PR DESCRIPTION
In python, we can write functions directly under the file.
In this case, the behavior of parsing TestPath becomes strange.  