### PR TITLE
Capture job links

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,7 +1,7 @@
 import click
 import os
 import sys
-from typing import Sequence
+from typing import Dict, Mapping, Optional, Sequence
 from http import HTTPStatus
 from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -10,6 +10,14 @@ from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
+JENKINS_URL_KEY = 'JENKINS_URL'
+JENKINS_BUILD_URL_KEY = 'BUILD_URL'
+GITHUB_ACTION_KEY = 'GITHUB_ACTION'
+GITHUB_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
+GITHUB_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
+GITHUB_RUN_ID_KEY = 'GITHUB_RUN_ID'
+CIRCLECI_KEY = 'CIRCLECI'
+CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
 
 
 @click.command()
@@ -67,13 +75,18 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
         elif isinstance(f, Sequence):
             flavor_dict[f[0]] = f[1]
 
+    link = _capture_link(os.environ)
+    payload = {
+        "flavors": flavor_dict,
+        "observation": is_observation,
+    }
+    if link:
+        payload["link"] = link
+
     client = LaunchableClient(dry_run=ctx.obj.dry_run)
     try:
         sub_path = "builds/{}/test_sessions".format(build_name)
-        res = client.request("post", sub_path, payload={
-                             "flavors": flavor_dict,
-                             "observation": is_observation,
-                             })
+        res = client.request("post", sub_path, payload=payload)
 
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(
@@ -94,3 +107,14 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
             raise e
         else:
             click.echo(e, err=True)
+
+
+def _capture_link(env: Mapping[str, str]) -> Optional[Dict[str, str]]:
+    if env.get(JENKINS_URL_KEY):
+        return {"service": "jenkins", "url": env.get(JENKINS_BUILD_URL_KEY, "")}
+    elif env.get(GITHUB_ACTION_KEY):
+        return {"service": "github", "url": "{}/{}/actions/runs/{}".format(env.get(GITHUB_SERVER_URL_KEY), env.get(GITHUB_REPOSITORY_KEY), env.get(GITHUB_RUN_ID_KEY))}
+    elif env.get(CIRCLECI_KEY):
+        return {"service": "circleci", "url": env.get(CIRCLECI_BUILD_URL_KEY, "")}
+    else:
+        return None

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -15,10 +15,10 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 
 JENKINS_URL_KEY = 'JENKINS_URL'
 JENKINS_BUILD_URL_KEY = 'BUILD_URL'
-GITHUB_ACTION_KEY = 'GITHUB_ACTION'
-GITHUB_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
-GITHUB_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
-GITHUB_RUN_ID_KEY = 'GITHUB_RUN_ID'
+GITHUB_ACTIONS_KEY = 'GITHUB_ACTIONS'
+GITHUB_ACTIONS_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
+GITHUB_ACTIONS_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
+GITHUB_ACTIONS_RUN_ID_KEY = 'GITHUB_RUN_ID'
 CIRCLECI_KEY = 'CIRCLECI'
 CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
 
@@ -115,8 +115,8 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
 def _capture_link(env: Mapping[str, str]) -> Optional[Dict[str, str]]:
     if env.get(JENKINS_URL_KEY):
         return {"provider": CIProvider.JENKINS.value, "url": env.get(JENKINS_BUILD_URL_KEY, "")}
-    elif env.get(GITHUB_ACTION_KEY):
-        return {"provider": CIProvider.GITHUB_ACTIONS.value, "url": "{}/{}/actions/runs/{}".format(env.get(GITHUB_SERVER_URL_KEY), env.get(GITHUB_REPOSITORY_KEY), env.get(GITHUB_RUN_ID_KEY))}
+    elif env.get(GITHUB_ACTIONS_KEY):
+        return {"provider": CIProvider.GITHUB_ACTIONS.value, "url": "{}/{}/actions/runs/{}".format(env.get(GITHUB_ACTIONS_SERVER_URL_KEY), env.get(GITHUB_ACTIONS_REPOSITORY_KEY), env.get(GITHUB_ACTIONS_RUN_ID_KEY))}
     elif env.get(CIRCLECI_KEY):
         return {"provider": CIProvider.CIRCLECI.value, "url": env.get(CIRCLECI_BUILD_URL_KEY, "")}
     else:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -3,6 +3,8 @@ import os
 import sys
 from typing import Dict, Mapping, Optional, Sequence
 from http import HTTPStatus
+
+from ...utils.ci_provider import CIProvider
 from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.session import write_session
@@ -10,6 +12,7 @@ from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
+
 JENKINS_URL_KEY = 'JENKINS_URL'
 JENKINS_BUILD_URL_KEY = 'BUILD_URL'
 GITHUB_ACTION_KEY = 'GITHUB_ACTION'
@@ -111,10 +114,10 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
 
 def _capture_link(env: Mapping[str, str]) -> Optional[Dict[str, str]]:
     if env.get(JENKINS_URL_KEY):
-        return {"service": "jenkins", "url": env.get(JENKINS_BUILD_URL_KEY, "")}
+        return {"provider": CIProvider.JENKINS.value, "url": env.get(JENKINS_BUILD_URL_KEY, "")}
     elif env.get(GITHUB_ACTION_KEY):
-        return {"service": "github", "url": "{}/{}/actions/runs/{}".format(env.get(GITHUB_SERVER_URL_KEY), env.get(GITHUB_REPOSITORY_KEY), env.get(GITHUB_RUN_ID_KEY))}
+        return {"provider": CIProvider.GITHUB_ACTIONS.value, "url": "{}/{}/actions/runs/{}".format(env.get(GITHUB_SERVER_URL_KEY), env.get(GITHUB_REPOSITORY_KEY), env.get(GITHUB_RUN_ID_KEY))}
     elif env.get(CIRCLECI_KEY):
-        return {"service": "circleci", "url": env.get(CIRCLECI_BUILD_URL_KEY, "")}
+        return {"provider": CIProvider.CIRCLECI.value, "url": env.get(CIRCLECI_BUILD_URL_KEY, "")}
     else:
         return None

--- a/launchable/utils/ci_provider.py
+++ b/launchable/utils/ci_provider.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class CIProvider(Enum):
+    JENKINS = "jenkins"
+    GITHUB_ACTIONS = "github-actions"
+    CIRCLECI = "circleci"

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -80,7 +80,7 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True, "link": {"service": "jenkins", "url": "https://jenkins.example.com/job/launchableinc/job/example/357/"}}, payload)
+            {"flavors": {}, "observation": True, "link": {"provider": "jenkins", "url": "https://jenkins.example.com/job/launchableinc/job/example/357/"}}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -98,7 +98,7 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True, "link": {"service": "github", "url": "https://github.com/launchableinc/example/actions/runs/2709244304"}}, payload)
+            {"flavors": {}, "observation": True, "link": {"provider": "github-actions", "url": "https://github.com/launchableinc/example/actions/runs/2709244304"}}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -114,4 +114,4 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True, "link": {"service": "circleci", "url": "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935"}}, payload)
+            {"flavors": {}, "observation": True, "link": {"provider": "circleci", "url": "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935"}}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -15,7 +15,8 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        # it's needed to run the CLI because the line cleared all exsting environment
+        # LANG=C.UTF-8 is needed to run CliRunner().invoke(command).
+        # Generally it's provided by shell. But in this case, `clear=True` removes the variable.
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_without_flavor(self):

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -86,7 +86,7 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        GITHUB_ACTIONS_KEY: "1",
+        GITHUB_ACTIONS_KEY: "true",
         GITHUB_ACTIONS_SERVER_URL_KEY: "https://github.com",
         GITHUB_ACTIONS_REPOSITORY_KEY: "launchableinc/example",
         GITHUB_ACTIONS_RUN_ID_KEY: "2709244304",
@@ -104,7 +104,7 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        CIRCLECI_KEY: "1",
+        CIRCLECI_KEY: "true",
         CIRCLECI_BUILD_URL_KEY: "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935",
         'LANG': 'C.UTF-8',
     }, clear=True)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -9,7 +9,11 @@ from unittest import mock
 class SessionTest(CliTestCase):
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token}, clear=True)
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        # it's needed to run the CLI because the line cleared all exsting environment
+        'LANG': 'C.UTF-8',
+    }, clear=True)
     def test_run_session_without_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name)
         self.assertEqual(result.exit_code, 0)
@@ -19,7 +23,10 @@ class SessionTest(CliTestCase):
             {"flavors": {}, "observation": False}, payload)
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token}, clear=True)
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
+    }, clear=True)
     def test_run_session_with_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name,
                           "--flavor", "key=value", "--flavor", "k", "v", "--flavor", "k e y = v a l u e")
@@ -44,6 +51,7 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_observation(self):
         result = self.cli("record", "session", "--build",
@@ -59,6 +67,7 @@ class SessionTest(CliTestCase):
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
         JENKINS_URL_KEY: "https://jenkins.example.com/",
         JENKINS_BUILD_URL_KEY: "https://jenkins.example.com/job/launchableinc/job/example/357/",
+        'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_jenkins_url(self):
         result = self.cli("record", "session", "--build",
@@ -75,7 +84,8 @@ class SessionTest(CliTestCase):
         GITHUB_ACTION_KEY: "1",
         GITHUB_SERVER_URL_KEY: "https://github.com",
         GITHUB_REPOSITORY_KEY: "launchableinc/example",
-        GITHUB_RUN_ID_KEY: "2709244304"
+        GITHUB_RUN_ID_KEY: "2709244304",
+        'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_github_url(self):
         result = self.cli("record", "session", "--build",
@@ -91,6 +101,7 @@ class SessionTest(CliTestCase):
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
         CIRCLECI_KEY: "1",
         CIRCLECI_BUILD_URL_KEY: "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935",
+        'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_circleci_url(self):
         result = self.cli("record", "session", "--build",

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -7,6 +7,10 @@ from unittest import mock
 
 
 class SessionTest(CliTestCase):
+    """
+    This test needs to specify `clear=True` in mocking because the test is run on GithubActions. 
+    Otherwise GithubActions will export $GITHUB_* variables at runs.
+    """
 
     @responses.activate
     @mock.patch.dict(os.environ, {

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -1,4 +1,4 @@
-from launchable.commands.record.session import CIRCLECI_BUILD_URL_KEY, CIRCLECI_KEY, GITHUB_ACTION_KEY, GITHUB_REPOSITORY_KEY, GITHUB_RUN_ID_KEY, GITHUB_SERVER_URL_KEY, JENKINS_BUILD_URL_KEY, JENKINS_URL_KEY
+from launchable.commands.record.session import CIRCLECI_BUILD_URL_KEY, CIRCLECI_KEY, GITHUB_ACTIONS_KEY, GITHUB_ACTIONS_REPOSITORY_KEY, GITHUB_ACTIONS_RUN_ID_KEY, GITHUB_ACTIONS_SERVER_URL_KEY, JENKINS_BUILD_URL_KEY, JENKINS_URL_KEY
 from tests.cli_test_case import CliTestCase
 import responses  # type: ignore
 import json
@@ -85,10 +85,10 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        GITHUB_ACTION_KEY: "1",
-        GITHUB_SERVER_URL_KEY: "https://github.com",
-        GITHUB_REPOSITORY_KEY: "launchableinc/example",
-        GITHUB_RUN_ID_KEY: "2709244304",
+        GITHUB_ACTIONS_KEY: "1",
+        GITHUB_ACTIONS_SERVER_URL_KEY: "https://github.com",
+        GITHUB_ACTIONS_REPOSITORY_KEY: "launchableinc/example",
+        GITHUB_ACTIONS_RUN_ID_KEY: "2709244304",
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_github_url(self):

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -75,13 +75,12 @@ class SessionTest(CliTestCase):
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_jenkins_url(self):
-        result = self.cli("record", "session", "--build",
-                          self.build_name, "--observation")
+        result = self.cli("record", "session", "--build", self.build_name)
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True, "link": {"provider": "jenkins", "url": "https://jenkins.example.com/job/launchableinc/job/example/357/"}}, payload)
+            {"flavors": {}, "isObservation": False, "link": {"provider": "jenkins", "url": "https://jenkins.example.com/job/launchableinc/job/example/357/"}}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -93,13 +92,12 @@ class SessionTest(CliTestCase):
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_github_url(self):
-        result = self.cli("record", "session", "--build",
-                          self.build_name, "--observation")
+        result = self.cli("record", "session", "--build", self.build_name)
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True, "link": {"provider": "github-actions", "url": "https://github.com/launchableinc/example/actions/runs/2709244304"}}, payload)
+            {"flavors": {}, "isObservation": False, "link": {"provider": "github-actions", "url": "https://github.com/launchableinc/example/actions/runs/2709244304"}}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -109,10 +107,9 @@ class SessionTest(CliTestCase):
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_circleci_url(self):
-        result = self.cli("record", "session", "--build",
-                          self.build_name, "--observation")
+        result = self.cli("record", "session", "--build", self.build_name)
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "isObservation": True, "link": {"provider": "circleci", "url": "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935"}}, payload)
+            {"flavors": {}, "isObservation": False, "link": {"provider": "circleci", "url": "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935"}}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -9,7 +9,7 @@ from unittest import mock
 class SessionTest(CliTestCase):
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token}, clear=True)
     def test_run_session_without_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name)
         self.assertEqual(result.exit_code, 0)
@@ -19,7 +19,7 @@ class SessionTest(CliTestCase):
             {"flavors": {}, "observation": False}, payload)
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token}, clear=True)
     def test_run_session_with_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name,
                           "--flavor", "key=value", "--flavor", "k", "v", "--flavor", "k e y = v a l u e")
@@ -44,7 +44,7 @@ class SessionTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-    })
+    }, clear=True)
     def test_run_session_with_observation(self):
         result = self.cli("record", "session", "--build",
                           self.build_name, "--observation")
@@ -59,7 +59,7 @@ class SessionTest(CliTestCase):
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
         JENKINS_URL_KEY: "https://jenkins.example.com/",
         JENKINS_BUILD_URL_KEY: "https://jenkins.example.com/job/launchableinc/job/example/357/",
-    })
+    }, clear=True)
     def test_run_session_with_jenkins_url(self):
         result = self.cli("record", "session", "--build",
                           self.build_name, "--observation")
@@ -76,7 +76,7 @@ class SessionTest(CliTestCase):
         GITHUB_SERVER_URL_KEY: "https://github.com",
         GITHUB_REPOSITORY_KEY: "launchableinc/example",
         GITHUB_RUN_ID_KEY: "2709244304"
-    })
+    }, clear=True)
     def test_run_session_with_github_url(self):
         result = self.cli("record", "session", "--build",
                           self.build_name, "--observation")
@@ -91,7 +91,7 @@ class SessionTest(CliTestCase):
         "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
         CIRCLECI_KEY: "1",
         CIRCLECI_BUILD_URL_KEY: "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935",
-    })
+    }, clear=True)
     def test_run_session_with_circleci_url(self):
         result = self.cli("record", "session", "--build",
                           self.build_name, "--observation")


### PR DESCRIPTION
The CLI captures job links from CI providers in the `test sessions` command to show the links on the web app. It supports the following providers:

* Jenkins
* Github Action
* CircleCI 
  * It doesn't exist in the original plan, but I added it because it's easy to add.