### PR TITLE
doc: fix link to Subsetting hierarchy

### DIFF
--- a/docs/resources/integrations/raw.md
+++ b/docs/resources/integrations/raw.md
@@ -56,7 +56,7 @@ file=login/test_a.py#class=class1#testcase=testcase899
 
 This example declares a hierarchy of three levels: a `testcase` belongs to a `class` which belongs to a `file` (path). Your hierarchy may be different, but you'll need to include enough hierarchy to uniquely identify every test.
 
-When creating your `testPath` hierarchy, keep in mind that you'll also use this structure for subsetting tests. See (Subsetting hierarchy)\[#subsetting-hierarchy] for examples.
+When creating your `testPath` hierarchy, keep in mind that you'll also use this structure for subsetting tests. See (Subsetting hierarchy)[#subsetting-hierarchy] for examples.
 
 Finally, include relative file paths instead of absolute ones where possible.
 
@@ -98,7 +98,7 @@ file=login/test_b.py#class=class3#testcase=testcase901
 file=login/test_b.py#class=class3#testcase=testcase902
 ```
 
-**Subsetting hierarchy**
+#### Subsetting hierarchy
 
 One common scenario is that a test runner cannot subset tests at the same level of granularity used for reporting tests.
 


### PR DESCRIPTION
# Background

I found the following broken link and section (no link) and want to fix for what we expect.

<img width="761" alt="image" src="https://user-images.githubusercontent.com/5056295/185547855-b6890299-213c-4110-bff6-cba4a7a2ed91.png">

![image](https://user-images.githubusercontent.com/5056295/185547863-5ae8fc51-f90f-4c6d-a0df-25ade6c0ba6b.png)

# Changes

* Fix markdown syntax for `#subsetting-hierarchy`
* Make the "Subsetting hierarchy" section linkable