### PR TITLE
Properly construct HTTPS proxy array

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -3,33 +3,38 @@ import click
 import sys
 import subprocess
 from urllib.parse import urlparse
+from typing import List
 
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import get_base_url
 from ...utils.java import get_java_command
 from ...utils.logger import Logger, LOG_LEVEL_AUDIT
 
-jar_file_path = os.path.normpath(os.path.join(
-    os.path.dirname(__file__), "../../jar/exe_deploy.jar"))
+jar_file_path = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../jar/exe_deploy.jar"))
 
 
 @click.command()
-@click.option('--source',
-              help="repository path",
-              default=os.getcwd(),
-              type=click.Path(exists=True, file_okay=False),
-              )
-@click.option('--executable',
-              help="[Obsolete] it was to specify how to perform commit collection but has been removed",
-              type=click.Choice(['jar', 'docker']),
-              default='jar',
-              hidden=True
-              )
-@click.option('--max-days',
-              help="the maximum number of days to collect commits retroactively",
-              default=30
-              )
-@click.option('--scrub-pii', is_flag=True, help='[Deprecated] Scrub emails and names', hidden=True)
+@click.option(
+    '--source',
+    help="repository path",
+    default=os.getcwd(),
+    type=click.Path(exists=True, file_okay=False),
+)
+@click.option(
+    '--executable',
+    help="[Obsolete] it was to specify how to perform commit collection but has been removed",
+    type=click.Choice(['jar', 'docker']),
+    default='jar',
+    hidden=True)
+@click.option(
+    '--max-days',
+    help="the maximum number of days to collect commits retroactively",
+    default=30)
+@click.option('--scrub-pii',
+              is_flag=True,
+              help='[Deprecated] Scrub emails and names',
+              hidden=True)
 @click.pass_context
 def commit(ctx, source, executable, max_days, scrub_pii):
     if executable == 'docker':
@@ -41,8 +46,11 @@ def commit(ctx, source, executable, max_days, scrub_pii):
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
-            click.echo(click.style("Can't get commit history from `{}`. Do you run command root of git-controlled directory? If not, please set a directory use by --source option.".format(
-                os.path.abspath(source)), fg='yellow'), err=True)
+            click.echo(click.style(
+                "Can't get commit history from `{}`. Do you run command root of git-controlled directory? If not, please set a directory use by --source option."
+                .format(os.path.abspath(source)),
+                fg='yellow'),
+                err=True)
             print(e)
 
 
@@ -57,23 +65,17 @@ def exec_jar(source, max_days, dry_run):
     # using subprocess.check_out with shell=False and a list of command to prevent vulnerability
     # https://knowledge-base.secureflag.com/vulnerabilities/code_injection/os_command_injection_python.html
     command = [java]
-    https_proxy = os.getenv("HTTPS_PROXY")
-    proxy_option = _build_proxy_option(https_proxy) if https_proxy else ""
-    if proxy_option != "":
-        command.append(proxy_option)
-
-    command.extend(
-        [
-            "-jar",
-            jar_file_path,
-            "ingest:commit",
-            "-endpoint",
-            "{}/intake/".format(base_url),
-            "-max-days",
-            str(max_days),
-            "-scrub-pii",
-        ],
-    )
+    command.extend(_build_proxy_option(os.getenv("HTTPS_PROXY")))
+    command.extend([
+        "-jar",
+        jar_file_path,
+        "ingest:commit",
+        "-endpoint",
+        "{}/intake/".format(base_url),
+        "-max-days",
+        str(max_days),
+        "-scrub-pii",
+    ])
 
     if Logger().logger.isEnabledFor(LOG_LEVEL_AUDIT):
         command.append("-audit")
@@ -88,8 +90,12 @@ def exec_jar(source, max_days, dry_run):
     )
 
 
-def _build_proxy_option(https_proxy: str) -> str:
-    if not (https_proxy.startswith("https://") or https_proxy.startswith("http://")):
+def _build_proxy_option(https_proxy: str) -> List[str]:
+    if not https_proxy:
+        return []
+
+    if not (https_proxy.startswith("https://")
+            or https_proxy.startswith("http://")):
         https_proxy = "https://" + https_proxy
     proxy_url = urlparse(https_proxy)
 
@@ -98,5 +104,4 @@ def _build_proxy_option(https_proxy: str) -> str:
         options.append("-Dhttps.proxyHost={}".format(proxy_url.hostname))
     if proxy_url.port:
         options.append("-Dhttps.proxyPort={}".format(proxy_url.port))
-
-    return "{} ".format(" ".join(options)) if len(options) else ""
+    return options

--- a/tests/commands/record/test_commit.py
+++ b/tests/commands/record/test_commit.py
@@ -27,7 +27,9 @@ class CommitHandler(SimpleHTTPRequestHandler):
 
 
 class CommitTest(CliTestCase):
-    @ mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+
+    @mock.patch.dict(os.environ,
+                     {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_run_commit(self):
         server = HTTPServer(("", 0), CommitHandler)
         thread = threading.Thread(None, server.serve_forever)
@@ -44,13 +46,15 @@ class CommitTest(CliTestCase):
         thread.join()
 
     def test_proxy_options(self):
-        self.assertEqual(_build_proxy_option("https://some_proxy:1234"),
-                         "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
-        self.assertEqual(_build_proxy_option("some_proxy:1234"),
-                         "-Dhttps.proxyHost=some_proxy -Dhttps.proxyPort=1234 ")
+        self.assertEqual(
+            _build_proxy_option("https://some_proxy:1234"),
+            ['-Dhttps.proxyHost=some_proxy', '-Dhttps.proxyPort=1234'])
+        self.assertEqual(
+            _build_proxy_option("some_proxy:1234"),
+            ['-Dhttps.proxyHost=some_proxy', '-Dhttps.proxyPort=1234'])
         self.assertEqual(_build_proxy_option("some_proxy"),
-                         "-Dhttps.proxyHost=some_proxy ")
-        self.assertEqual(_build_proxy_option(
-            "https://some_proxy"), "-Dhttps.proxyHost=some_proxy ")
+                         ['-Dhttps.proxyHost=some_proxy'])
+        self.assertEqual(_build_proxy_option("https://some_proxy"),
+                         ['-Dhttps.proxyHost=some_proxy'])
         self.assertEqual(_build_proxy_option("http://yoyoyo"),
-                         "-Dhttps.proxyHost=yoyoyo ")
+                         ['-Dhttps.proxyHost=yoyoyo'])


### PR DESCRIPTION
Prior to this change, the proxy config is concatenated as one string
(e.g. ['java', '-Dhttps.proxyHost=something -Dhttps.proxyPort=80']).
This must be ['java', '-Dhttps.proxyHost=something',
'-Dhttps.proxyPort=80'].

The formatting is automatically done by pre-commit.
