### PR TITLE
fix git submodule test to support git-shell update

### DIFF
--- a/launchable/__main__.py
+++ b/launchable/__main__.py
@@ -9,8 +9,8 @@ import click
 from .commands.inspect import inspect
 from .commands.record import record
 from .commands.split_subset import split_subset
-from .commands.subset import subset
 from .commands.stats import stats
+from .commands.subset import subset
 from .commands.verify import verify
 from .utils import logger
 from .version import __version__

--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -138,7 +138,7 @@ class TestFilePathNormalizer(unittest.TestCase):
                 ['git', 'init',
                  str(temppath.joinpath("gitrepo"))])
             self._run_command(
-                ['git', 'submodule', 'add', str(temppath.joinpath("submod")), 'submod'],
+                ['git', '-c', 'protocol.file.allow=always', 'submodule', 'add', str(temppath.joinpath("submod")), 'submod'],
                 cwd=str(temppath.joinpath("gitrepo")))
 
             base = str(temppath.joinpath("gitrepo"))

--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -103,9 +103,9 @@ class TestFilePathNormalizer(unittest.TestCase):
         self.assertEqual(relpath, n.relativize(relpath))
         self.assertEqual(relpath, n.relativize(abspath))
 
-    @unittest.skipIf(sys.platform.startswith(
-        "win"
-    ), "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed."
+    @unittest.skipIf(
+        sys.platform.startswith("win"),
+        "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed."
     )
     def test_inference_git(self):
         with tempfile.TemporaryDirectory() as tempdirname:
@@ -119,9 +119,9 @@ class TestFilePathNormalizer(unittest.TestCase):
             n = FilePathNormalizer()
             self.assertEqual(relpath, n.relativize(abspath))
 
-    @unittest.skipIf(sys.platform.startswith(
-        "win"
-    ), "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed. Also when this runs on Windows, GIT_AUTHOR_NAME etc. is ignored and fails."
+    @unittest.skipIf(
+        sys.platform.startswith("win"),
+        "tempfile creates 8.3 filenames, and it's hard to deal with them. Practically, we don't see them often, so do not support them now until it's needed. Also when this runs on Windows, GIT_AUTHOR_NAME etc. is ignored and fails."
     )
     def test_inference_git_submodule(self):
         with tempfile.TemporaryDirectory() as tempdirname:
@@ -137,10 +137,8 @@ class TestFilePathNormalizer(unittest.TestCase):
             self._run_command(
                 ['git', 'init',
                  str(temppath.joinpath("gitrepo"))])
-            self._run_command([
-                'git', 'submodule', 'add',
-                str(temppath.joinpath("submod")), 'submod'
-            ],
+            self._run_command(
+                ['git', 'submodule', 'add', str(temppath.joinpath("submod")), 'submod'],
                 cwd=str(temppath.joinpath("gitrepo")))
 
             base = str(temppath.joinpath("gitrepo"))
@@ -161,8 +159,8 @@ class TestFilePathNormalizer(unittest.TestCase):
                 env={
                     "GIT_AUTHOR_NAME": "Test User",
                     "GIT_AUTHOR_EMAIL": "user@example.com",
-                                        "GIT_COMMITTER_NAME": "Test User",
-                                        "GIT_COMMITTER_EMAIL": "user@example.com",
+                    "GIT_COMMITTER_NAME": "Test User",
+                    "GIT_COMMITTER_EMAIL": "user@example.com",
                 })
         except subprocess.CalledProcessError as e:
             self.fail(


### PR DESCRIPTION
# What
- Fix git submodel test for workaround to support git-shell update happened 18th October, 2022.
- https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
- Our github actions started to fail due to git-shell update: https://github.com/launchableinc/cli/actions/runs/3292983667/jobs/5429303370
- Apply format and isort.