### PR TITLE
fix subset and rest output to be pair

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -304,8 +304,8 @@ def subset(
             """called after tests are scanned to compute the optimized order"""
 
             # When Error occurs, return the test name as it is passed.
-            origin_subset = self.test_paths
-            origin_rests = []
+            original_subset = self.test_paths
+            original_rests = []
             summary = {}
             subset_id = ""
             is_brainless = False
@@ -332,8 +332,8 @@ def subset(
 
                     res.raise_for_status()
 
-                    origin_subset = res.json().get("testPaths", [])
-                    origin_rests = res.json().get("rest", [])
+                    original_subset = res.json().get("testPaths", [])
+                    original_rests = res.json().get("rest", [])
                     subset_id = res.json()["subsettingId"]
                     summary = res.json()["summary"]
                     is_brainless = res.json().get("isBrainless", False)
@@ -348,7 +348,7 @@ def subset(
                         "Warning: the service failed to subset. Falling back to running all tests", fg='yellow'),
                         err=True)
 
-            if len(origin_subset) == 0:
+            if len(original_subset) == 0:
                 click.echo(click.style(
                     "Error: no tests found matching the path.", 'yellow'), err=True)
                 return
@@ -356,7 +356,7 @@ def subset(
             if split:
                 click.echo("subset/{}".format(subset_id))
             else:
-                output_subset, output_rests = origin_subset, origin_rests
+                output_subset, output_rests = original_subset, original_rests
 
                 if is_observation:
                     output_subset = output_subset + output_rests
@@ -380,20 +380,20 @@ def subset(
             rows = [
                 [
                     "Subset",
-                    len(origin_subset),
+                    len(original_subset),
                     summary["subset"].get("rate", 0.0),
                     summary["subset"].get("duration", 0.0),
                 ],
                 [
                     "Remainder",
-                    len(origin_rests),
+                    len(original_rests),
                     summary["rest"].get("rate", 0.0),
                     summary["rest"].get("duration", 0.0),
                 ],
                 [],
                 [
                     "Total",
-                    len(origin_subset) + len(origin_rests),
+                    len(original_subset) + len(original_rests),
                     summary["subset"].get("rate", 0.0) +
                     summary["rest"].get("rate", 0.0),
                     summary["subset"].get("duration", 0.0) +

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -181,28 +181,13 @@ def subset(
             super(Optimize, self).__init__(dry_run=dry_run)
 
         def _default_output_handler(self, output: List[TestPath], rests: List[TestPath]):
-            # regardless of whether we managed to talk to the service we produce
-            # test names
             if rest:
-                if len(rests) == 0:
-                    rests.append(output[0])
-
                 self.write_file(rest, rests)
 
-            self.print(output)
+            if output:
+                self.print(output)
 
-        def _default_exclusion_output_handler(self, subset: List[TestPath], rest: List[TestPath], is_observation: bool):
-            # This requires third argument is_observation. During the
-            # observation mode, the subset is subset + rest and the rest is
-            # still rest. The reason that the rest won't be an empty array is
-            # not known. However, because the first version is written like so,
-            # we are not sure if changing this will break the users.
-            #
-            # For the custom implementations, when is_observation is True, they
-            # should assume that the 'true rest' is empty. Otherwise, it would
-            # produce bogus output.
-
-            # Swap here to make an inverse.
+        def _default_exclusion_output_handler(self, subset: List[TestPath], rest: List[TestPath]):
             self.output_handler(rest, subset)
 
         def test_path(self, path: TestPathLike):
@@ -319,8 +304,8 @@ def subset(
             """called after tests are scanned to compute the optimized order"""
 
             # When Error occurs, return the test name as it is passed.
-            output = self.test_paths
-            rests = []
+            origin_subset = self.test_paths
+            origin_rests = []
             summary = {}
             subset_id = ""
             is_brainless = False
@@ -347,8 +332,8 @@ def subset(
 
                     res.raise_for_status()
 
-                    output = res.json()["testPaths"]
-                    rests = res.json()["rest"]
+                    origin_subset = res.json().get("testPaths", [])
+                    origin_rests = res.json().get("rest", [])
                     subset_id = res.json()["subsettingId"]
                     summary = res.json()["summary"]
                     is_brainless = res.json().get("isBrainless", False)
@@ -363,7 +348,7 @@ def subset(
                         "Warning: the service failed to subset. Falling back to running all tests", fg='yellow'),
                         err=True)
 
-            if len(output) == 0:
+            if len(origin_subset) == 0:
                 click.echo(click.style(
                     "Error: no tests found matching the path.", 'yellow'), err=True)
                 return
@@ -371,16 +356,17 @@ def subset(
             if split:
                 click.echo("subset/{}".format(subset_id))
             else:
-                _output, _rests = output, rests
+                output_subset, output_rests = origin_subset, origin_rests
 
                 if is_observation:
-                    _output = _output + _rests
+                    output_subset = output_subset + output_rests
+                    output_rests = []
 
                 if is_output_exclusion_rules:
                     self.exclusion_output_handler(
-                        _output, _rests, is_observation)
+                        output_subset, output_rests)
                 else:
-                    self.output_handler(_output, _rests)
+                    self.output_handler(output_subset, output_rests)
 
             # When Launchable returns an error, the cli skips showing summary report
             if "subset" not in summary.keys() or "rest" not in summary.keys():
@@ -394,20 +380,20 @@ def subset(
             rows = [
                 [
                     "Subset",
-                    len(output),
+                    len(origin_subset),
                     summary["subset"].get("rate", 0.0),
                     summary["subset"].get("duration", 0.0),
                 ],
                 [
                     "Remainder",
-                    len(rests),
+                    len(origin_rests),
                     summary["rest"].get("rate", 0.0),
                     summary["rest"].get("duration", 0.0),
                 ],
                 [],
                 [
                     "Total",
-                    len(output) + len(rests),
+                    len(origin_subset) + len(origin_rests),
                     summary["subset"].get("rate", 0.0) +
                     summary["rest"].get("rate", 0.0),
                     summary["subset"].get("duration", 0.0) +

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -37,9 +37,7 @@ def subset(client, bare, source_roots):
     for root in source_roots:
         client.scan(root, '**/*', file2test)
 
-    def exclusion_output_handler(subset_tests, rest_tests, is_observation):
-        if is_observation:
-            rest_tests = []
+    def exclusion_output_handler(subset_tests, rest_tests):
         if client.rest:
             with open(client.rest, "w+", encoding="utf-8") as fp:
                 if not bare and len(rest_tests) == 0:

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -164,11 +164,7 @@ class APIErrorTest(CliTestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
             self.assertTrue(subset_file in result.stdout)
-
-            rest = Path(rest_file.name).read_text()
-            self.assertEqual(
-                len(rest.rstrip().split("\n")), 1)
-            self.assertTrue(subset_file in rest)
+            self.assertEqual(Path(rest_file.name).read_text(), "")
 
         responses.replace(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
             base=get_base_url(), org=self.organization, ws=self.workspace), status=404)
@@ -180,11 +176,7 @@ class APIErrorTest(CliTestCase):
 
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
             self.assertTrue(subset_file in result.stdout)
-
-            rest = Path(rest_file.name).read_text()
-            self.assertEqual(
-                len(rest.rstrip().split("\n")), 1)
-            self.assertTrue(subset_file in rest)
+            self.assertEqual(Path(rest_file.name).read_text(), "")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -369,6 +369,7 @@ class SubsetTest(CliTestCase):
                     "subset": {"duration": 15, "candidates": 3, "rate": 70},
                     "rest": {"duration": 6, "candidates": 3, "rate": 30}
                 },
+                "isObservation": True,
             }, status=200)
 
         rest = tempfile.NamedTemporaryFile(delete=False)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -10,7 +10,7 @@ from tests.cli_test_case import CliTestCase
 class SubsetTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_subset_with_observation_mode(self):
+    def test_subset(self):
         pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py"
         mock_json_response = {
             "testPaths": [
@@ -49,7 +49,64 @@ class SubsetTest(CliTestCase):
         rest.close()
         os.unlink(rest.name)
 
-        mock_json_response["isObservation"] = True
+        # case: rest is empty
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+            ],
+            "testRunner": "file",
+            "rest": [],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "isObservation": False,
+        }
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_json_response,
+            status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name, "file", mix_stderr=False, input=pipe)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
+        self.assertEqual(
+            rest.read().decode(), "")
+        rest.close()
+        os.unlink(rest.name)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_observation_mode(self):
+        pipe = "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py"
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+            ],
+            "testRunner": "file",
+            "rest": [
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "isObservation": True,
+        }
+
         responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
             get_base_url(),
             self.organization,
@@ -75,12 +132,47 @@ class SubsetTest(CliTestCase):
         self.assertEqual(
             result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
         self.assertEqual(
-            observation_mode_rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
+            observation_mode_rest.read().decode(), "")
         observation_mode_rest.close()
         os.unlink(observation_mode_rest.name)
 
-    @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+        # case: rest is empty
+        mock_json_response = {
+            "testPaths": [
+                [{"type": "file", "name": "test_1.py"}],
+                [{"type": "file", "name": "test_2.py"}],
+                [{"type": "file", "name": "test_3.py"}],
+                [{"type": "file", "name": "test_4.py"}],
+            ],
+            "testRunner": "file",
+            "rest": [],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 10, "candidates": 3, "rate": 50},
+                "rest": {"duration": 10, "candidates": 3, "rate": 50}
+            },
+            "isObservation": True,
+        }
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_json_response,
+            status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli("subset", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name, "--observation", "file", mix_stderr=False, input=pipe)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
+        self.assertEqual(
+            rest.read().decode(), "")
+        rest.close()
+        os.unlink(rest.name)
+
+    @ responses.activate
+    @ mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_with_get_tests_from_previous_full_runs(self):
         responses.replace(
             responses.POST,
@@ -199,5 +291,106 @@ class SubsetTest(CliTestCase):
 
         self.assertEqual(
             rest.read().decode(), os.linesep.join(["test_aaa.py", "test_bbb.py", "test_ccc.py"]))
+        rest.close()
+        os.unlink(rest.name)
+
+        # case: reset is empty
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={
+                "testPaths": [
+                    [{"type": "file", "name": "test_aaa.py"}],
+                    [{"type": "file", "name": "test_bbb.py"}],
+                    [{"type": "file", "name": "test_ccc.py"}],
+                    [{"type": "file", "name": "test_111.py"}],
+                    [{"type": "file", "name": "test_222.py"}],
+                    [{"type": "file", "name": "test_333.py"}],
+                ],
+                "testRunner": "file",
+                "rest": [],
+                "subsettingId": 123,
+                "summary": {
+                    "subset": {"duration": 15, "candidates": 6, "rate": 100},
+                    "rest": {"duration": 0, "candidates": 0, "rate": 0}
+                },
+            }, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli(
+            "subset",
+            "--target",
+            "70%",
+            "--session",
+            self.session,
+            "--rest",
+            rest.name,
+            "--output-exclusion-rules",
+            "file",
+            input=pipe,
+            mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "")
+
+        self.assertEqual(
+            rest.read().decode(), os.linesep.join(["test_aaa.py", "test_bbb.py", "test_ccc.py", "test_111.py", "test_222.py", "test_333.py"]))
+        rest.close()
+        os.unlink(rest.name)
+
+    @ responses.activate
+    @ mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_observation_and_output_exclusion_rules(self):
+        pipe = "test_aaa.py\ntest_111.py\ntest_bbb.py\ntest_222.py\ntest_ccc.py\ntest_333.py\n"
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={
+                "testPaths": [
+                    [{"type": "file", "name": "test_aaa.py"}],
+                    [{"type": "file", "name": "test_bbb.py"}],
+                    [{"type": "file", "name": "test_ccc.py"}],
+                ],
+                "testRunner": "file",
+                "rest": [
+                    [{"type": "file", "name": "test_111.py"}],
+                    [{"type": "file", "name": "test_222.py"}],
+                    [{"type": "file", "name": "test_333.py"}],
+                ],
+                "subsettingId": 123,
+                "summary": {
+                    "subset": {"duration": 15, "candidates": 3, "rate": 70},
+                    "rest": {"duration": 6, "candidates": 3, "rate": 30}
+                },
+            }, status=200)
+
+        rest = tempfile.NamedTemporaryFile(delete=False)
+        result = self.cli(
+            "subset",
+            "--target",
+            "70%",
+            "--session",
+            self.session,
+            "--rest",
+            rest.name,
+            "--output-exclusion-rules",
+            "--observation",
+            "file",
+            input=pipe,
+            mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout, "")
+
+        self.assertEqual(
+            rest.read().decode(), os.linesep.join(["test_aaa.py", "test_bbb.py", "test_ccc.py", "test_111.py", "test_222.py", "test_333.py"]))
         rest.close()
         os.unlink(rest.name)

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -8,6 +8,7 @@ import responses  # type: ignore
 from launchable.utils.http_client import get_base_url
 from launchable.utils.session import write_build
 from tests.cli_test_case import CliTestCase
+from tests.helper import ignore_warnings
 
 
 class RawTest(CliTestCase):
@@ -125,6 +126,7 @@ class RawTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @ignore_warnings
     def test_split_subset(self):
         responses.replace(
             responses.POST,


### PR DESCRIPTION
⚠️ **This PR includes breaking change.** ⚠️ 

Before this change, when the rest response is empty we fill a test path to the rest output not to suspend the user pipeline that depends on the rest output. However, the behavior breaks the policy that the subset and the rest should be a pair.

So, I fixed it. And, I summarized the subset and the rest output rules.

e.g) 
Assume there are test_paths, `file=aaa.py`, `file=bbbb.py`, `file=111.py`, and `file=222.py`, also `file=aaa.py` and `file=bbb.py` are included in the subset, `file=111.py` and `file=222.py` are included the rest.

### As Is

| command | subset | rest |
|:---:|:---:|:---:|
| `launchable subset --target 50% file` | `file=aaa.py`, `file=bbb.py`|  `file=111.py`, `file=222.py`
| `launchable subset --observation --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |  `file=111.py`, `file=222.py`|
| `launchable subset --output-exclusion-rules --rest rest.txt > subset.txt` | `file=111.py`, `file=222.py` | `file=aaa.py`, `file=bbb.py` |
`launchable subset --observation --output-exclusion-rules --rest rest.txt > subset.txt` | `file=111.py`, `file=222.py` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |

### To Be

| command | subset | rest |
|:---:|:---:|:---:|
| `launchable subset --target 50% file` | `file=aaa.py`, `file=bbb.py`|  `file=111.py`, `file=222.py`
| `launchable subset --observation --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |  |
| `launchable subset --output-exclusion-rules --rest rest.txt > subset.txt` | `file=111.py`, `file=222.py` | `file=aaa.py`, `file=bbb.py` |
`launchable subset --observation --output-exclusion-rules --rest rest.txt > subset.txt` | | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |

___

Also, `file=aaa.py`, `file=bbb.py`, `file=111.py` and `file=222.py` are included in the subset and the rest is empty.

### As Is
| command | subset | rest |
|:---:|:---:|:---:|
| `launchable subset --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |  `file=aaa.py` |
| `launchable subset --observation --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` | `file=aaa.py` |
| `launchable subset --output-exclusion-rules --rest rest.txt > subset.txt` |  `file=aaa.py` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |
`launchable subset --observation --output-exclusion-rules --rest rest.txt > subset.txt` | `file=aaa.py` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |

### To Be
| command | subset | rest |
|:---:|:---:|:---:|
| `launchable subset --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |  |
| `launchable subset --observation --target 50% file` | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |  |
| `launchable subset --output-exclusion-rules --rest rest.txt > subset.txt` |   | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |
`launchable subset --observation --output-exclusion-rules --rest rest.txt > subset.txt` |  | `file=aaa.py`, `file=bbb.py`, `file=111.py`, `file=222.py` |