### PR TITLE
Add a root exception handler

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -1,6 +1,10 @@
 import importlib
 import importlib.util
 import logging
+import os
+import sys
+import textwrap
+import traceback
 from glob import glob
 from os.path import basename, dirname, join
 
@@ -79,5 +83,27 @@ main.add_command(split_subset)
 main.add_command(verify)
 main.add_command(inspect)
 
+
+def cli_main():
+    if os.environ.get("LAUNCHABLE_RETURNS_ERROR") == '1':
+        main.main()
+    else:
+        try:
+            # Ignore the exit code.
+            main.main(standalone_mode=False)
+        except BaseException:
+            # Click handles ClickException etc. specially. We don't add that
+            # handling because in the production mode those errors should be
+            # handled exceptionally.
+            click.utils.echo(textwrap.dedent("""
+            ====================================================================
+            Exception raised. But since LAUNCHABLE_RETURNS_ERROR is not set,
+            exit with the exit code 0.
+            ====================================================================
+            """), file=sys.stderr)
+            traceback.print_exc()
+            sys.exit(0)
+
+
 if __name__ == '__main__':
-    main()
+    cli_main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 python_requires = >=3.5
 
 [options.entry_points]
-console_scripts = launchable = launchable.__main__:main
+console_scripts = launchable = launchable.__main__:cli_main
 
 [options.package_data]
 launchable = jar/exe_deploy.jar


### PR DESCRIPTION
By using standalone_mode
(https://click.palletsprojects.com/en/8.0.x/exceptions/), we can get
exceptions from Click without it processing them. This allows us to
catch them and exit with an arbitrary exit code.

This changes the default behavior to exit the CLI always with the exit
code 0, which is a breaking change.

---

While this appears to be a safe change on the first sight, this can
silently disrupt some integrations. Imagine the scenario that, an
integration script is written in a way that if launchable command fails,
it falls back to a full run. With this change, that fallback stops
working, and it can end up reading an empty test subset, and not
executing any test in the worst case.