### PR TITLE
Implement observation mode output

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -72,7 +72,7 @@ def session(ctx: click.core.Context, build_name: str, save_session_file: bool, p
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload={
                              "flavors": flavor_dict,
-                             "observation": is_observation,
+                             "isObservation": is_observation,
                              })
 
         if res.status_code == HTTPStatus.NOT_FOUND:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -60,6 +60,7 @@ def split_subset(context: click.core.Context, subset_id: str, bin, rest: str, ba
 
             output = []
             rests = []
+            is_observation = False
 
             try:
                 client = LaunchableClient(
@@ -77,6 +78,7 @@ def split_subset(context: click.core.Context, subset_id: str, bin, rest: str, ba
 
                 output = res.json()["testPaths"]
                 rests = res.json()["rest"]
+                is_observation = res.json().get("observation", False)
 
             except Exception as e:
                 if os.getenv(REPORT_ERROR_KEY):
@@ -93,6 +95,8 @@ def split_subset(context: click.core.Context, subset_id: str, bin, rest: str, ba
                     "Error: no tests found in this subset id.", 'yellow'), err=True)
                 return
 
+            if is_observation:
+                output = output + rests
             if rest:
                 if len(rests) == 0:
                     rests.append(output[0])

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -78,7 +78,7 @@ def split_subset(context: click.core.Context, subset_id: str, bin, rest: str, ba
 
                 output = res.json()["testPaths"]
                 rests = res.json()["rest"]
-                is_observation = res.json().get("observation", False)
+                is_observation = res.json().get("isObservation", False)
 
             except Exception as e:
                 if os.getenv(REPORT_ERROR_KEY):

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -269,6 +269,7 @@ def subset(
             summary = {}
             subset_id = ""
             is_brainless = False
+            is_observation = False
 
             if not session_id:
                 # Session ID in --session is missing. It might be caused by Launchable API errors.
@@ -293,7 +294,8 @@ def subset(
                     rests = res.json()["rest"]
                     subset_id = res.json()["subsettingId"]
                     summary = res.json()["summary"]
-                    is_brainless = res.json()["isBrainless"]
+                    is_brainless = res.json().get("isBrainless", False)
+                    is_observation = res.json().get("observation", False)
 
                 except Exception as e:
                     if os.getenv(REPORT_ERROR_KEY):
@@ -312,7 +314,11 @@ def subset(
             if split:
                 click.echo("subset/{}".format(subset_id))
             else:
-                self.output_handler(output, rests)
+                _output, _rests = output, rests
+                if is_observation:
+                    _output = _output + _rests
+
+                self.output_handler(_output, _rests)
 
             # When Launchable returns an error, the cli skips showing summary report
             if "subset" not in summary.keys() or "rest" not in summary.keys():

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -295,7 +295,7 @@ def subset(
                     subset_id = res.json()["subsettingId"]
                     summary = res.json()["summary"]
                     is_brainless = res.json().get("isBrainless", False)
-                    is_observation = res.json().get("observation", False)
+                    is_observation = res.json().get("isObservation", False)
 
                 except Exception as e:
                     if os.getenv(REPORT_ERROR_KEY):

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -15,7 +15,7 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": False}, payload)
+            {"flavors": {}, "isObservation": False}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -31,7 +31,7 @@ class SessionTest(CliTestCase):
                 "k": "v",
                 "k e y": "v a l u e",
             },
-            "observation": False, }, payload)
+            "isObservation": False, }, payload)
 
         with self.assertRaises(ValueError):
             result = self.cli("record", "session", "--build", self.build_name,
@@ -49,4 +49,4 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
-            {"flavors": {}, "observation": True}, payload)
+            {"flavors": {}, "isObservation": True}, payload)

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+from unittest import mock
+import responses
+from launchable.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class SplitSubsetTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset_with_observation_mode(self):
+        pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\ntest_5.py\ntest_6.py"
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_3.py"}],
+
+            ],
+            "rest": [
+                [{"type": "file", "name": "test_5.py"}],
+
+            ],
+            "subsettingId": 456,
+            "observation": False,
+        }
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
+                          json=mock_json_response, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("split-subset", "--subset-id", "subset/456", "--bin", "1/2", "--rest",
+                          rest.name, "file", mix_stderr=False, input=pipe)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_3.py\n")
+        self.assertEqual(
+            rest.read().decode(), os.linesep.join(["test_5.py"]))
+        rest.close()
+        os.unlink(rest.name)
+
+        mock_json_response["observation"] = True
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
+                          json=mock_json_response, status=200)
+
+        observation_mode_rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("split-subset", "--subset-id", "subset/456", "--bin", "1/2", "--rest",
+                          observation_mode_rest.name, "file", mix_stderr=False, input=pipe)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_3.py\ntest_5.py\n")
+        self.assertEqual(
+            observation_mode_rest.read().decode(), os.linesep.join(["test_5.py"]))
+        observation_mode_rest.close()
+        os.unlink(observation_mode_rest.name)

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -22,7 +22,7 @@ class SplitSubsetTest(CliTestCase):
 
             ],
             "subsettingId": 456,
-            "observation": False,
+            "isObservation": False,
         }
 
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
@@ -39,7 +39,7 @@ class SplitSubsetTest(CliTestCase):
         rest.close()
         os.unlink(rest.name)
 
-        mock_json_response["observation"] = True
+        mock_json_response["isObservation"] = True
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(get_base_url(), self.organization, self.workspace, self.subsetting_id),
                           json=mock_json_response, status=200)
 

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+from unittest import mock
+import responses
+from launchable.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class SubsetTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_observation_mode(self):
+
+        pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py"
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+
+            ],
+            "rest": [
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "observation": False,
+        }
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json=mock_json_response, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name,   "file", mix_stderr=False, input=pipe)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\n")
+        self.assertEqual(
+            rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
+        rest.close()
+        os.unlink(rest.name)
+
+        mock_json_response["observation"] = True
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
+                          json=mock_json_response, status=200)
+
+        observation_mode_rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", observation_mode_rest.name, "--observation", "file", input=pipe, mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
+        self.assertEqual(
+            observation_mode_rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
+        observation_mode_rest.close()
+        os.unlink(observation_mode_rest.name)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -28,7 +28,7 @@ class SubsetTest(CliTestCase):
                 "subset": {"duration": 10, "candidates": 3, "rate": 50},
                 "rest": {"duration": 10, "candidates": 3, "rate": 50}
             },
-            "observation": False,
+            "isObservation": False,
         }
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
                           json=mock_json_response, status=200)
@@ -44,7 +44,7 @@ class SubsetTest(CliTestCase):
         rest.close()
         os.unlink(rest.name)
 
-        mock_json_response["observation"] = True
+        mock_json_response["isObservation"] = True
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(get_base_url(), self.organization, self.workspace),
                           json=mock_json_response, status=200)
 


### PR DESCRIPTION
At first, we planned to receive a merged subset result (subset + rests) from Launchable. However, if we did so, output summary data will be changed.
So I changed to merge at the cli side.

I made another PR https://github.com/launchableinc/cli/pull/437 before, however, we need to release faster than zero input subsetting mode. So, I made a new PR.