### PR TITLE
Ignore inner class for --test-compile-create-file option

### DIFF
--- a/launchable/test_runners/maven.py
+++ b/launchable/test_runners/maven.py
@@ -34,6 +34,11 @@ def subset(client, source_roots, test_compile_created_file):
                     # trim trailing newline
                     l = l.strip()
 
+                    # ignore inner class
+                    # e.g) com/example/Hoge$Inner.class
+                    if "$" in l:
+                        continue
+
                     if is_file(l):
                         client.test_paths.append(file2class_test_path(l))
                     else:

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -39,9 +39,13 @@ class MavenTest(CliTestCase):
 
         list_1 = ["com.example.launchable.model.a.ModelATest",
                   "com.example.launchable.model.b.ModelBTest",
+                  "com.example.launchable.model.b.ModelBTest$SomeInner",
                   "com.example.launchable.model.c.ModelCTest",
+
                   ]
+
         list_2 = ["com.example.launchable.service.ServiceATest",
+                  "com.example.launchable.service.ServiceATest$Inner1$Inner2",
                   "com.example.launchable.service.ServiceBTest",
                   "com.example.launchable.service.ServiceCTest",
                   ]


### PR DESCRIPTION
A class list file that was produced by `mvn test-compile` is included inner classes. But we support only top class so I fixed to ignore inner class.

this is example that `mvn test-compile` will be produced
```
com/hoge/Fuga.class
com/hoge/Fuga$InnerClassName.class
```