### PR TITLE
Add error case

### DIFF
--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -11,7 +11,8 @@ from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 
 
-# To mock exe.jar
+# dummy server for exe.jar
+# exe.jar calls commits/latest (GET) then commits/collect (POST)
 class SuccessCommitHandlerMock(SimpleHTTPRequestHandler):
     def do_GET(self):
         body = []
@@ -67,6 +68,7 @@ class APIErrorTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_build(self):
+        # case: cli catches error
         success_server = HTTPServer(("", 0), SuccessCommitHandlerMock)
         thread = threading.Thread(None, success_server.serve_forever)
         thread.start()
@@ -84,7 +86,7 @@ class APIErrorTest(CliTestCase):
         success_server.shutdown()
         thread.join()
 
-        # exe.jar caught error
+        # case: exe.jar catches error
         error_server = HTTPServer(("", 0), ErrorCommitHandlerMock)
         thread = threading.Thread(None, error_server.serve_forever)
         thread.start()

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -160,9 +160,6 @@ class APIErrorTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_tests(self):
-        test_files_dir = Path(__file__).parent.joinpath(
-            '../data/minitest/').resolve()
-
         responses.replace(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}/test_sessions/{session_id}/events".format(
             base=get_base_url(),
             org=self.organization,
@@ -172,7 +169,7 @@ class APIErrorTest(CliTestCase):
             json=[], status=500)
 
         result = self.cli("record", "tests", "--session", self.session,
-                          "minitest", str(test_files_dir) + "/")
+                          "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
 
         responses.replace(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}/test_sessions/{session_id}/events".format(
@@ -184,5 +181,5 @@ class APIErrorTest(CliTestCase):
             json=[], status=404)
 
         result = self.cli("record", "tests", "--session", self.session,
-                          "minitest", str(test_files_dir) + "/")
+                          "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
`record commit` command exec `exe.jar`. However, we hadn't mocked and checked it.
So, I changed to check it.