### PR TITLE
add same bin option to subset split

### DIFF
--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -122,9 +122,9 @@ def split_subset(
                                 ```
                                 "sameBins" [
                                     [
-                                        [{"class": "example.AddTest"}],
-                                        [{"class": "example.DivTest"}],
-                                        [{"class": "example.SubTest"}]
+                                        [{"type": "class", "name": "example.AddTest"}],
+                                        [{"type": "class", "name": "example.DivTest"}],
+                                        [{"type": "class", "name": "example.SubTest"}]
                                     ]
                                 ]
                                 ```
@@ -140,12 +140,12 @@ def split_subset(
                                 "sameBins" [
                                     [
                                         [
-                                            {"class": "example"}, 
-                                            {"testcase": "BenchmarkGreeting"}
+                                            {"type": "class", "name": "example"},
+                                            {"type": "testcase", "name": "BenchmarkGreeting"}
                                         ],
                                         [
-                                            {"class": "example"}, 
-                                            {"testcase": "ExampleGreeting"}    
+                                            {"type": "class", "name": "example"},
+                                            {"type": "testcase", "name": "ExampleGreeting"}
                                         ]
                                     ]
                                 ]

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -148,17 +148,18 @@ def split_subset(
                                 ]
                                 ```
                             """
-                            t = f.readlines()
+                            tests = f.readlines()
                             # make a list to set to remove duplicate.
-                            t = list(set([s.strip() for s in t]))
+                            tests = list(set([s.strip() for s in tests]))
                             for tests_in_file in tests_in_files:
-                                for u in t:
-                                    if u in tests_in_file:
+                                for test in tests:
+                                    if test in tests_in_file:
                                         raise ValueError(
                                             "Error: you cannot have one test, {}, in multiple same-bins.".format(u))
-                            tests_in_files.append(t)
-                            d = [self.same_bin_formatter(s) for s in t]
-                            same_bins.append(d)
+                            tests_in_files.append(tests)
+                            test_data = [
+                                self.same_bin_formatter(s) for s in tests]
+                            same_bins.append(test_data)
 
                     payload["sameBins"] = same_bins
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -155,7 +155,7 @@ def split_subset(
                                 for test in tests:
                                     if test in tests_in_file:
                                         raise ValueError(
-                                            "Error: you cannot have one test, {}, in multiple same-bins.".format(u))
+                                            "Error: you cannot have one test, {}, in multiple same-bins.".format(test))
                             tests_in_files.append(tests)
                             test_data = [
                                 self.same_bin_formatter(s) for s in tests]

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -149,7 +149,8 @@ def split_subset(
                                 ```
                             """
                             t = f.readlines()
-                            t = [s.strip() for s in t]
+                            # make a list to set to remove duplicate.
+                            t = list(set([s.strip() for s in t]))
                             for tests_in_file in tests_in_files:
                                 for u in t:
                                     if u in tests_in_file:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -98,6 +98,8 @@ def split_subset(
                     "sameBins": [],
                 }
 
+                tests_in_files = []
+
                 if same_bin_files is not None:
                     same_bins = []
                     for same_bin_file in same_bin_files:
@@ -117,9 +119,9 @@ def split_subset(
                                 ```
                                 "sameBins" [
                                     [
-                                        {"class": "example.AddTest"},
-                                        {"class": "example.DivTest"},
-                                        {"class": "example.SubTest"}
+                                        [{"class": "example.AddTest"}],
+                                        [{"class": "example.DivTest"}],
+                                        [{"class": "example.SubTest"}]
                                     ]
                                 ]
                                 ```
@@ -134,23 +136,28 @@ def split_subset(
                                 ```
                                 "sameBins" [
                                     [
-                                        {"class": "example", "testcase": "BenchmarkGreeting"},
-                                        {"class": "example", "testcase": "ExampleGreeting"}
+                                        [
+                                            {"class": "example"}, 
+                                            {"testcase": "BenchmarkGreeting"}
+                                        ],
+                                        [
+                                            {"class": "example"}, 
+                                            {"testcase": "ExampleGreeting"}    
+                                        ]
                                     ]
                                 ]
                                 ```
                             """
                             t = f.readlines()
                             t = [s.strip() for s in t]
+                            for tests_in_file in tests_in_files:
+                                for u in t:
+                                    if u in tests_in_file:
+                                        raise ValueError(
+                                            "Error: you cannot have one test, {}, in multiple same-bins.".format(u))
+                            tests_in_files.append(t)
                             d = [self.same_bin_formatter(s) for s in t]
                             same_bins.append(d)
-                    for i, s in enumerate(same_bins):
-                        for j, t in enumerate(same_bins):
-                            if i != j:
-                                for u in s:
-                                    if u in t:
-                                        raise ValueError(
-                                            "Error: you cannot have same tests in multiple same-bin texts.")
 
                     payload["sameBins"] = same_bins
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -100,7 +100,10 @@ def split_subset(
 
                 tests_in_files = []
 
-                if same_bin_files is not None:
+                if same_bin_files is not None and len(same_bin_files) > 0:
+                    if self.same_bin_formatter is None:
+                        raise ValueError("--same-bin option is supported only for gradle test and go-test. "
+                                         "Please remove --same-bin option for the other test runner.")
                     same_bins = []
                     for same_bin_file in same_bin_files:
                         with open(same_bin_file, "r") as f:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -99,6 +99,7 @@ def split_subset(
                 }
 
                 if same_bin_files is not None:
+                    same_bins = []
                     for same_bin_file in same_bin_files:
                         with open(same_bin_file, "r") as f:
                             """
@@ -142,7 +143,16 @@ def split_subset(
                             t = f.readlines()
                             t = [s.strip() for s in t]
                             d = [self.same_bin_formatter(s) for s in t]
-                            payload["sameBins"].append(d)
+                            same_bins.append(d)
+                    for i, s in enumerate(same_bins):
+                        for j, t in enumerate(same_bins):
+                            if i != j:
+                                for u in s:
+                                    if u in t:
+                                        raise ValueError(
+                                            "Error: you cannot have same tests in multiple same-bin texts.")
+
+                    payload["sameBins"] = same_bins
 
                 res = client.request(
                     "POST", "{}/slice".format(subset_id), payload=payload)

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -1,5 +1,5 @@
 from os.path import join
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import click
 
@@ -50,3 +50,15 @@ class TestPathWriter(object):
     def print(self, test_paths: List[TestPath]):
         click.echo(self.separator.join(self.formatter(t)
                                        for t in test_paths))
+
+    @classmethod
+    def default_same_bin_formatter(cls, s: str) -> Dict[str, str]:
+        return {"testcase": s}
+
+    @property
+    def same_bin_formatter(self) -> Callable[[str], Dict[str, str]]:
+        return self._same_bin_formatter
+
+    @same_bin_formatter.setter
+    def same_bin_formatter(self, v: Callable[[str], Dict[str, str]]):
+        self._same_bin_formatter = v

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -12,6 +12,7 @@ class TestPathWriter(object):
     def __init__(self, dry_run=False):
         self._formatter = TestPathWriter.default_formatter
         self._separator = "\n"
+        self._same_bin_formatter = None
         self.dry_run = dry_run
 
     @classmethod
@@ -50,10 +51,6 @@ class TestPathWriter(object):
     def print(self, test_paths: List[TestPath]):
         click.echo(self.separator.join(self.formatter(t)
                                        for t in test_paths))
-
-    @classmethod
-    def default_same_bin_formatter(cls, s: str) -> Dict[str, str]:
-        return {"testcase": s}
 
     @property
     def same_bin_formatter(self) -> Callable[[str], Dict[str, str]]:

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import re
+from typing import Dict
 
 import click
 from junitparser import TestCase, TestSuite  # type: ignore
@@ -71,5 +72,14 @@ def record_tests(client, source_roots):
     client.run()
 
 
+def format_same_bin(s: str) -> Dict[str, str]:
+    t = s.split(".")
+    return {"class": t[0], "testcase": t[1]}
+
+
 split_subset = launchable.CommonSplitSubsetImpls(
-    __name__, formatter=lambda x: "^{}$".format(x[1]['name']), seperator='|').split_subset()
+    __name__,
+    formatter=lambda x: "^{}$".format(x[1]['name']),
+    seperator='|',
+    same_bin_formatter=format_same_bin,
+).split_subset()

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -74,7 +74,7 @@ def record_tests(client, source_roots):
 
 def format_same_bin(s: str) -> List[Dict[str, str]]:
     t = s.split(".")
-    return [{"class": t[0]}, {"testcase": t[1]}]
+    return [{"type": "class", "name": t[0]}, {"type": "testcase", "name": t[1]}]
 
 
 split_subset = launchable.CommonSplitSubsetImpls(

--- a/launchable/test_runners/go_test.py
+++ b/launchable/test_runners/go_test.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import re
-from typing import Dict
+from typing import Dict, List
 
 import click
 from junitparser import TestCase, TestSuite  # type: ignore
@@ -72,9 +72,9 @@ def record_tests(client, source_roots):
     client.run()
 
 
-def format_same_bin(s: str) -> Dict[str, str]:
+def format_same_bin(s: str) -> List[Dict[str, str]]:
     t = s.split(".")
-    return {"class": t[0], "testcase": t[1]}
+    return [{"class": t[0]}, {"testcase": t[1]}]
 
 
 split_subset = launchable.CommonSplitSubsetImpls(

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, List
 
 import click
 
@@ -79,8 +79,8 @@ def split_subset(client, bare):
         client.formatter = lambda x: "--tests {}".format(x[0]['name'])
         client.separator = ' '
 
-    def format_same_bin(s: str) -> Dict[str, str]:
-        return {"class": s}
+    def format_same_bin(s: str) -> List[Dict[str, str]]:
+        return [{"class": s}]
 
     client.same_bin_formatter = format_same_bin
 

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -80,7 +80,7 @@ def split_subset(client, bare):
         client.separator = ' '
 
     def format_same_bin(s: str) -> List[Dict[str, str]]:
-        return [{"class": s}]
+        return [{"type": "class", "name": s}]
 
     client.same_bin_formatter = format_same_bin
 

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict
 
 import click
 
@@ -77,6 +78,11 @@ def split_subset(client, bare):
     else:
         client.formatter = lambda x: "--tests {}".format(x[0]['name'])
         client.separator = ' '
+
+    def format_same_bin(s: str) -> Dict[str, str]:
+        return {"class": s}
+
+    client.same_bin_formatter = format_same_bin
 
     client.run()
 

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -130,11 +130,17 @@ class CommonRecordTestImpls:
 
 
 class CommonSplitSubsetImpls:
-
-    def __init__(self, module_name, formatter=None, seperator=None):
+    def __init__(
+            self,
+            module_name,
+            formatter=None,
+            seperator=None,
+            same_bin_formatter=None,
+    ):
         self.cmdname = cmdname(module_name)
         self._formatter = formatter
         self._separator = seperator
+        self._same_bin_formatter = same_bin_formatter
 
     def split_subset(self):
         def split_subset(client):
@@ -144,6 +150,9 @@ class CommonSplitSubsetImpls:
 
             if self._separator:
                 client.separator = self._separator
+
+            if self._same_bin_formatter:
+                client.same_bin_formatter = self._same_bin_formatter
 
             client.run()
 

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -7,9 +7,9 @@ import types
 import unittest
 
 import click.testing
+import responses  # type: ignore
 from click.testing import CliRunner
 
-import responses  # type: ignore
 from launchable.__main__ import main
 from launchable.utils.http_client import get_base_url
 from launchable.utils.session import SESSION_DIR_KEY, clean_session_files

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -72,7 +72,7 @@ class SplitSubsetTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_split_subset_with_same_bin(self):
+    def test_split_subset(self):
         pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\ntest_5.py\ntest_6.py"
         mock_json_response = {
             "testPaths": [
@@ -94,21 +94,15 @@ class SplitSubsetTest(CliTestCase):
             json=mock_json_response,
             status=200)
 
-        same_bin_file = tempfile.NamedTemporaryFile(delete=False)
-        same_bin_file.write(b'test_1.py\ntest_6.py')
         result = self.cli(
             "split-subset",
             "--subset-id",
             "subset/456",
             "--bin",
             "1/2",
-            "--same-bin",
-            same_bin_file.name,
             "file",
             mix_stderr=False,
             input=pipe,
         )
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "test_1.py\ntest_6.py\n")
-        same_bin_file.close()
-        os.unlink(same_bin_file.name)

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -94,19 +94,21 @@ class SplitSubsetTest(CliTestCase):
             json=mock_json_response,
             status=200)
 
-        with tempfile.NamedTemporaryFile() as same_bin_file:
-            same_bin_file.write(b'test_1.py\ntest_6.py')
-            result = self.cli(
-                "split-subset",
-                "--subset-id",
-                "subset/456",
-                "--bin",
-                "1/2",
-                "--same-bin",
-                same_bin_file.name,
-                "file",
-                mix_stderr=False,
-                input=pipe,
-            )
-            self.assertEqual(result.exit_code, 0)
-            self.assertEqual(result.stdout, "test_1.py\ntest_6.py\n")
+        same_bin_file = tempfile.NamedTemporaryFile(delete=False)
+        same_bin_file.write(b'test_1.py\ntest_6.py')
+        result = self.cli(
+            "split-subset",
+            "--subset-id",
+            "subset/456",
+            "--bin",
+            "1/2",
+            "--same-bin",
+            same_bin_file.name,
+            "file",
+            mix_stderr=False,
+            input=pipe,
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.stdout, "test_1.py\ntest_6.py\n")
+        same_bin_file.close()
+        os.unlink(same_bin_file.name)

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -69,3 +69,44 @@ class SplitSubsetTest(CliTestCase):
             observation_mode_rest.read().decode(), os.linesep.join(["test_5.py"]))
         observation_mode_rest.close()
         os.unlink(observation_mode_rest.name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset_with_same_bin(self):
+        pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\ntest_5.py\ntest_6.py"
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_6.py"}],
+            ],
+            "rest": [],
+            "subsettingId": 456,
+            "isObservation": False,
+        }
+
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset/{}/slice".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.subsetting_id),
+            json=mock_json_response,
+            status=200)
+
+        with tempfile.NamedTemporaryFile() as same_bin_file:
+            same_bin_file.write(b'test_1.py\ntest_6.py')
+            result = self.cli(
+                "split-subset",
+                "--subset-id",
+                "subset/456",
+                "--bin",
+                "1/2",
+                "--same-bin",
+                same_bin_file.name,
+                "file",
+                mix_stderr=False,
+                input=pipe,
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.stdout, "test_1.py\ntest_6.py\n")

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -143,20 +143,22 @@ class GoTestTest(CliTestCase):
             status=200,
         )
 
-        with tempfile.NamedTemporaryFile() as same_bin_file:
-            same_bin_file.write(
-                b'rocket-car-gotest.TestExample1\n'
-                b'rocket-car-gotest.TestExample2')
-            result = self.cli(
-                'split-subset',
-                '--subset-id',
-                'subset/456',
-                '--bin',
-                '1/2',
-                "--same-bin",
-                same_bin_file.name,
-                'go-test',
-            )
+        same_bin_file = tempfile.NamedTemporaryFile(delete=False)
+        same_bin_file.write(
+            b'rocket-car-gotest.TestExample1\n'
+            b'rocket-car-gotest.TestExample2')
+        result = self.cli(
+            'split-subset',
+            '--subset-id',
+            'subset/456',
+            '--bin',
+            '1/2',
+            "--same-bin",
+            same_bin_file.name,
+            'go-test',
+        )
 
-            self.assertEqual(result.exit_code, 0)
-            self.assertEqual("^TestExample1$|^TestExample2$\n", result.output)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual("^TestExample1$|^TestExample2$\n", result.output)
+        same_bin_file.close()
+        os.unlink(same_bin_file.name)

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -1,10 +1,12 @@
 import gzip
 import json
 import os
+import tempfile
 from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
+from launchable.utils.http_client import get_base_url
 from launchable.utils.session import read_session, write_build
 from tests.cli_test_case import CliTestCase
 
@@ -114,3 +116,47 @@ class GoTestTest(CliTestCase):
 
         self.assertIn(
             'close', responses.calls[3].request.url, 'call close API')
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset_with_same_bin(self):
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset/456/slice".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+            ),
+            json={
+                'testPaths': [
+                    [
+                        {'type': 'class', 'name': 'rocket-car-gotest'},
+                        {'type': 'testcase', 'name': 'TestExample1'},
+                    ],
+                    [
+                        {'type': 'class', 'name': 'rocket-car-gotest'},
+                        {'type': 'testcase', 'name': 'TestExample2'},
+                    ],
+                ],
+                "rest": [],
+            },
+            status=200,
+        )
+
+        with tempfile.NamedTemporaryFile() as same_bin_file:
+            same_bin_file.write(
+                b'rocket-car-gotest.TestExample1\n'
+                b'rocket-car-gotest.TestExample2')
+            result = self.cli(
+                'split-subset',
+                '--subset-id',
+                'subset/456',
+                '--bin',
+                '1/2',
+                "--same-bin",
+                same_bin_file.name,
+                'go-test',
+            )
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual("^TestExample1$|^TestExample2$\n", result.output)

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -1,14 +1,12 @@
 import gzip
 import json
 import os
-import sys
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
 from launchable.utils.http_client import get_base_url
-from launchable.utils.session import read_session, write_build
+from launchable.utils.session import write_build
 from tests.cli_test_case import CliTestCase
 
 
@@ -124,3 +122,79 @@ class RawTest(CliTestCase):
                 ],
                 "testRunner": "raw"
             })
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset(self):
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset/456/slice".format(
+                get_base_url(), self.organization, self.workspace),
+            json={
+                "testPaths": [
+                    [{'type': 'testcase', 'name': 'FooTest.Bar'}],
+                    [{'type': 'testcase', 'name': 'FooTest.Foo'}],
+                ],
+                "rest": [[{'type': 'testcase', 'name': 'FooTest.Baz'}]],
+            },
+            status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli(
+            'split-subset',
+            '--subset-id',
+            'subset/456',
+            '--bin',
+            '1/2',
+            '--rest',
+            rest.name,
+            'raw')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout,
+            '\n'.join([
+                'testcase=FooTest.Bar',
+                'testcase=FooTest.Foo\n',
+            ]))
+        self.assertEqual(
+            rest.read().decode(),
+            'testcase=FooTest.Baz',
+        )
+        rest.close()
+        os.unlink(rest.name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset_with_same_bin(self):
+        # This test must raise error.
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset/456/slice".format(
+                get_base_url(), self.organization, self.workspace),
+            json={
+                "testPaths": [
+                    [{'type': 'testcase', 'name': 'FooTest.Bar'}],
+                    [{'type': 'testcase', 'name': 'FooTest.Foo'}],
+                ],
+                "rest": [],
+            },
+            status=200)
+
+        same_bin_file = tempfile.NamedTemporaryFile(delete=False)
+        same_bin_file.write(
+            b'FooTest.Bar\n'
+            b'FooTest.Foo')
+        result = self.cli(
+            'split-subset',
+            '--subset-id',
+            'subset/456',
+            '--bin',
+            '1/2',
+            "--same-bin",
+            same_bin_file.name,
+            'raw')
+        self.assertTrue(
+            "--same-bin option is supported only for gradle test and go-test." in result.stdout)
+        same_bin_file.close()
+        os.unlink(same_bin_file.name)


### PR DESCRIPTION
# What
- Add `same bin` support for split subset. It is aimed to support grouping some tests that must not be run parallel simultaneously.
- The `same bin` is specified in a text file, with a test per line, and passed with `--same-bin` option.
- Tests specified to the same bin will be packed to the same bin in the split.
- It is possible to specify multiple `same bins`.

- For example, we have 9 tests, and we do not like DB0Test and DB1Test to run parallel, and File0Test and File1Test to run parallel as well.

```sh
$ launchable inspect tests --test-session-id 6
| Test Path                             |   Duration (sec) | Status   | Uploaded At                 |
|---------------------------------------|------------------|----------|-----------------------------|
| class=example.SubTest#testcase=calc   |            0.001 | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.File1Test#testcase=calc |            0     | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.File0Test#testcase=calc |            0.001 | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.DivTest#testcase=calc   |            0     | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.AddTest#testcase=calc   |            0     | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.DB1Test#testcase=calc   |            0.001 | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.Add2Test#testcase=calc  |            0     | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.DB0Test#testcase=calc   |            0.004 | SUCCESS  | 2022-10-06T21:28:10.822524Z |
| class=example.MulTest#testcase=calc   |            0.001 | SUCCESS  | 2022-10-06T21:28:10.822524Z |

# To avoid running DB0Test and DB1Test to run parallel, we have same_bin0.txt.
$ cat same_bin0.txt
example.DB0Test
example.DB1Test

# To avoid running File0Test and File1Test to run parallel, we have same_bin1.txt.
$ cat same_bin1.txt
example.File0Test
example.File1Test

# Here, we have DB0Test and DB1Test in the same bin so that they won't run simultaneously.
$ launchable split-subset --subset-id subset/14 --bin 1/2 --same-bin same_bin0.txt --same-bin same_bin1.txt gradle
--tests example.DB1Test --tests example.DB0Test --tests example.SubTest --tests example.MulTest --tests example.Add2Test

# Here, we have File0Test and File1Test in the same bin so that they won't run simultaneously.
$ launchable split-subset --subset-id subset/14 --bin 2/2 --same-bin same_bin0.txt --same-bin same_bin1.txt gradle
--tests example.File1Test --tests example.File0Test --tests example.DivTest --tests example.AddTest
```

- If a test is specified in multiple `same bins`, it raises error.
```sh
# We have File0Test in both same_bin0.txt and same_bin1.txt.
$ cat same_bin0.txt
example.DB0Test
example.DB1Test
example.File0Test

$ cat same_bin1.txt
example.File0Test
example.File1Test

# Error.
$ launchable split-subset --subset-id subset/14 --bin 1/2 --same-bin same_bin0.txt --same-bin same_bin1.txt gradle
Error: you cannot have same tests in multiple same-bin texts.
Warning: the service failed to split subset. Falling back to running all tests
```