### PR TITLE
Add a git-log parser

### DIFF
--- a/launchable/utils/commit_ingester.py
+++ b/launchable/utils/commit_ingester.py
@@ -1,0 +1,57 @@
+from .git_log_parser import GitCommit
+from .http_client import LaunchableClient
+from typing import List, Dict, Optional
+from datetime import tzinfo
+import hashlib
+
+
+def _sha256(s: str) -> str:
+    return hashlib.sha256(s.encode('utf8')).hexdigest()
+
+
+def _format_tzinfo(tz: Optional[tzinfo]) -> int:
+    if not tz:
+        return 0
+    delta = tz.utcoffset(None)
+    if not delta:
+        return 0
+    return round(delta.total_seconds() / 60)
+
+
+def _convert_git_commit(commit: GitCommit) -> Dict:
+    changed_files = []
+    for changed_file in commit.changed_files:
+        cf = dict()
+        cf['linesAdded'] = changed_file.added
+        cf['linesDeleted'] = changed_file.deleted
+        cf['status'] = 'M'
+        cf['path'] = changed_file.path
+        cf['pathTo'] = changed_file.path
+        changed_files.append(cf)
+    parents = dict()
+    if len(commit.parents) > 0:
+        # We don't know which diff is for which parent. Use the first parent.
+        parents[commit.parents[0]] = changed_files
+        for parent in commit.parents[1:len(commit.parents)]:
+            parents[parent] = []
+
+    d = dict()
+    d['commitHash'] = commit.commit_hash
+    d['authorEmailAddress'] = _sha256(commit.author_email)
+    d['authorWhen'] = round(commit.author_time.timestamp() * 1000)
+    d['authorTimezoneOffset'] = _format_tzinfo(commit.author_time.tzinfo)
+    d['committerEmailAddress'] = _sha256(commit.committer_email)
+    d['committerWhen'] = round(commit.committer_time.timestamp() * 1000)
+    d['committerTimezoneOffset'] = _format_tzinfo(commit.committer_time.tzinfo)
+    d['parentHashes'] = parents
+    return d
+
+
+def upload_commits(commits: List[GitCommit], dry_run: bool):
+    payload = {
+        'commits': [_convert_git_commit(commit) for commit in commits]
+    }
+
+    client = LaunchableClient(dry_run=dry_run)
+    res = client.request("post", "commits/collect", payload=payload)
+    res.raise_for_status()

--- a/launchable/utils/git_log_parser.py
+++ b/launchable/utils/git_log_parser.py
@@ -1,0 +1,50 @@
+from collections import namedtuple
+from typing import Dict, List, TextIO, Any
+from datetime import datetime
+import dateutil.parser
+import json
+
+ChangedFile = namedtuple('ChangedFile', ['path', 'added', 'deleted'])
+
+GitCommit = namedtuple('GitCommit', [
+    'commit_hash', 'parents', 'author_email', 'author_time', 'committer_email',
+    'committer_time', 'changed_files'
+])
+
+
+def parse_git_log(fp: TextIO) -> List[GitCommit]:
+    """Parses the output of a git log command.
+
+    This parses the output of `git log --pretty='format:{"commit": "%H",
+    "parents": "%P", "authorEmail": "%ae", "authorTime": "%aI",
+    "committerEmail": "%ce", "committerTime": "%cI"}' --numstat`
+    """
+    ret = []
+    meta = {}  # type: Dict[str, Any]
+    files = []  # type: List[ChangedFile]
+    for line in fp:
+        line = line.strip()
+        if line == '':
+            continue
+        if line.startswith('{'):
+            if len(meta) != 0:
+                ret.append(GitCommit(changed_files=files, **meta))
+                meta = {}
+                files = []
+            d = json.loads(line)
+            meta['commit_hash'] = d['commit']
+            meta['parents'] = d['parents'].split(' ')
+            meta['author_email'] = d['authorEmail']
+            meta['author_time'] = dateutil.parser.parse(d['authorTime'])
+            meta['committer_email'] = d['committerEmail']
+            meta['committer_time'] = dateutil.parser.parse(d['committerTime'])
+        elif line.startswith('-'):
+            # Ignore binary file changes
+            pass
+        else:
+            added, deleted, path = line.split('\t', 3)
+            files.append(
+                ChangedFile(path=path, added=int(added), deleted=int(deleted)))
+    if len(meta) != 0:
+        ret.append(GitCommit(changed_files=files, **meta))
+    return ret

--- a/tests/data/git_log_ingest/sample.out
+++ b/tests/data/git_log_ingest/sample.out
@@ -1,0 +1,31 @@
+{"commit": "1f0c18ea3df6575b4132b311d52a339af34c90ba", "parents": "b068a8a515e6cbbb2d6673ddb2c421939bd618b7", "authorEmail": "example1@example.com", "authorTime": "2022-09-21T15:59:21-07:00", "committerEmail": "example1@example.com", "committerTime": "2022-09-21T16:34:35-07:00"}
+24	4	launchable/commands/subset.py
+24	0	launchable/test_runners/gradle.py
+62	0	tests/test_runners/test_gradle.py
+
+{"commit": "b068a8a515e6cbbb2d6673ddb2c421939bd618b7", "parents": "cb1d1b797726fe16e661d8377bd807f2508e9df4", "authorEmail": "example2@example.com", "authorTime": "2022-09-16T17:03:52+00:00", "committerEmail": "example3@example.com", "committerTime": "2022-09-16T17:03:52+00:00"}
+-	-	.gitbook/assets/sending-data-diagram (1) (1).png
+-	-	.gitbook/assets/sending-data-diagram (2).png
+-	-	.gitbook/assets/subsetting-diagram (2).png
+-	-	docs/.gitbook/assets/image (1).png
+-	-	docs/.gitbook/assets/image (2).png
+1	1	docs/README.md
+1	0	docs/SUMMARY.md
+1	1	docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/README.md
+26	0	docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/zero-input-subsetting.md
+1	1	docs/sending-data-to-launchable/README.md
+
+{"commit": "cb1d1b797726fe16e661d8377bd807f2508e9df4", "parents": "fba956e638a7d91a6a89a40132d7d1c8f5f40d71 f22ea479d9c088d0da4109118b25c3f5b1b7b96e", "authorEmail": "example4@example.com", "authorTime": "2022-09-15T14:51:22-04:00", "committerEmail": "example5@example.com", "committerTime": "2022-09-15T14:51:22-04:00"}
+{"commit": "f22ea479d9c088d0da4109118b25c3f5b1b7b96e", "parents": "38d92db01c0603978aab3a7bd43fbb5f5957c8f3", "authorEmail": "example4@example.com", "authorTime": "2022-09-15T14:51:14-04:00", "committerEmail": "example5@example.com", "committerTime": "2022-09-15T14:51:14-04:00"}
+2	2	docs/features/insights/flaky-tests.md
+
+{"commit": "38d92db01c0603978aab3a7bd43fbb5f5957c8f3", "parents": "fba956e638a7d91a6a89a40132d7d1c8f5f40d71", "authorEmail": "example1@example.com", "authorTime": "2022-09-15T11:29:45-07:00", "committerEmail": "example1@example.com", "committerTime": "2022-09-15T11:29:45-07:00"}
+3	3	docs/features/insights/flaky-tests.md
+
+{"commit": "fba956e638a7d91a6a89a40132d7d1c8f5f40d71", "parents": "a08f6ab9cb534a6818998883f8712aedddd459ae 039f5f6f7874836739ec7cbfe2bf9d0ffea0f8d3", "authorEmail": "example2@example.com", "authorTime": "2022-09-13T13:28:45-04:00", "committerEmail": "example2@example.com", "committerTime": "2022-09-13T13:28:45-04:00"}
+{"commit": "039f5f6f7874836739ec7cbfe2bf9d0ffea0f8d3", "parents": "de1076e9a6c4efd28339496ac10906693e980ce3 8a7cb5c8cef17b9d5323c0338dce9d7b8639c85b", "authorEmail": "example6@example.com", "authorTime": "2022-09-14T02:24:32+09:00", "committerEmail": "example5@example.com", "committerTime": "2022-09-14T02:24:32+09:00"}
+{"commit": "8a7cb5c8cef17b9d5323c0338dce9d7b8639c85b", "parents": "de1076e9a6c4efd28339496ac10906693e980ce3", "authorEmail": "example6@example.com", "authorTime": "2022-09-13T09:43:59-07:00", "committerEmail": "example6@example.com", "committerTime": "2022-09-13T09:43:59-07:00"}
+3	1	docs/resources/integrations/maven.md
+
+{"commit": "a08f6ab9cb534a6818998883f8712aedddd459ae", "parents": "de1076e9a6c4efd28339496ac10906693e980ce3", "authorEmail": "example2@example.com", "authorTime": "2022-09-13T14:43:41+00:00", "committerEmail": "example3@example.com", "committerTime": "2022-09-13T14:43:41+00:00"}
+1	1	docs/concepts/subset.md

--- a/tests/utils/test_git_log_parser.py
+++ b/tests/utils/test_git_log_parser.py
@@ -1,0 +1,147 @@
+from launchable.utils.git_log_parser import parse_git_log, GitCommit, ChangedFile
+from pathlib import Path
+from unittest import TestCase
+from dateutil.parser import parse
+
+
+class GitLogParserTest(TestCase):
+    test_file_path = Path(__file__).parent.joinpath(
+        '../data/git_log_ingest/sample.out').resolve()
+
+    def test_parse(self):
+        with self.test_file_path.open('r') as fp:
+            commits = parse_git_log(fp)
+
+        self.maxDiff = None
+        self.assertEqual(commits, [
+            GitCommit(
+                commit_hash="1f0c18ea3df6575b4132b311d52a339af34c90ba",
+                parents=["b068a8a515e6cbbb2d6673ddb2c421939bd618b7"],
+                author_email="example1@example.com",
+                author_time=parse("2022-09-21T15:59:21-07:00"),
+                committer_email="example1@example.com",
+                committer_time=parse("2022-09-21T16:34:35-07:00"),
+                changed_files=[
+                    ChangedFile(path="launchable/commands/subset.py",
+                                added=24,
+                                deleted=4),
+                    ChangedFile(path="launchable/test_runners/gradle.py",
+                                added=24,
+                                deleted=0),
+                    ChangedFile(path="tests/test_runners/test_gradle.py",
+                                added=62,
+                                deleted=0),
+                ],
+            ),
+            GitCommit(
+                commit_hash="b068a8a515e6cbbb2d6673ddb2c421939bd618b7",
+                parents=["cb1d1b797726fe16e661d8377bd807f2508e9df4"],
+                author_email="example2@example.com",
+                author_time=parse("2022-09-16T17:03:52+00:00"),
+                committer_email="example3@example.com",
+                committer_time=parse("2022-09-16T17:03:52+00:00"),
+                changed_files=[
+                    ChangedFile(path="docs/README.md", added=1, deleted=1),
+                    ChangedFile(path="docs/SUMMARY.md", added=1, deleted=0),
+                    ChangedFile(
+                        path="docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/README.md",
+                        added=1,
+                        deleted=1),
+                    ChangedFile(
+                        path="docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/zero-input-subsetting.md",
+                        added=26,
+                        deleted=0),
+                    ChangedFile(
+                        path="docs/sending-data-to-launchable/README.md",
+                        added=1,
+                        deleted=1),
+                ],
+            ),
+            GitCommit(
+                commit_hash="cb1d1b797726fe16e661d8377bd807f2508e9df4",
+                parents=[
+                    "fba956e638a7d91a6a89a40132d7d1c8f5f40d71",
+                    "f22ea479d9c088d0da4109118b25c3f5b1b7b96e"
+                ],
+                author_email="example4@example.com",
+                author_time=parse("2022-09-15T14:51:22-04:00"),
+                committer_email="example5@example.com",
+                committer_time=parse("2022-09-15T14:51:22-04:00"),
+                changed_files=[],
+            ),
+            GitCommit(
+                commit_hash="f22ea479d9c088d0da4109118b25c3f5b1b7b96e",
+                parents=["38d92db01c0603978aab3a7bd43fbb5f5957c8f3"],
+                author_email="example4@example.com",
+                author_time=parse("2022-09-15T14:51:14-04:00"),
+                committer_email="example5@example.com",
+                committer_time=parse("2022-09-15T14:51:14-04:00"),
+                changed_files=[
+                    ChangedFile(path="docs/features/insights/flaky-tests.md",
+                                added=2,
+                                deleted=2),
+                ],
+            ),
+            GitCommit(
+                commit_hash="38d92db01c0603978aab3a7bd43fbb5f5957c8f3",
+                parents=["fba956e638a7d91a6a89a40132d7d1c8f5f40d71"],
+                author_email="example1@example.com",
+                author_time=parse("2022-09-15T11:29:45-07:00"),
+                committer_email="example1@example.com",
+                committer_time=parse("2022-09-15T11:29:45-07:00"),
+                changed_files=[
+                    ChangedFile(path="docs/features/insights/flaky-tests.md",
+                                added=3,
+                                deleted=3),
+                ],
+            ),
+            GitCommit(
+                commit_hash="fba956e638a7d91a6a89a40132d7d1c8f5f40d71",
+                parents=[
+                    "a08f6ab9cb534a6818998883f8712aedddd459ae",
+                    "039f5f6f7874836739ec7cbfe2bf9d0ffea0f8d3",
+                ],
+                author_email="example2@example.com",
+                author_time=parse("2022-09-13T13:28:45-04:00"),
+                committer_email="example2@example.com",
+                committer_time=parse("2022-09-13T13:28:45-04:00"),
+                changed_files=[],
+            ),
+            GitCommit(
+                commit_hash="039f5f6f7874836739ec7cbfe2bf9d0ffea0f8d3",
+                parents=[
+                    "de1076e9a6c4efd28339496ac10906693e980ce3",
+                    "8a7cb5c8cef17b9d5323c0338dce9d7b8639c85b",
+                ],
+                author_email="example6@example.com",
+                author_time=parse("2022-09-14T02:24:32+09:00"),
+                committer_email="example5@example.com",
+                committer_time=parse("2022-09-14T02:24:32+09:00"),
+                changed_files=[],
+            ),
+            GitCommit(
+                commit_hash="8a7cb5c8cef17b9d5323c0338dce9d7b8639c85b",
+                parents=["de1076e9a6c4efd28339496ac10906693e980ce3"],
+                author_email="example6@example.com",
+                author_time=parse("2022-09-13T09:43:59-07:00"),
+                committer_email="example6@example.com",
+                committer_time=parse("2022-09-13T09:43:59-07:00"),
+                changed_files=[
+                    ChangedFile(path="docs/resources/integrations/maven.md",
+                                added=3,
+                                deleted=1),
+                ],
+            ),
+            GitCommit(
+                commit_hash="a08f6ab9cb534a6818998883f8712aedddd459ae",
+                parents=["de1076e9a6c4efd28339496ac10906693e980ce3"],
+                author_email="example2@example.com",
+                author_time=parse("2022-09-13T14:43:41+00:00"),
+                committer_email="example3@example.com",
+                committer_time=parse("2022-09-13T14:43:41+00:00"),
+                changed_files=[
+                    ChangedFile(
+                        path="docs/concepts/subset.md", added=1, deleted=1),
+                ],
+            ),
+        ])


### PR DESCRIPTION
This implements --import-git-log-output option. In some cases, it's hard
to access the git repository from the machine that connects to the
Internet. This makes a workaround that a user can create a file based on
a Git log command (shown in the doc comment), transfer that to the
machine with the Internet connection, and run a commit ingestion.

Tested with one of the demo workspaces.
