### PR TITLE
Improve record commit test

### DIFF
--- a/tests/commands/record/test_commit.py
+++ b/tests/commands/record/test_commit.py
@@ -1,18 +1,47 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import json
 import os
+import threading
+from typing import Any
 from unittest import mock
 from tests.cli_test_case import CliTestCase
+from launchable.utils.env_keys import BASE_URL_KEY
 from launchable.commands.record.commit import _build_proxy_option
+from tests.helper import ignore_warnings
+
+
+class CommitHandler(SimpleHTTPRequestHandler):
+    # mock commits/latest
+    def do_GET(self):
+        response = []
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(response).encode("utf-8"))
+
+    # mock commits/collect
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
 
 
 class CommitTest(CliTestCase):
-
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @ mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_run_commit(self):
-        """
-        `record commit` command cause error because we can't mock Apache HTTP Client in Java
-        """
-        result = self.cli("record", "commit")
-        self.assertEqual(result.exit_code, 0, "exit normally")
+        server = HTTPServer(("", 0), CommitHandler)
+        thread = threading.Thread(None, server.serve_forever)
+        thread.start()
+
+        host, port = server.server_address
+        endpoint = "http://{}:{}".format(host, port)
+
+        with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
+            result = self.cli("record", "commit")
+            self.assertEqual(result.exit_code, 0, "exit normally")
+
+        server.shutdown()
+        thread.join()
 
     def test_proxy_options(self):
         self.assertEqual(_build_proxy_option("https://some_proxy:1234"),


### PR DESCRIPTION
Now, we send a request to production in the record commit test. But it's not good.

e.g) https://github.com/launchableinc/cli/runs/5323115390?check_suite_focus=true#step:10:92


I changed to use a mock server to avoid request production directly