### PR TITLE
Add observation mode

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -3,7 +3,7 @@ from typing import Optional
 from ..utils.session import read_build, read_session
 
 
-def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[]) -> Optional[str]:
+def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], evaluation=False) -> Optional[str]:
     """Determine the test session ID to be used.
 
     1. If the user explicitly provides the session id via the `--session` option
@@ -36,5 +36,5 @@ def find_or_create_session(context: click.core.Context, session: Optional[str], 
             return session_id
         else:
             context.invoke(
-                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor)
+                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor, evaluation=evaluation)
             return read_session(saved_build_name)

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -3,7 +3,7 @@ from typing import Optional
 from ..utils.session import read_build, read_session
 
 
-def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], evaluation=False) -> Optional[str]:
+def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], is_evaluation=False) -> Optional[str]:
     """Determine the test session ID to be used.
 
     1. If the user explicitly provides the session id via the `--session` option
@@ -36,5 +36,5 @@ def find_or_create_session(context: click.core.Context, session: Optional[str], 
             return session_id
         else:
             context.invoke(
-                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor, evaluation=evaluation)
+                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor, is_evaluation=is_evaluation)
             return read_session(saved_build_name)

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -3,7 +3,7 @@ from typing import Optional
 from ..utils.session import read_build, read_session
 
 
-def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], is_observation=False) -> Optional[str]:
+def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], is_observation: bool = False) -> Optional[str]:
     """Determine the test session ID to be used.
 
     1. If the user explicitly provides the session id via the `--session` option

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -3,7 +3,7 @@ from typing import Optional
 from ..utils.session import read_build, read_session
 
 
-def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], is_evaluation=False) -> Optional[str]:
+def find_or_create_session(context: click.core.Context, session: Optional[str], build_name: Optional[str], flavor=[], is_observation=False) -> Optional[str]:
     """Determine the test session ID to be used.
 
     1. If the user explicitly provides the session id via the `--session` option
@@ -36,5 +36,5 @@ def find_or_create_session(context: click.core.Context, session: Optional[str], 
             return session_id
         else:
             context.invoke(
-                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor, is_evaluation=is_evaluation)
+                session_command, build_name=saved_build_name, save_session_file=True, print_session=False, flavor=flavor, is_observation=is_observation)
             return read_session(saved_build_name)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -35,8 +35,15 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     cls=KeyValueType,
     multiple=True,
 )
+@click.option(
+    "--evaluation",
+    "evaluation",
+    help='evaluation',
+    is_flag=True,
+    default=False,
+)
 @click.pass_context
-def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[]):
+def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], evaluation: bool = False):
     """
     print_session is for barckward compatibility.
     If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.
@@ -65,7 +72,9 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
     try:
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={
-                             "flavors": flavor_dict})
+                             "flavors": flavor_dict,
+                             "evaluation": evaluation,
+                             })
 
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -40,7 +40,7 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     "evaluation",
     help='evaluation',
     is_flag=True,
-    default=False,
+    required=False,
 )
 @click.pass_context
 def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], evaluation: bool = False):

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -38,9 +38,8 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 @click.option(
     "--observation",
     "is_observation",
-    help='observation',
+    help="enable observation mode",
     is_flag=True,
-    required=False,
 )
 @click.pass_context
 def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], is_observation: bool = False):

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -36,14 +36,14 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     multiple=True,
 )
 @click.option(
-    "--evaluation",
-    "is_evaluation",
-    help='evaluation',
+    "--observation",
+    "is_observation",
+    help='observation',
     is_flag=True,
     required=False,
 )
 @click.pass_context
-def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], is_evaluation: bool = False):
+def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], is_observation: bool = False):
     """
     print_session is for barckward compatibility.
     If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.
@@ -73,7 +73,7 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={
                              "flavors": flavor_dict,
-                             "evaluation": is_evaluation,
+                             "observation": is_observation,
                              })
 
         if res.status_code == HTTPStatus.NOT_FOUND:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -37,13 +37,13 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 )
 @click.option(
     "--evaluation",
-    "evaluation",
+    "is_evaluation",
     help='evaluation',
     is_flag=True,
     required=False,
 )
 @click.pass_context
-def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], evaluation: bool = False):
+def session(ctx: click.core.Context, build_name: str, save_session_file: bool, print_session: bool = True, flavor=[], is_evaluation: bool = False):
     """
     print_session is for barckward compatibility.
     If you run this `record session` standalone, the command should print the session ID because v1.1 users expect the beheivior. That is why the flag is default True.
@@ -73,7 +73,7 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={
                              "flavors": flavor_dict,
-                             "evaluation": evaluation,
+                             "evaluation": is_evaluation,
                              })
 
         if res.status_code == HTTPStatus.NOT_FOUND:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -99,6 +99,13 @@ from tabulate import tabulate
     help='Ignore tests that were added recently.\n\nNOTICE: this option will ignore tests that you added just now as well',
     is_flag=True
 )
+@click.option(
+    "--evaluation",
+    "evaluation",
+    help='evaluation',
+    is_flag=True,
+    default=False,
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -113,9 +120,16 @@ def subset(
     split: bool,
     no_base_path_inference: bool,
     ignore_new_tests: bool,
+    evaluation: bool,
 ):
 
-    session_id = find_or_create_session(context, session, build_name, flavor)
+    session_id = find_or_create_session(
+        context=context,
+        session=session,
+        build_name=build_name,
+        flavor=flavor,
+        evaluation=evaluation,
+    )
     file_path_normalizer = FilePathNormalizer(
         base_path, no_base_path_inference=no_base_path_inference)
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -104,7 +104,7 @@ from tabulate import tabulate
     "evaluation",
     help='evaluation',
     is_flag=True,
-    default=False,
+    required=False,
 )
 @click.pass_context
 def subset(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -100,9 +100,9 @@ from tabulate import tabulate
     is_flag=True
 )
 @click.option(
-    "--evaluation",
-    "is_evaluation",
-    help='evaluation',
+    "--observation",
+    "is_observation",
+    help='observation',
     is_flag=True,
     required=False,
 )
@@ -120,7 +120,7 @@ def subset(
     split: bool,
     no_base_path_inference: bool,
     ignore_new_tests: bool,
-    is_evaluation: bool,
+    is_observation: bool,
 ):
 
     session_id = find_or_create_session(
@@ -128,7 +128,7 @@ def subset(
         session=session,
         build_name=build_name,
         flavor=flavor,
-        is_evaluation=is_evaluation,
+        is_observation=is_observation,
     )
     file_path_normalizer = FilePathNormalizer(
         base_path, no_base_path_inference=no_base_path_inference)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -102,9 +102,8 @@ from tabulate import tabulate
 @click.option(
     "--observation",
     "is_observation",
-    help='observation',
+    help="enable observation mode",
     is_flag=True,
-    required=False,
 )
 @click.pass_context
 def subset(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -101,7 +101,7 @@ from tabulate import tabulate
 )
 @click.option(
     "--evaluation",
-    "evaluation",
+    "is_evaluation",
     help='evaluation',
     is_flag=True,
     required=False,
@@ -120,7 +120,7 @@ def subset(
     split: bool,
     no_base_path_inference: bool,
     ignore_new_tests: bool,
-    evaluation: bool,
+    is_evaluation: bool,
 ):
 
     session_id = find_or_create_session(
@@ -128,7 +128,7 @@ def subset(
         session=session,
         build_name=build_name,
         flavor=flavor,
-        evaluation=evaluation,
+        is_evaluation=is_evaluation,
     )
     file_path_normalizer = FilePathNormalizer(
         base_path, no_base_path_inference=no_base_path_inference)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -39,3 +39,14 @@ class SessionTest(CliTestCase):
             self.assertEqual(result.exit_code, 1)
             self.assertTrue(
                 "Expected key-value like --option kye=value or --option key value." in result.output)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_run_session_with_evaluation(self):
+        result = self.cli("record", "session", "--build",
+                          self.build_name, "--evaluation")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {"flavors": {}, "evaluation": True}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -14,7 +14,8 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}}, payload)
+        self.assert_json_orderless_equal(
+            {"flavors": {}, "evaluation": False}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -24,11 +25,13 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {
-            "key": "value",
-            "k": "v",
-            "k e y": "v a l u e",
-        }}, payload)
+        self.assert_json_orderless_equal({
+            "flavors": {
+                "key": "value",
+                "k": "v",
+                "k e y": "v a l u e",
+            },
+            "evaluation": False, }, payload)
 
         with self.assertRaises(ValueError):
             result = self.cli("record", "session", "--build", self.build_name,

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -15,7 +15,7 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "evaluation": False}, payload)
+            {"flavors": {}, "observation": False}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -31,7 +31,7 @@ class SessionTest(CliTestCase):
                 "k": "v",
                 "k e y": "v a l u e",
             },
-            "evaluation": False, }, payload)
+            "observation": False, }, payload)
 
         with self.assertRaises(ValueError):
             result = self.cli("record", "session", "--build", self.build_name,
@@ -42,11 +42,11 @@ class SessionTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_run_session_with_evaluation(self):
+    def test_run_session_with_observation(self):
         result = self.cli("record", "session", "--build",
-                          self.build_name, "--evaluation")
+                          self.build_name, "--observation")
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "evaluation": True}, payload)
+            {"flavors": {}, "observation": True}, payload)


### PR DESCRIPTION
Add new option `--observation`.
If the user uses this option, Launchable will show details information for the subset and the record test results.
