### PR TITLE
fix invalid testPath format for raw profile testRunner

### DIFF
--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -117,13 +117,11 @@ def record_tests(client, test_result_file):
         default_created_at = datetime.datetime.now(
             datetime.timezone.utc).isoformat()
         for case in doc['testCases']:
-            test_path = case['testPath']
+            test_path = parse_test_path(case['testPath'])
             status = case['status']
             duration_secs = case['duration'] or 0
             created_at = case['createdAt'] or default_created_at
 
-            # Validation
-            parse_test_path(test_path)
             if status not in CaseEvent.STATUS_MAP:
                 raise ValueError(
                     "The status of {} should be one of {} (was {})".format(

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -108,7 +108,10 @@ class RawTest(CliTestCase):
             self.assert_json_orderless_equal(payload, {
                 'events': [
                     {
-                        'testPath': 'file=a.py#class=classA',
+                        'testPath': [
+                            {'type': 'file', 'name': 'a.py'},
+                            {'type': 'class', 'name': 'classA'},
+                        ],
                         'duration': 42,
                         'status': 1,
                         'stdout': 'This is stdout',


### PR DESCRIPTION
# Background

The parser used for raw profile test runner does not parse and create testPath field for `record tests` payload as our expected format. Currently the format of the `testPath`  field is `string` but it must be `Array<TestPathComponent>`.

This causes the following 500 error.

```
$ pipenv run launchable record tests --session SOMETHING raw ~/Downloads/downloadHaSR1065559/TEST-report.json

Traceback (most recent call last):
  File "/Users/takayuki-watanabe/src/github.com/launchableinc/cli/launchable/commands/record/tests.py", line 324, in run
    send(p)
  File "/Users/takayuki-watanabe/src/github.com/launchableinc/cli/launchable/commands/record/tests.py", line 292, in send
    res.raise_for_status()
  File "/Users/takayuki-watanabe/.local/share/virtualenvs/cli-f4jrwhCf/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error:  for url: http://localhost:8080/intake/organizations/launchableinc/workspaces/SOMETHING/builds/SOMETHING/test_sessions/6/events
```

# Changes


This commit separates the string sent via `record tests`

```
'testPath': 'file=a.py#class=classA'
```

into the array of testPath components described as follows:

```
'testPath': [
    {'type': 'file', 'name': 'a.py'},
    {'type': 'class', 'name': 'classA'},
],
```

# Other implementations

The code change in this PR should create the same payload format as other test runners create.

- [Bazel](https://github.com/launchableinc/cli/blob/5b96681b2651640b9584d333a6057723fb27c40b/tests/data/bazel/record_test_with_build_event_json_result.json#L5-L10)
- [Gradle](https://github.com/launchableinc/cli/blob/5b96681b2651640b9584d333a6057723fb27c40b/tests/data/gradle/recursion/expected.json#L5-L14)