### PR TITLE
Don't swallow the output message from commit collection

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -1,9 +1,8 @@
 import os
 import click
 import sys
+import subprocess
 from urllib.parse import urlparse
-
-from launchable.utils import subprocess
 
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import get_base_url
@@ -82,8 +81,9 @@ def exec_jar(source, max_days, dry_run):
         command.append("-dry-run")
     command.append(source)
 
-    subprocess.check_output(
+    subprocess.run(
         command,
+        check=True,
         shell=False,
     )
 


### PR DESCRIPTION
Al noticed that we no longer seem to be reporting the # of commits collected:

```
awilkes@MacBook-Pro cli-demo % launchable record build --name 20220615-2 --source src=cli
Launchable recorded build 20220615-2 to workspace launchableinc/awilkes with commits from 1 repository:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| src    | cli    | ec205499a358f3b9b7a06a182cc819c5536b631e |

awilkes@MacBook-Pro cli-demo % launchable record commit --source cli
awilkes@MacBook-Pro cli-demo %
```

I looked into this and realized that PR #375 introduecd this change. Judging from https://github.com/launchableinc/cli/pull/375, this is probably unintended.

The change makes sure stdout/stderr of the commit collection process is inherited from the CLI.