### PR TITLE
Honor default test inclusion/exclusion with Maven

### DIFF
--- a/launchable/test_runners/maven.py
+++ b/launchable/test_runners/maven.py
@@ -59,11 +59,9 @@ def subset(client, source_roots, test_compile_created_file):
                     # trim trailing newline
                     l = l.strip()
 
-                    if is_file(l):
-                        client.test_paths.append(file2class_test_path(l))
-                    else:
-                        client.test_paths.append(
-                            [{"type": "class", "name": l}])
+                    path = file2test(l)
+                    if path:
+                        client.test_paths.append(path)
     else:
         for root in source_roots:
             client.scan(root, '**/*', file2test)

--- a/launchable/utils/glob.py
+++ b/launchable/utils/glob.py
@@ -1,0 +1,44 @@
+"""Path name matching with extended GLOBs.
+
+Primarily developed to interface with Maven, which supports "**", "*", and "?" as the special characters
+"""
+import re
+
+def is_path_separator(c :str):
+    return c=='/' or c=='\\'
+
+def compile(glob :str) -> re.Pattern:
+    """Compiles a glob pattern like foo/**/*.txt into a """
+    # fnmatch.fnmatch is close but it doesn't deal with paths well, including '**'
+
+    p = ""
+    i = 0
+    n = len(glob)
+    while i < n:
+        c = glob[i]
+        i += 1
+
+        if c == '*':
+            if i<n and glob[i]=='*':
+                i += 1
+                if i<n and is_path_separator(glob[i]):
+                    # '**/' matches any sub-directories or none
+                    i += 1
+                    p += "(.+[\\/])?"
+                else:
+                    # '**' used like **Test.java. Is this even legal?
+                    p += ".*"
+            else:
+                p += "[^\\/]*"
+        elif c == '?':
+            p += "[^\\/]"
+        elif is_path_separator(c):
+            p += "[\\/]"
+        else:
+            p += re.escape(c)
+
+    return re.compile(p)
+
+
+
+

--- a/launchable/utils/glob.py
+++ b/launchable/utils/glob.py
@@ -3,11 +3,12 @@
 Primarily developed to interface with Maven, which supports "**", "*", and "?" as the special characters
 """
 import re
+from typing import Pattern
 
 def is_path_separator(c :str):
     return c=='/' or c=='\\'
 
-def compile(glob :str) -> re.Pattern:
+def compile(glob :str) -> Pattern:
     """Compiles a glob pattern like foo/**/*.txt into a """
     # fnmatch.fnmatch is close but it doesn't deal with paths well, including '**'
 

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -5,7 +5,7 @@ import json
 import gzip
 import os
 from tests.cli_test_case import CliTestCase
-
+from launchable.test_runners import maven
 
 class MavenTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath(
@@ -113,3 +113,19 @@ class MavenTest(CliTestCase):
             self.test_files_dir.joinpath("record_test_result.json"))
 
         self.assert_json_orderless_equal(expected, payload)
+
+    def test_glob(self):
+        for x in [
+            'foo/BarTest.java',
+            'foo/BarTest.class',
+            'FooTest.class',
+            'TestFoo.class',
+        ]:
+            self.assertTrue(maven.is_file(x))
+
+        for x in [
+            'foo/Bar$Test.class',
+            'foo/MyTest$Inner.class',
+            'foo/Util.class',
+        ]:
+            self.assertFalse(maven.is_file(x))

--- a/tests/utils/test_glob.py
+++ b/tests/utils/test_glob.py
@@ -1,0 +1,65 @@
+from launchable.utils.glob import *
+from unittest import TestCase
+
+
+class GlobTest(TestCase):
+    def check(self, glob: str, matches, not_matches):
+        p = compile(glob)
+        for m in matches:
+            self.assertTrue(p.fullmatch(m), "%s is expected to match %s" % (glob, m))
+        for m in not_matches:
+            self.assertFalse(p.fullmatch(m), "%s is expected not to match %s" % (glob, m))
+
+    def test_everything(self):
+        self.check(
+            glob='*.txt',
+            matches=[
+                "foo.txt",
+                "bar.txt",
+                "f.txt",
+                ".txt"
+            ],
+            not_matches=[
+                "dir/foo.txt",
+                "foo.exe",
+                "f_txt"
+            ]
+        )
+        self.check(
+            glob='???.txt',
+            matches=[
+                "foo.txt",
+                "bar.txt",
+            ],
+            not_matches=[
+                "dir/foo.txt",
+                "f.txt",
+                "food.txt",
+                "foo.exe"
+            ]
+        )
+        self.check(
+            glob='**/*.txt',
+            matches=[
+                "foo.txt",
+                "a/foo.txt",
+                "a/b/foo.txt",
+                "a\\b\\foo.txt"
+            ],
+            not_matches=[
+                "b.exe",
+                "footxt",
+                "a/footxt"
+            ]
+        )
+        self.check(
+            glob='**/*$*.class',
+            matches=[
+                "f$f.class",
+                "foo/bar$zot.class"
+            ],
+            not_matches=[
+                "foo.class",
+                "foo/bar.class"
+            ]
+        )


### PR DESCRIPTION
Maven Surefire has a mechanism to not only recursively scan directories to find tests but also include/exclude subset of the files as valid tests.

Emulate this behavior to collectly list up tests that should be selected. Since these are configurable parameters in our CLI as well, but I'm kicking that can down the road until it's needed. Especially given that the long term future of the Maven support would have to be in-process.