### PR TITLE
Support observation mode output

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -53,11 +53,11 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
 
     """
     TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
-    E.G. 
-        <click8.0: 
+    E.G.
+        <click8.0:
             `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.5` is parsed as build=aaa, flavor=(("os", "ubuntu"), ("python", "3.5"))
-        >=click8.0: 
-            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")        
+        >=click8.0:
+            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")
     """
     for f in flavor:
         if isinstance(f, str):

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -336,13 +336,13 @@ def subset(
             if split:
                 click.echo("subset/{}".format(subset_id))
             else:
-                _output, _rest = output, rests
+                _output, _rests = output, rests
                 if is_output_exclusion_rules:
-                    _output, _rest = _rest, _output
+                    _output, _rests = _rests, _output
                 elif is_observation:
-                    _output = _output + _rest
+                    _output = _output + _rests
 
-                self.output_handler(_output, _rest)
+                self.output_handler(_output, _rests)
 
             # When Launchable returns an error, the cli skips showing summary report
             if "subset" not in summary.keys() or "rest" not in summary.keys():

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -9,6 +9,73 @@ from tests.cli_test_case import CliTestCase
 class SubsetTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_observation_mode(self):
+        pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py"
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json={
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+
+            ],
+            "rest": [
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "observation": False,
+        }, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name,   "file", mix_stderr=False, input=pipe)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\n")
+        self.assertEqual(
+            rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
+        rest.close()
+        os.unlink(rest.name)
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json={
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+
+            ],
+            "rest": [
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "observation": True,
+        }, status=200)
+
+        observation_mode_rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", observation_mode_rest.name, "--observation", "file", input=pipe, mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
+        self.assertEqual(
+            observation_mode_rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
+        observation_mode_rest.close()
+        os.unlink(observation_mode_rest.name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_with_get_tests_from_previous_full_runs(self):
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
                           json={


### PR DESCRIPTION
At first, we planned to receive a merged subset result (subset + rests) from Launchable. However, if we did so, output summary data will be changed.
So I changed to merge at the cli side.

___

I need to edit around the codes that were changed for zero input subsetting mode.
So, I made a branch from zero-input-subsetting mode and make PR to it.