### PR TITLE
add Python3.10

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# What
- This PR is to add support for Python3.10.x.
- We already have cli support for Python 3.5.x to 3.9.x. Python3.9.13 is released recently as the last version for 3.9 series. Since Python 3.10.x becomes the latest series to be updated, it will be mandatory to support Python 3.10 for customers updating to the latest Python.
[Python Release Python 3.9.13](https://www.python.org/downloads/release/python-3913/) 
- Python3.11 already exists, but it is unnecessary to support until it becomes main stream.
[What’s New In Python 3.11 — Python 3.11.0b1 documentation](https://docs.python.org/3.11/whatsnew/3.11.html)