### PR TITLE
Revert "Temporarily enable observation mode to generate some prod data"

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,9 +70,8 @@ jobs:
 
         # Tell Launchable about the build you are producing and testing
         launchable record build --name ${GITHUB_RUN_ID}
-        
-        # [awilkes 2022-08-22] Temporarily enable observation mode to generate some production data
-        launchable record session --observation --build ${GITHUB_RUN_ID} --flavor os=${{ matrix.os }} --flavor python=${{ matrix.python-version }} > session.txt
+
+        launchable record session --build ${GITHUB_RUN_ID} --flavor os=${{ matrix.os }} --flavor python=${{ matrix.python-version }} > session.txt
 
         # Find 25% of the relevant tests to run for this change
         find tests -name test_*.py | grep -v tests/data | launchable subset --target 25% --session $(cat session.txt) --rest launchable-remainder.txt file > subset.txt


### PR DESCRIPTION
Reverts launchableinc/cli#444.

We have enough production data that this change can be reverted.