### PR TITLE
Fix Pytest profile failed with "local variable 'case' referenced before assignment"

### DIFF
--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -2,7 +2,7 @@ import glob
 import json
 import pathlib
 from platform import node
-from typing import Generator, List
+from typing import Generator, List, Optional
 from os.path import *
 import subprocess
 import click
@@ -93,6 +93,10 @@ def _path_to_class_name(path):
 
 
 def _pytest_formatter(test_path):
+    cls_name: Optional[str] = None
+    case: Optional[str] = None
+    file: Optional[str] = None
+
     for path in test_path:
         t = path.get('type', '')
         n = path.get('name', '')

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -93,9 +93,7 @@ def _path_to_class_name(path):
 
 
 def _pytest_formatter(test_path):
-    cls_name: Optional[str] = None
-    case: Optional[str] = None
-    file: Optional[str] = None
+    cls_name, case, file = None, None, None
 
     for path in test_path:
         t = path.get('type', '')


### PR DESCRIPTION
When the CLI working with `pytest-launchable`, the Pytest profile on the CLI failed with the message "local variable 'case' referenced before assignment". So, I add a few lines to define the variables at the top of the function.