### PR TITLE
change pypi publish to API token auth

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,16 +89,3 @@ jobs:
         # Test rest of tests
         pipenv run test-xml $(tr '\r\n' '\n' < launchable-remainder.txt)
       shell: bash
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools setuptools_scm wheel twine
-    - name: Build
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Test publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,3 +89,16 @@ jobs:
         # Test rest of tests
         pipenv run test-xml $(tr '\r\n' '\n' < launchable-remainder.txt)
       shell: bash
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools setuptools_scm wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Test publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -100,5 +100,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,13 +22,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools setuptools_scm wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Test publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
     - name: Actions for Discord
       uses: Ilshidur/action-discord@0.3.0
       env:

--- a/.github/workflows/test-python-publish.yml
+++ b/.github/workflows/test-python-publish.yml
@@ -1,14 +1,16 @@
-# This workflows will upload a Python Package
+# This workflows will upload a Python Package to Test PyPI
 # For more information see: https://github.com/marketplace/actions/pypi-publish
 
-name: Upload Python Package
+name: TEST Upload Python Package
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-  deploy:
+  test_deploy:
 
     runs-on: ubuntu-latest
 
@@ -20,7 +22,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    # build and publish package using GitHub Actions workflow
+    # test build and publish package using GitHub Actions workflow
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
     - name: Install pypa/build
       run: >-
@@ -36,22 +38,9 @@ jobs:
         --wheel
         --outdir dist/
         .
-    # test publish
     - name: Test publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-    # actual publish
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-    - name: Actions for Discord
-      uses: Ilshidur/action-discord@0.3.0
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      with:
-        args: 'Launchable CLI {{ EVENT_PAYLOAD.release.tag_name }} is released! {{ EVENT_PAYLOAD.release.html_url }}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ install_requires =
     python-dateutil
     tabulate
 python_requires = >=3.5
+setup_requires =
+    setuptools-scm
 
 [options.entry_points]
 console_scripts = launchable = launchable.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,12 @@
 from setuptools import setup
 
-setup()
+
+def local_scheme(version) -> str:
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
+
+
+setup(
+    use_scm_version={"local_scheme": local_scheme},
+)


### PR DESCRIPTION
# What
- change PyPI authentication to API token
  - use Test PyPI for test publish and PyPI for official one
- update Github actions for PyPI publish
  - github action: https://github.com/marketplace/actions/pypi-publish
  - usage with build and publish: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/