### PR TITLE
Enable slack notification default

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -324,14 +324,8 @@ def tests(
                     send(p)
                     exceptions.extend(es)
 
-                payload = None
-                # NOTE: this feature is still beta. If you want to try please set env value
-                if os.getenv("LAUNCHABLE_SLACK_NOTIFICATION"):
-                    metadata = get_env_values(client)
-                    payload = {"metadata": metadata}
-
                 res = client.request(
-                    "patch", "{}/close".format(session_id), payload=payload)
+                    "patch", "{}/close".format(session_id), payload={"metadata": get_env_values(client)})
                 res.raise_for_status()
 
                 if len(exceptions) > 0:

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -50,6 +50,8 @@ class CliTestCase(unittest.TestCase):
                       json={}, status=200)
         responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/builds/{}".format(get_base_url(), self.organization, self.workspace, self.build_name),
                       json={'createdAt': "2020-01-02T03:45:56.123+00:00", 'id': 123}, status=200)
+        responses.add(responses.GET, "{}/intake/organizations/{}/workspaces/{}/slack/notification/key/list".format(get_base_url(), self.organization, self.workspace),
+                      json={'keys': ["GITHUB_ACTOR", "BRANCH_NAME"]}, status=200)
 
     def tearDown(self):
         clean_session_files()

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -50,4 +50,4 @@ class CypressTest(CliTestCase):
                           'cypress', str(self.test_files_dir) + "/empty.xml")
         self.assertEqual(result.exit_code, 0)
         self.assertIn(
-            "close", responses.calls[1].request.url, "No record request")
+            "close", responses.calls[2].request.url, "No record request")

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -64,7 +64,7 @@ class GoTestTest(CliTestCase):
         self.assert_json_orderless_equal(expected, payload)
 
         self.assertIn(
-            'close', responses.calls[2].request.url, 'call close API')
+            'close', responses.calls[3].request.url, 'call close API')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -90,4 +90,4 @@ class GoTestTest(CliTestCase):
         self.assert_json_orderless_equal(expected, payload)
 
         self.assertIn(
-            'close', responses.calls[3].request.url, 'call close API')
+            'close', responses.calls[4].request.url, 'call close API')


### PR DESCRIPTION
Slack notification feature is already closed beta ref: https://docs.launchableinc.com/features/test-notifications-via-slack
So, I changed to enable this feature by default.