### PR TITLE
Cygwin support

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -7,7 +7,7 @@ from typing import List
 
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import get_base_url
-from ...utils.java import get_java_command
+from ...utils.java import get_java_command, cygpath
 from ...utils.logger import Logger, LOG_LEVEL_AUDIT
 
 jar_file_path = os.path.normpath(
@@ -68,7 +68,7 @@ def exec_jar(source, max_days, dry_run):
     command.extend(_build_proxy_option(os.getenv("HTTPS_PROXY")))
     command.extend([
         "-jar",
-        jar_file_path,
+        cygpath(jar_file_path),
         "ingest:commit",
         "-endpoint",
         "{}/intake/".format(base_url),
@@ -81,7 +81,7 @@ def exec_jar(source, max_days, dry_run):
         command.append("-audit")
     if dry_run:
         command.append("-dry-run")
-    command.append(source)
+    command.append(cygpath(source))
 
     subprocess.run(
         command,

--- a/launchable/utils/java.py
+++ b/launchable/utils/java.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import subprocess
+import sys
 
 
 def get_java_command():
@@ -10,3 +12,17 @@ def get_java_command():
         return os.path.expandvars("$JAVA_HOME/bin/java")
 
     return None
+
+def cygpath(p):
+    # When running in Cygwin ported Python (as opposed to Windows native Python), the paths we deal with are in
+    # the cygwin format. But when we invoke Windows native Java (and there's no Cygwin ported Java), those parameters
+    # need to be in the Windows path format.
+    #
+    # In Cygwin aware world, it is always the responsibility of the Cygwin process calling Windows native process to
+    # do this conversion, so here we are.
+    #
+    # Cygwin ported Python is not to be confused with Windows native Python running in Windows with cygwin.
+    # So tests like CYGWIN env var, "uname" are incorrect.
+    if sys.platform == 'cygwin':
+        p = subprocess.check_output(['cygpath', '-w', p]).decode().strip()
+    return p


### PR DESCRIPTION
Failure mode:
```
    Exec: /cygdrive/c/[reducted]/.venv/bin/launchable record build --name XYZ --source ABC=/cygdrive/c/abc/def
        : Command '['java', '-jar', '/cygdrive/c/[reducted]/git-utils/.venv/lib/python3.8/site-packages/launchable/jar/exe_deploy.jar', 'ingest:commit', '-endpoint', 'https://api.mercury.launchableinc.com/intake/', '-max-days', '30', '-scrub-pii', '/cygdrive/c/abc/def']' returned non-zero exit status 1.
        : Launchable recorded build XYZ to workspace abc/def with commits from 1 repository:
        :
        : | Name          | Path                        | HEAD Commit                              |
        : |---------------|-----------------------------|------------------------------------------|
          << reducted >>
        : Error: Unable to access jarfile /cygdrive/c/[reducted]/git-utils/.venv/lib/python3.8/site-packages/launchable/jar/exe_deploy.jar
        : Can't get commit history from `/cygdrive/c/abc/def`. Do you run command root of git-controlled directory? If not, please set a directory use by --source option.
```