### PR TITLE
Added another reported failure mode

### DIFF
--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -9,6 +9,10 @@ If you receive an error like this one, then you'll need to configure your firewa
 ```bash
 $ launchable verify
 unable to post to https://api.mercury.launchableinc.com/...
+
+$ launchable record build
+...
+Exception in thread "main" java.net.UnknownHostException: api.mercury.launchableinc.com: No address associated with hostname
 ```
 
 If you need to interact with the API via static IPs, first set the `LAUNCHABLE_BASE_URL` environment variable to `https://api-static.mercury.launchableinc.com`.


### PR DESCRIPTION
If DNS doesn't resolve during `record build` we get this:
```
2022-03-08_09:53:25  parallel: timeit run_launchable:	Exception in thread "main" java.net.UnknownHostException: api.mercury.launchableinc.com: No address associated with hostname
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:929)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1519)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:848)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1509)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1368)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1302)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.conn.SystemDefaultDnsResolver.resolve(SystemDefaultDnsResolver.java:45)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:112)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at com.launchableinc.commits.CommitGraphCollector.transfer(CommitGraphCollector.java:128)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at com.launchableinc.ingest.commits.CommitIngester.run(CommitIngester.java:142)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at com.launchableinc.cmdline.Main.main2(Main.java:90)
2022-03-08_09:53:25  parallel: timeit run_launchable:		at com.launchableinc.cmdline.Main.main(Main.java:82)
```