### PR TITLE
add `stats test-sessions` subcommand

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -10,6 +10,7 @@ from .commands.inspect import inspect
 from .commands.record import record
 from .commands.split_subset import split_subset
 from .commands.subset import subset
+from .commands.stats import stats
 from .commands.verify import verify
 from .utils import logger
 from .version import __version__
@@ -78,6 +79,7 @@ main.add_command(subset)
 main.add_command(split_subset)
 main.add_command(verify)
 main.add_command(inspect)
+main.add_command(stats)
 
 if __name__ == '__main__':
     main()

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -10,7 +10,6 @@ from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.flavor import normalize_flavors
 from ...utils.session import write_session
 from ...utils.click import KeyValueType
-from ...utils.logger import Logger, AUDIT_LOG_FORMAT
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,12 +1,13 @@
 import click
 import os
 import sys
-from typing import Dict, Mapping, Optional, Sequence, List
+from typing import Dict, Mapping, Optional, List
 from http import HTTPStatus
 
 from ...utils.ci_provider import CIProvider
 from ...utils.http_client import LaunchableClient
 from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.flavor import normalize_flavors
 from ...utils.session import write_session
 from ...utils.click import KeyValueType
 from ...utils.logger import Logger, AUDIT_LOG_FORMAT
@@ -68,22 +69,8 @@ def session(
     """
 
     flavor_dict = {}
-
-    """
-    TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
-    E.G. 
-        <click8.0: 
-            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.5` is parsed as build=aaa, flavor=(("os", "ubuntu"), ("python", "3.5"))
-        >=click8.0: 
-            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")        
-    """
-    for f in flavor:
-        if isinstance(f, str):
-            k, v = f.replace("(", "").replace(
-                ")", "").replace("'", "").split(",")
-            flavor_dict[k.strip()] = v.strip()
-        elif isinstance(f, Sequence):
-            flavor_dict[f[0]] = f[1]
+    for f in normalize_flavors(flavor):
+        flavor_dict[f[0]] = f[1]
 
     link = _capture_link(os.environ)
     payload = {

--- a/launchable/commands/stats.py
+++ b/launchable/commands/stats.py
@@ -1,0 +1,59 @@
+import click
+import os
+from typing import Sequence
+from ..utils.click import KeyValueType
+from ..utils.env_keys import REPORT_ERROR_KEY
+from ..utils.http_client import LaunchableClient
+
+
+@click.command()
+@click.option(
+    '--days',
+    'days',
+    help='subsetting target from 0% to 100%',
+    type=int,
+    default=7
+)
+@click.option(
+    "--flavor",
+    "flavor",
+    help='flavors',
+    cls=KeyValueType,
+    multiple=True,
+)
+@click.pass_context
+def stats(
+    context: click.core.Context,
+    days: int,
+    flavor: KeyValueType,
+):
+    try:
+        test_runner = context.invoked_subcommand
+        params = {'days': days}
+        flavors = []
+        for f in flavor:
+            if isinstance(f, str):
+                k, v = f.replace("(", "").replace(
+                    ")", "").replace("'", "").split(",")
+                flavors.append('%s=%s' % (k.strip(), v.strip()))
+            elif isinstance(f, Sequence):
+                flavors.append('%s=%s' % (f[0], f[1]))
+
+        if flavors:
+            params['flavor'] = flavors
+
+        client = LaunchableClient(
+            test_runner=test_runner,
+            dry_run=context.obj.dry_run)
+        res = client.request('get', '/stats/test-sessions', params=params)
+        res.raise_for_status()
+        click.echo(res.text)
+
+    except Exception as e:
+        if os.getenv(REPORT_ERROR_KEY):
+            raise e
+        else:
+            click.echo(e, err=True)
+        click.echo(click.style(
+            "Warning: the service failed to get stat.", fg='yellow'),
+            err=True)

--- a/launchable/commands/stats/__init__.py
+++ b/launchable/commands/stats/__init__.py
@@ -1,0 +1,11 @@
+from .test_sessions import test_sessions
+import click
+from launchable.utils.click import GroupWithAlias
+
+
+@click.group(cls=GroupWithAlias)
+def stats():
+    pass
+
+
+stats.add_command(test_sessions)

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -10,7 +10,7 @@ from ...utils.http_client import LaunchableClient
 @click.option(
     '--days',
     'days',
-    help='subsetting target from 0% to 100%',
+    help='How many days of test sessions in the past to be stat',
     type=int,
     default=7
 )

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,8 +1,10 @@
 import click
 import os
-from typing import Sequence, List
+from typing import List
+
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.flavor import normalize_flavors
 from ...utils.http_client import LaunchableClient
 
 
@@ -29,13 +31,8 @@ def test_sessions(
 ):
     params = {'days': days, 'flavor': []}
     flavors = []
-    for f in flavor:
-        if isinstance(f, str):
-            k, v = f.replace("(", "").replace(
-                ")", "").replace("'", "").split(",")
-            flavors.append('%s=%s' % (k.strip(), v.strip()))
-        elif isinstance(f, Sequence):
-            flavors.append('%s=%s' % (f[0], f[1]))
+    for f in normalize_flavors(flavor):
+        flavors.append('%s=%s' % (f[0], f[1]))
 
     if flavors:
         params['flavor'] = flavors

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -41,6 +41,8 @@ def test_sessions(
 
         if flavors:
             params['flavor'] = flavors
+        else:
+            del params['flavor']
 
         client = LaunchableClient(
             test_runner=test_runner,

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,6 +1,6 @@
 import click
 import os
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, List
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
@@ -25,7 +25,7 @@ from ...utils.http_client import LaunchableClient
 def test_sessions(
     context: click.core.Context,
     days: int,
-    flavor: KeyValueType,
+    flavor: List[str] = [],
 ):
     try:
         test_runner = context.invoked_subcommand

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,6 +1,6 @@
 import click
 import os
-from typing import Sequence
+from typing import Any, Dict, Sequence
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
@@ -29,7 +29,7 @@ def test_sessions(
 ):
     try:
         test_runner = context.invoked_subcommand
-        params = {'days': days}
+        params: Dict[str, Any] = {'days': days}
         flavors = []
         for f in flavor:
             if isinstance(f, str):

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -40,7 +40,7 @@ def test_sessions(
     if flavors:
         params['flavor'] = flavors
     else:
-        del params['flavor']
+        params.pop('flavor', None)
 
     try:
         client = LaunchableClient(dry_run=context.obj.dry_run)

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -29,7 +29,7 @@ def test_sessions(
 ):
     try:
         test_runner = context.invoked_subcommand
-        params: Dict[str, Any] = {'days': days}
+        params = {'days': days, 'flavor': []}
         flavors = []
         for f in flavor:
             if isinstance(f, str):

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -27,22 +27,22 @@ def test_sessions(
     days: int,
     flavor: List[str] = [],
 ):
+    params = {'days': days, 'flavor': []}
+    flavors = []
+    for f in flavor:
+        if isinstance(f, str):
+            k, v = f.replace("(", "").replace(
+                ")", "").replace("'", "").split(",")
+            flavors.append('%s=%s' % (k.strip(), v.strip()))
+        elif isinstance(f, Sequence):
+            flavors.append('%s=%s' % (f[0], f[1]))
+
+    if flavors:
+        params['flavor'] = flavors
+    else:
+        del params['flavor']
+
     try:
-        params = {'days': days, 'flavor': []}
-        flavors = []
-        for f in flavor:
-            if isinstance(f, str):
-                k, v = f.replace("(", "").replace(
-                    ")", "").replace("'", "").split(",")
-                flavors.append('%s=%s' % (k.strip(), v.strip()))
-            elif isinstance(f, Sequence):
-                flavors.append('%s=%s' % (f[0], f[1]))
-
-        if flavors:
-            params['flavor'] = flavors
-        else:
-            del params['flavor']
-
         client = LaunchableClient(dry_run=context.obj.dry_run)
         res = client.request('get', '/stats/test-sessions', params=params)
         res.raise_for_status()

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,6 +1,6 @@
 import click
 import os
-from typing import Any, Dict, Sequence, List
+from typing import Sequence, List
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,9 +1,9 @@
 import click
 import os
 from typing import Sequence
-from ..utils.click import KeyValueType
-from ..utils.env_keys import REPORT_ERROR_KEY
-from ..utils.http_client import LaunchableClient
+from ...utils.click import KeyValueType
+from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.http_client import LaunchableClient
 
 
 @click.command()
@@ -22,7 +22,7 @@ from ..utils.http_client import LaunchableClient
     multiple=True,
 )
 @click.pass_context
-def stats(
+def test_sessions(
     context: click.core.Context,
     days: int,
     flavor: KeyValueType,

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -29,6 +29,9 @@ def test_sessions(
     days: int,
     flavor: List[str] = [],
 ):
+    # We originally wanted to write it like `params: Dict[str, Any]`, but python 3.5 does not support it,
+    # so we gave an empty list in the 'flavor' key to give a type hint.
+    # If we don't write this, `pip run type` will assume it is Dict[str, int], and the check will not pass.
     params = {'days': days, 'flavor': []}
     flavors = []
     for f in normalize_flavors(flavor):

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -28,7 +28,6 @@ def test_sessions(
     flavor: List[str] = [],
 ):
     try:
-        test_runner = context.invoked_subcommand
         params = {'days': days, 'flavor': []}
         flavors = []
         for f in flavor:
@@ -44,9 +43,7 @@ def test_sessions(
         else:
             del params['flavor']
 
-        client = LaunchableClient(
-            test_runner=test_runner,
-            dry_run=context.obj.dry_run)
+        client = LaunchableClient(dry_run=context.obj.dry_run)
         res = client.request('get', '/stats/test-sessions', params=params)
         res.raise_for_status()
         click.echo(res.text)

--- a/launchable/utils/flavor.py
+++ b/launchable/utils/flavor.py
@@ -1,0 +1,23 @@
+from typing import List, Sequence, Tuple
+
+
+def normalize_flavors(flavors_raw: List[str]) -> List[Tuple[str, str]]:
+    """Normalize flavor list, because the type of the flavor list specified in the command line flags differs depending on the version of the click.
+
+    TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple of str
+    E.G.
+        <click8.0:
+            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.5` is parsed as build=aaa, flavor=(("os", "ubuntu"), ("python", "3.5"))
+        >=click8.0:
+            `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")
+    """
+    flavors = List()
+    for f in flavors_raw:
+        if isinstance(f, str):
+            k, v = f.replace("(", "").replace(
+                ")", "").replace("'", "").split(",")
+            flavors.append((k.strip(), v.strip()))
+        elif isinstance(f, Sequence):
+            flavors.append((f[0], f[1]))
+
+    return flavors

--- a/launchable/utils/flavor.py
+++ b/launchable/utils/flavor.py
@@ -11,7 +11,7 @@ def normalize_flavors(flavors_raw: List[str]) -> List[Tuple[str, str]]:
         >=click8.0:
             `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8` is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")
     """
-    flavors = List()
+    flavors = []
     for f in flavors_raw:
         if isinstance(f, str):
             k, v = f.replace("(", "").replace(

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -66,6 +66,7 @@ class LaunchableClient:
         method: str,
         sub_path: str,
         payload: Optional[Dict] = None,
+        params: Optional[Dict] = None,
         timeout: Tuple[int, int] = (5, 60),
         compress: bool = False,
     ):
@@ -88,7 +89,7 @@ class LaunchableClient:
 
         try:
             response = self.session.request(
-                method, url, headers=headers, timeout=timeout, data=data)
+                method, url, headers=headers, timeout=timeout, data=data, params=params)
             Logger().debug(
                 "received response status:{} message:{} headers:{}".format(
                     response.status_code, response.reason, response.headers)


### PR DESCRIPTION
With this change, we can get the stats of test sessions via the API, which can be obtained with the stats subcommand.

There is also a function to filter by number of days and flavor, which is useful for predicting test times before running tests.

```console
$ curl -H "Content-Type: application/json" -H "Authorization: Bearer $LAUNCHABLE_TOKEN" https://api.mercury.launchableinc.com/intake/organizations/OOO/workspaces/WWW/stats/test-sessions'?flavor=os=ubuntu-latest'
{"averageDurationSeconds":0.007610803807083564,"count":158,"days":7}
```

```console
$ launchable stats test-sessions --flavor=os=windows-latest
{"averageDurationSeconds":0.007610803807083564,"count":158,"days":7}
```