### PR TITLE
Fix the ctest command example

### DIFF
--- a/docs/resources/integrations/ctest.md
+++ b/docs/resources/integrations/ctest.md
@@ -42,9 +42,10 @@ ctest --show-only=json-v1 > test_list.json
 launchable subset \
     --build <BUILD NAME> \
     --confidence <TARGET> \
+    ctest
     --output-regex-files \
     --output-regex-files-dir=subsets \
-    ctest test_list.json
+    test_list.json
 ```
 
 *   The `--build` should use the same `<BUILD NAME>` value that you used before in


### PR DESCRIPTION
--output-regex-files and --output-regex-files-dir are the options under
ctest, not at the root level.
