### PR TITLE
Narrow down the click version for Python 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,8 @@ classifiers =
 packages = find:
 install_requires =
     click~=7.0;python_version<'3.6'
-    click>=8.0;python_version>='3.6'
+    click>=8.0,<8.1;python_version=='3.6'
+    click>=8.1;python_version>'3.6'
     requests>=2.25;python_version>='3.6'
 # requests dropped python 3.5 support since v2.26
     requests>=2.25,<2.26;python_version<'3.6'


### PR DESCRIPTION
Click dropped Python 3.6 support since 8.1 and we need to restrict the
version for it. Since we also need to support Python 3.5, which is not
supported by Click since 8.0, the version specifier is split into three.
