### PR TITLE
Add options for zero input subsetting

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -110,6 +110,12 @@ from tabulate import tabulate
     help="get subset list from previous full tests",
     is_flag=True,
 )
+@click.option(
+    "--output-exclusion-rules",
+    "is_output_exclusion_rules",
+    help="outputs the exclude test list. Switch the subset and rest.",
+    is_flag=True,
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -126,6 +132,7 @@ def subset(
     ignore_new_tests: bool,
     is_observation: bool,
     is_get_tests_from_previous_full_runs: bool,
+    is_output_exclusion_rules: bool,
 ):
 
     if is_observation and is_get_tests_from_previous_full_runs:
@@ -331,8 +338,11 @@ def subset(
                 click.echo("subset/{}".format(subset_id))
             else:
                 _output, _rests = output, rests
+
                 if is_observation:
                     _output = _output + _rests
+                if is_output_exclusion_rules:
+                    _output, _rests = _rests, _output
 
                 self.output_handler(_output, _rests)
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -1,13 +1,12 @@
-from launchable.commands.record.build import build
 from launchable.utils.authentication import get_org_workspace
-from launchable.utils.session import parse_session, read_build
+from launchable.utils.session import parse_session
 import click
 import os
 import sys
-from os.path import join, relpath
+from os.path import join
 import pathlib
 import glob
-from typing import Callable, Union, Optional, List
+from typing import Callable, TextIO, Union, Optional, List
 from ..utils.click import PERCENTAGE, DURATION, PercentageType, DurationType
 from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.http_client import LaunchableClient
@@ -191,7 +190,11 @@ def subset(
             """register one test"""
             self.test_paths.append(self.to_test_path(rel_base_path(path)))
 
-        def stdin(self):
+        def stdin(self) -> Union[TextIO, List]:
+            # To avoid the cli continue to wait from stdin
+            if is_get_tests_from_previous_full_runs:
+                return []
+
             """
             Returns sys.stdin, but after ensuring that it's connected to something reasonable.
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -105,8 +105,8 @@ from tabulate import tabulate
     is_flag=True,
 )
 @click.option(
-    "--get-tests-from-previous-full-runs",
-    "is_get_tests_from_previous_full_runs",
+    "--get-tests-from-previous-sessions",
+    "is_get_tests_from_previous_sessions",
     help="get subset list from previous full tests",
     is_flag=True,
 )
@@ -131,11 +131,11 @@ def subset(
     no_base_path_inference: bool,
     ignore_new_tests: bool,
     is_observation: bool,
-    is_get_tests_from_previous_full_runs: bool,
+    is_get_tests_from_previous_sessions: bool,
     is_output_exclusion_rules: bool,
 ):
 
-    if is_observation and is_get_tests_from_previous_full_runs:
+    if is_observation and is_get_tests_from_previous_sessions:
         click.echo(click.style(
             "Can not use --observation and --get-tests-from-previous-full-runs options at the same time", fg="red"), err=True)
         sys.exit(1)
@@ -199,7 +199,7 @@ def subset(
 
         def stdin(self) -> Union[TextIO, List]:
             # To avoid the cli continue to wait from stdin
-            if is_get_tests_from_previous_full_runs:
+            if is_get_tests_from_previous_sessions:
                 return []
 
             """
@@ -262,7 +262,7 @@ def subset(
                     "id": os.path.basename(session_id)
                 },
                 "ignoreNewTests": ignore_new_tests,
-                "getTestsFromPreviousFullRuns": is_get_tests_from_previous_full_runs,
+                "getTestsFromPreviousSessions": is_get_tests_from_previous_sessions,
             }
 
             if target is not None:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -129,6 +129,11 @@ def subset(
     is_get_tests_from_previous_full_runs: bool,
 ):
 
+    if is_observation and is_get_tests_from_previous_full_runs:
+        click.echo(click.style(
+            "Can not use --observation and --get-tests-from-previous-full-runs options at the same time", fg="red"), err=True)
+        sys.exit(1)
+
     session_id = find_or_create_session(
         context=context,
         session=session,

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -105,6 +105,12 @@ from tabulate import tabulate
     help="enable observation mode",
     is_flag=True,
 )
+@click.option(
+    "--get-tests-from-previous-full-runs",
+    "is_get_tests_from_previous_full_runs",
+    help="get subset list from previous full tests",
+    is_flag=True,
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -120,6 +126,7 @@ def subset(
     no_base_path_inference: bool,
     ignore_new_tests: bool,
     is_observation: bool,
+    is_get_tests_from_previous_full_runs: bool,
 ):
 
     session_id = find_or_create_session(
@@ -240,6 +247,7 @@ def subset(
                     "id": os.path.basename(session_id)
                 },
                 "ignoreNewTests": ignore_new_tests,
+                "getTestsFromPreviousFullRuns": is_get_tests_from_previous_full_runs,
             }
 
             if target is not None:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -137,7 +137,7 @@ def subset(
 
     if is_observation and is_get_tests_from_previous_sessions:
         click.echo(click.style(
-            "Can not use --observation and --get-tests-from-previous-full-runs options at the same time", fg="red"), err=True)
+            "Cannot use --observation and --get-tests-from-previous-sessions options at the same time", fg="red"), err=True)
         sys.exit(1)
 
     session_id = find_or_create_session(

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -59,3 +59,50 @@ class SubsetTest(CliTestCase):
             observation_mode_rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
         observation_mode_rest.close()
         os.unlink(observation_mode_rest.name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_output_exclusion_rules(self):
+        pipe = "test_aaa.py\ntest_111.py\ntest_bbb.py\ntest_222.py\ntest_ccc.py\ntest_333.py\n"
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json={
+            "testPaths": [
+                [{"type": "file", "name": "test_aaa.py"}],
+                [{"type": "file", "name": "test_bbb.py"}],
+                [{"type": "file", "name": "test_ccc.py"}],
+            ],
+            "rest": [
+                [{"type": "file", "name": "test_111.py"}],
+                [{"type": "file", "name": "test_222.py"}],
+                [{"type": "file", "name": "test_333.py"}],
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 15, "candidates": 3, "rate": 70},
+                "rest": {"duration": 6, "candidates": 3, "rate": 30}
+            },
+        }, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "70%", "--session",
+                          self.session, "--rest", rest.name,  "file", input=pipe, mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_aaa.py\ntest_bbb.py\ntest_ccc.py\n")
+        self.assertEqual(
+            rest.read().decode(), "test_111.py\ntest_222.py\ntest_333.py")
+        rest.close()
+        os.unlink(rest.name)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "70%", "--session",
+                          self.session, "--rest", rest.name, "--output-exclusion-rules", "file", input=pipe, mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_111.py\ntest_222.py\ntest_333.py\n")
+        self.assertEqual(
+            rest.read().decode(), "test_aaa.py\ntest_bbb.py\ntest_ccc.py")
+        rest.close()
+        os.unlink(rest.name)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -89,7 +89,7 @@ class SubsetTest(CliTestCase):
         self.assertEqual(
             result.stdout, "test_aaa.py\ntest_bbb.py\ntest_ccc.py\n")
         self.assertEqual(
-            rest.read().decode(), "test_eee.py\ntest_fff.py\ntest_ggg.py")
+            rest.read().decode(), os.linesep.join(["test_eee.py", "test_fff.py", "test_ggg.py"]))
         rest.close()
         os.unlink(rest.name)
 
@@ -124,7 +124,7 @@ class SubsetTest(CliTestCase):
         self.assertEqual(
             result.stdout, "test_aaa.py\ntest_bbb.py\ntest_ccc.py\n")
         self.assertEqual(
-            rest.read().decode(), "test_111.py\ntest_222.py\ntest_333.py")
+            rest.read().decode(), os.linesep.join(["test_111.py", "test_222.py", "test_333.py"]))
         rest.close()
         os.unlink(rest.name)
 
@@ -135,7 +135,8 @@ class SubsetTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
             result.stdout, "test_111.py\ntest_222.py\ntest_333.py\n")
+
         self.assertEqual(
-            rest.read().decode(), "test_aaa.py\ntest_bbb.py\ntest_ccc.py")
+            rest.read().decode(), os.linesep.join(["test_aaa.py", "test_bbb.py", "test_ccc.py"]))
         rest.close()
         os.unlink(rest.name)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -83,7 +83,7 @@ class SubsetTest(CliTestCase):
 
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli("subset", "--target", "30%", "--session",
-                          self.session, "--rest", rest.name, "--get-tests-from-previous-full-runs",  "file", mix_stderr=False)
+                          self.session, "--rest", rest.name, "--get-tests-from-previous-sessions",  "file", mix_stderr=False)
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(

--- a/tests/data/adb/subset_result.json
+++ b/tests/data/adb/subset_result.json
@@ -10,5 +10,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/adb/subset_result.json
+++ b/tests/data/adb/subset_result.json
@@ -9,6 +9,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
-
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/ant/subset_result.json
+++ b/tests/data/ant/subset_result.json
@@ -5,5 +5,6 @@
   ],
   "session": { "id": "16" },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
-  "ignoreNewTests": false
+  "ignoreNewTests": false,
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/ant/subset_result.json
+++ b/tests/data/ant/subset_result.json
@@ -6,5 +6,5 @@
   "session": { "id": "16" },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/bazel/subset_result.json
+++ b/tests/data/bazel/subset_result.json
@@ -39,5 +39,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/bazel/subset_result.json
+++ b/tests/data/bazel/subset_result.json
@@ -40,5 +40,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/behave/subset_result.json
+++ b/tests/data/behave/subset_result.json
@@ -7,5 +7,5 @@
   "session": {
       "id":  "16"
   },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/behave/subset_result.json
+++ b/tests/data/behave/subset_result.json
@@ -6,5 +6,6 @@
   "ignoreNewTests": false,
   "session": {
       "id":  "16"
-  }
+  },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/ctest/subset_result.json
+++ b/tests/data/ctest/subset_result.json
@@ -8,5 +8,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/ctest/subset_result.json
+++ b/tests/data/ctest/subset_result.json
@@ -7,5 +7,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/cypress/subset_result.json
+++ b/tests/data/cypress/subset_result.json
@@ -12,5 +12,5 @@
       }
     ]
   ],
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/cypress/subset_result.json
+++ b/tests/data/cypress/subset_result.json
@@ -11,5 +11,6 @@
         "type": "file"
       }
     ]
-  ]
+  ],
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/go_test/subset_result.json
+++ b/tests/data/go_test/subset_result.json
@@ -4,4 +4,5 @@
   "testPaths": [[{"name": "TestExample1", "type": "testcase"}],
                 [{"name": "TestExample2", "type": "testcase"}],
                 [{"name": "TestExample3", "type": "testcase"}],
-                [{"name": "TestExample4", "type": "testcase"}]]}
+                [{"name": "TestExample4", "type": "testcase"}]],
+  "getTestsFromPreviousFullRuns": false}

--- a/tests/data/go_test/subset_result.json
+++ b/tests/data/go_test/subset_result.json
@@ -5,4 +5,4 @@
                 [{"name": "TestExample2", "type": "testcase"}],
                 [{"name": "TestExample3", "type": "testcase"}],
                 [{"name": "TestExample4", "type": "testcase"}]],
-  "getTestsFromPreviousFullRuns": false}
+  "getTestsFromPreviousSessions": false}

--- a/tests/data/googletest/subset_result.json
+++ b/tests/data/googletest/subset_result.json
@@ -15,5 +15,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/googletest/subset_result.json
+++ b/tests/data/googletest/subset_result.json
@@ -16,5 +16,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/jest/subset_result.json
+++ b/tests/data/jest/subset_result.json
@@ -35,5 +35,6 @@
   ],
   "session": { "id": "16" },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
-  "ignoreNewTests": false
+  "ignoreNewTests": false,
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/jest/subset_result.json
+++ b/tests/data/jest/subset_result.json
@@ -36,5 +36,5 @@
   "session": { "id": "16" },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/maven/createdFile_1.lst
+++ b/tests/data/maven/createdFile_1.lst
@@ -1,0 +1,4 @@
+com/example/launchable/model/a/ModelATest.class
+com/example/launchable/model/b/ModelBTest.class
+com/example/launchable/model/b/ModelBTest$SomeInner.class
+com/example/launchable/model/c/ModelCTest.class

--- a/tests/data/maven/createdFile_2.lst
+++ b/tests/data/maven/createdFile_2.lst
@@ -1,0 +1,4 @@
+com/example/launchable/service/ServiceATest.class
+com/example/launchable/service/ServiceATest$Inner1$Inner2.class
+com/example/launchable/service/ServiceBTest.class
+com/example/launchable/service/ServiceCTest.class

--- a/tests/data/maven/subset_by_absolute_time_result.json
+++ b/tests/data/maven/subset_by_absolute_time_result.json
@@ -11,5 +11,5 @@
   },
   "goal": {"type": "subset-by-absolute-time", "duration": 5400},
   "ignoreNewTests": false,
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/maven/subset_by_absolute_time_result.json
+++ b/tests/data/maven/subset_by_absolute_time_result.json
@@ -10,5 +10,6 @@
       "id":  "16"
   },
   "goal": {"type": "subset-by-absolute-time", "duration": 5400},
-  "ignoreNewTests": false
+  "ignoreNewTests": false,
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/maven/subset_by_confidence_result.json
+++ b/tests/data/maven/subset_by_confidence_result.json
@@ -10,5 +10,6 @@
       "id":  "16"
   },
   "goal": {"type": "subset-by-confidence", "percentage": 0.9},
-  "ignoreNewTests": false
+  "ignoreNewTests": false,
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/maven/subset_by_confidence_result.json
+++ b/tests/data/maven/subset_by_confidence_result.json
@@ -11,5 +11,5 @@
   },
   "goal": {"type": "subset-by-confidence", "percentage": 0.9},
   "ignoreNewTests": false,
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/maven/subset_from_file_result.json
+++ b/tests/data/maven/subset_from_file_result.json
@@ -24,7 +24,8 @@
   "ignoreNewTests": false,
   "session": {
       "id":  "16"
-  }
+  },
+  "getTestsFromPreviousFullRuns": false
 }
 
 

--- a/tests/data/maven/subset_from_file_result.json
+++ b/tests/data/maven/subset_from_file_result.json
@@ -25,7 +25,7 @@
   "session": {
       "id":  "16"
   },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }
 
 

--- a/tests/data/maven/subset_result.json
+++ b/tests/data/maven/subset_result.json
@@ -11,5 +11,5 @@
   "session": {
       "id":  "16"
   },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/maven/subset_result.json
+++ b/tests/data/maven/subset_result.json
@@ -10,5 +10,6 @@
   "ignoreNewTests": false,
   "session": {
       "id":  "16"
-  }
+  },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/nunit/subset_result.json
+++ b/tests/data/nunit/subset_result.json
@@ -45,5 +45,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/nunit/subset_result.json
+++ b/tests/data/nunit/subset_result.json
@@ -44,5 +44,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/pytest/subset_result.json
+++ b/tests/data/pytest/subset_result.json
@@ -127,5 +127,6 @@
     "id": "16"
   },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
-  "ignoreNewTests": false
+  "ignoreNewTests": false,
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/pytest/subset_result.json
+++ b/tests/data/pytest/subset_result.json
@@ -128,5 +128,5 @@
   },
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/data/robot/subset_result.json
+++ b/tests/data/robot/subset_result.json
@@ -27,5 +27,6 @@
   ],
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
-  "session": { "id": "16" }
+  "session": { "id": "16" },
+  "getTestsFromPreviousFullRuns": false
 }

--- a/tests/data/robot/subset_result.json
+++ b/tests/data/robot/subset_result.json
@@ -28,5 +28,5 @@
   "goal": {"type": "subset-by-percentage", "percentage": 0.1},
   "ignoreNewTests": false,
   "session": { "id": "16" },
-  "getTestsFromPreviousFullRuns": false
+  "getTestsFromPreviousSessions": false
 }

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -63,7 +63,8 @@ class RawTest(CliTestCase):
                 ],
                 'session': {'id': str(self.session_id)},
                 "goal": {"type": "subset-by-percentage", "percentage": 0.1},
-                "ignoreNewTests": False
+                "ignoreNewTests": False,
+                "getTestsFromPreviousFullRuns": False,
             })
             # Check split output
             self.assertEqual(result.stdout, '\n'.join([

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -64,7 +64,7 @@ class RawTest(CliTestCase):
                 'session': {'id': str(self.session_id)},
                 "goal": {"type": "subset-by-percentage", "percentage": 0.1},
                 "ignoreNewTests": False,
-                "getTestsFromPreviousFullRuns": False,
+                "getTestsFromPreviousSessions": False,
             })
             # Check split output
             self.assertEqual(result.stdout, '\n'.join([


### PR DESCRIPTION
I added two options 

- `--output-exclusion-rules`
- `--get-tests-from-previous-full-runs`

### --output-exclusion-rules

When the `--output-exclusion-rules` option enabled, the cli will switch the subset result and the rest result for excluding option

e.g)
```sh
launchable subset --target 30% --output-exclusion-rules src/test/** > exclude.txt
mvn test -Dsurefire.excludesFile=exclude.txt
```

### --get-tests-from-previous-full-runs

The `get-tests-from-previous-full-runs` option is new feature of subset. The user can execute a subset request without subset test lists, after reporting test results sometimes.


