### PR TITLE
Add warning when the user set --observation option to subset command not record session command

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -27,7 +27,7 @@ def find_or_create_session(
     from .record.session import session as session_command
 
     if session:
-        check_observation_mode_status(session, is_observation)
+        _check_observation_mode_status(session, is_observation)
         return session
 
     saved_build_name = read_build()
@@ -47,7 +47,7 @@ def find_or_create_session(
 
         session_id = read_session(saved_build_name)
         if session_id:
-            check_observation_mode_status(session_id, is_observation)
+            _check_observation_mode_status(session_id, is_observation)
             return session_id
         else:
             context.invoke(
@@ -61,7 +61,7 @@ def find_or_create_session(
             return read_session(saved_build_name)
 
 
-def check_observation_mode_status(session: str, is_observation: bool):
+def _check_observation_mode_status(session: str, is_observation: bool):
     if is_observation is False:
         return
 

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -68,10 +68,10 @@ def _check_observation_mode_status(session: str, is_observation: bool):
     client = LaunchableClient()
     res = client.request("get", session)
 
-    # Do not stop command so only check when the status code is 200
+    # only check when the status code is 200 not to stop the command
     if res.status_code == 200:
         is_observation_in_recorded_session = res.json().get("isObservation", False)
         if is_observation and is_observation_in_recorded_session is False:
             click.echo(click.style(
-                "Warning: you set --observation option this command but you need to set it `launchable record session` command", fg='yellow'),
+                "Warning: you set --observation option in this command but you need to set it `launchable record session` command", fg='yellow'),
                 err=True)

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -62,7 +62,7 @@ def find_or_create_session(
 
 
 def _check_observation_mode_status(session: str, is_observation: bool):
-    if is_observation is False:
+    if not is_observation:
         return
 
     client = LaunchableClient()
@@ -71,7 +71,7 @@ def _check_observation_mode_status(session: str, is_observation: bool):
     # only check when the status code is 200 not to stop the command
     if res.status_code == 200:
         is_observation_in_recorded_session = res.json().get("isObservation", False)
-        if is_observation and is_observation_in_recorded_session is False:
+        if is_observation and not is_observation_in_recorded_session:
             click.echo(click.style(
                 "Warning: you set --observation option in this command but you need to set it `launchable record session` command", fg='yellow'),
                 err=True)

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -73,5 +73,5 @@ def _check_observation_mode_status(session: str, is_observation: bool):
         is_observation_in_recorded_session = res.json().get("isObservation", False)
         if is_observation and not is_observation_in_recorded_session:
             click.echo(click.style(
-                "Warning: you set --observation option in this command but you need to set it `launchable record session` command", fg='yellow'),
+                "Warning: you set --observation option in `launchable subset` command but you need to set it `launchable record session` command", fg='yellow'),
                 err=True)

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -73,5 +73,5 @@ def _check_observation_mode_status(session: str, is_observation: bool):
         is_observation_in_recorded_session = res.json().get("isObservation", False)
         if is_observation and not is_observation_in_recorded_session:
             click.echo(click.style(
-                "Warning: you set --observation option in `launchable subset` command but you need to set it `launchable record session` command", fg='yellow'),
+                "WARNING: --observation flag was ignored. Observation mode can only be enabled for a test session during its initial creation. Add `--observation` option to the `launchable record session` command instead.", fg='yellow'),
                 err=True)

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -89,6 +89,19 @@ class CliTestCase(unittest.TestCase):
             json=[],
             status=200)
         responses.add(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.build_name,
+                self.session_id),
+            json={
+                'id': self.session_id,
+                'isObservation': False,
+            },
+            status=200)
+        responses.add(
             responses.PATCH,
             "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}/close".format(
                 get_base_url(),

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -21,7 +21,7 @@ class HelperTest(CliTestCase):
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
             _check_observation_mode_status(test_session,  False)
             print(stderr.getvalue())
-            self.assertNotIn("Warning:", stderr.getvalue())
+            self.assertNotIn("WARNING:", stderr.getvalue())
 
         request_path = "{}/intake/organizations/{}/workspaces/{}/{}".format(
             get_base_url(),
@@ -39,7 +39,7 @@ class HelperTest(CliTestCase):
                 }, status=200)
 
             _check_observation_mode_status(test_session,  True)
-            self.assertIn("Warning:", stderr.getvalue())
+            self.assertIn("WARNING:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
             responses.replace(
@@ -50,7 +50,7 @@ class HelperTest(CliTestCase):
                 }, status=200)
 
             _check_observation_mode_status(test_session,  True)
-            self.assertNotIn("Warning:", stderr.getvalue())
+            self.assertNotIn("WARNING:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
             responses.replace(
@@ -63,4 +63,4 @@ class HelperTest(CliTestCase):
             _check_observation_mode_status(test_session,  False)
 
             # not check when status isn't 200
-            self.assertNotIn("Warning:", stderr.getvalue())
+            self.assertNotIn("WARNING:", stderr.getvalue())

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -5,7 +5,7 @@ from unittest import mock
 from launchable.utils.http_client import get_base_url
 import responses
 from tests.cli_test_case import CliTestCase
-from launchable.commands.helper import check_observation_mode_status
+from launchable.commands.helper import _check_observation_mode_status
 
 
 class HelperTest(CliTestCase):
@@ -19,7 +19,7 @@ class HelperTest(CliTestCase):
         )
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
-            check_observation_mode_status(test_session,  False)
+            _check_observation_mode_status(test_session,  False)
             print(stderr.getvalue())
             self.assertNotIn("Warning:", stderr.getvalue())
 
@@ -38,7 +38,7 @@ class HelperTest(CliTestCase):
                     "isObservation": False
                 }, status=200)
 
-            check_observation_mode_status(test_session,  True)
+            _check_observation_mode_status(test_session,  True)
             self.assertIn("Warning:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
@@ -49,7 +49,7 @@ class HelperTest(CliTestCase):
                     "isObservation": True
                 }, status=200)
 
-            check_observation_mode_status(test_session,  True)
+            _check_observation_mode_status(test_session,  True)
             self.assertNotIn("Warning:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
@@ -60,7 +60,7 @@ class HelperTest(CliTestCase):
                     "isObservation": True
                 }, status=404)
 
-            check_observation_mode_status(test_session,  False)
+            _check_observation_mode_status(test_session,  False)
 
             # not check when status isn't 200
             self.assertNotIn("Warning:", stderr.getvalue())

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -1,0 +1,66 @@
+
+from io import StringIO
+import os
+from unittest import mock
+from launchable.utils.http_client import get_base_url
+import responses
+from tests.cli_test_case import CliTestCase
+from launchable.commands.helper import check_observation_mode_status
+
+
+class HelperTest(CliTestCase):
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_check_observation_mode_status(self):
+        test_session = "builds/{}/test_sessions/{}".format(
+            self.build_name,
+            self.session_id,
+        )
+
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            check_observation_mode_status(test_session,  False)
+            print(stderr.getvalue())
+            self.assertNotIn("Warning:", stderr.getvalue())
+
+        request_path = "{}/intake/organizations/{}/workspaces/{}/{}".format(
+            get_base_url(),
+            self.organization,
+            self.workspace,
+            test_session,
+        )
+
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            responses.replace(
+                responses.GET,
+                request_path,
+                json={
+                    "isObservation": False
+                }, status=200)
+
+            check_observation_mode_status(test_session,  True)
+            self.assertIn("Warning:", stderr.getvalue())
+
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            responses.replace(
+                responses.GET,
+                request_path,
+                json={
+                    "isObservation": True
+                }, status=200)
+
+            check_observation_mode_status(test_session,  True)
+            self.assertNotIn("Warning:", stderr.getvalue())
+
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            responses.replace(
+                responses.GET,
+                request_path,
+                json={
+                    "isObservation": True
+                }, status=404)
+
+            check_observation_mode_status(test_session,  False)
+
+            # not check when status isn't 200
+            self.assertNotIn("Warning:", stderr.getvalue())


### PR DESCRIPTION
When executing a `launchable subset` command with a session issued by the `launchable record session` command and want to enable observation mode, the user needs to `—observation` option to the `launchable record session` command.

However, sometimes the option is set to the `launchable subset` command, and observation mode isn’t enabled.

So, added a warning message when it happened.

```sh
$ $ launchable record build --name observation-mode
$ launchable record session --build observation-mode > session.txt
$ find tests/**/test_*.py | launchable subset --session $(cat session.txt) --target 30% --observation file > subset.txt
Warning: you set --observation option this command but you need to set it `launchable record session` command # added
Your model is currently in training
Launchable created subset 96 for build observation-mode (test session 69) in workspace launchableinc/mothership

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |           13 |                  28.8889 |                0.000216667 |
| Remainder |           32 |                  71.1111 |                0.000533333 |
|           |              |                          |                            |
| Total     |           45 |                 100      |                0.00075     |

Run `launchable inspect subset --subset-id 96` to view full subset details
```