### PR TITLE
add group option

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -3,6 +3,15 @@ import glob
 import os
 import traceback
 import xml.etree.ElementTree as ET
+from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
+from more_itertools import ichunked
+from .case_event import CaseEvent, CaseEventType
+from ...utils.http_client import LaunchableClient
+from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.session import parse_session, read_build
+from ...utils.exceptions import InvalidJUnitXMLException
+from ...testpath import TestPathComponent, FilePathNormalizer, unparse_test_path
+from ..helper import find_or_create_session
 from http import HTTPStatus
 from typing import Callable, Dict, Generator, List, Optional, Tuple
 
@@ -277,7 +286,7 @@ def tests(
                     raise Exception(exceptions)
 
             # generator that creates the payload incrementally
-            def payload(cases: Generator[TestCase, None, None], test_runner, group: str) -> Tuple[Dict[str, List, str], List[Exception]]:
+            def payload(cases: Generator[TestCase, None, None], test_runner, group: str) -> Tuple[Dict[str,  Union[str, List]], List[Exception]]:
                 nonlocal count
                 cs = []
                 exs = []
@@ -293,7 +302,7 @@ def tests(
                 count += len(cs)
                 return {"events": cs, "testRunner": test_runner, "group": group}, exs
 
-            def send(payload: Dict[str, List]) -> None:
+            def send(payload: Dict[str, Union[str, List]]) -> None:
                 res = client.request(
                     "post", "{}/events".format(session_id), payload=payload, compress=True)
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -1,3 +1,4 @@
+import re
 from ...utils.logger import Logger
 from ...utils.click import KeyValueType
 from launchable.utils.authentication import ensure_org_workspace
@@ -19,9 +20,21 @@ import glob
 import os
 import traceback
 import xml.etree.ElementTree as ET
-
-
 from junitparser import JUnitXml, JUnitXmlError, TestCase, TestSuite  # type: ignore  # noqa: F401
+
+
+group_name_rule = re.compile("^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+
+
+def _validate_group(ctx, param, value):
+    if value is None:
+        return ""
+
+    if group_name_rule.match(value):
+        return value
+    else:
+        raise click.BadParameter(
+            "group option supports only alphabet(a-z, A-Z), number(0-9), '-', and '_'")
 
 
 @click.group()
@@ -92,7 +105,7 @@ from junitparser import JUnitXml, JUnitXmlError, TestCase, TestSuite  # type: ig
     "group",
     help='Grouping name for test results',
     type=str,
-    default="",
+    callback=_validate_group,
 )
 @click.pass_context
 def tests(

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -277,7 +277,7 @@ def tests(
                     raise Exception(exceptions)
 
             # generator that creates the payload incrementally
-            def payload(cases: Generator[TestCase, None, None], test_runner, group: str) -> Tuple[Dict[str, List], List[Exception]]:
+            def payload(cases: Generator[TestCase, None, None], test_runner, group: str) -> Tuple[Dict[str, List, str], List[Exception]]:
                 nonlocal count
                 cs = []
                 exs = []

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -1,37 +1,27 @@
+from ...utils.logger import Logger
+from ...utils.click import KeyValueType
+from launchable.utils.authentication import ensure_org_workspace
+from tabulate import tabulate
+from dateutil.parser import parse
+import click
+from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
+from http import HTTPStatus
+from ..helper import find_or_create_session
+from ...testpath import TestPathComponent, FilePathNormalizer, unparse_test_path
+from ...utils.exceptions import InvalidJUnitXMLException
+from ...utils.session import parse_session, read_build
+from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.http_client import LaunchableClient
+from .case_event import CaseEvent, CaseEventType
+from more_itertools import ichunked
 import datetime
 import glob
 import os
 import traceback
 import xml.etree.ElementTree as ET
-from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
-from more_itertools import ichunked
-from .case_event import CaseEvent, CaseEventType
-from ...utils.http_client import LaunchableClient
-from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.session import parse_session, read_build
-from ...utils.exceptions import InvalidJUnitXMLException
-from ...testpath import TestPathComponent, FilePathNormalizer, unparse_test_path
-from ..helper import find_or_create_session
-from http import HTTPStatus
-from typing import Callable, Dict, Generator, List, Optional, Tuple
 
-import click
-from dateutil.parser import parse
+
 from junitparser import JUnitXml, JUnitXmlError, TestCase, TestSuite  # type: ignore  # noqa: F401
-from more_itertools import ichunked
-from tabulate import tabulate
-
-from launchable.utils.authentication import ensure_org_workspace
-
-from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
-from ...utils.click import KeyValueType
-from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.exceptions import InvalidJUnitXMLException
-from ...utils.http_client import LaunchableClient
-from ...utils.logger import Logger
-from ...utils.session import parse_session, read_build
-from ..helper import find_or_create_session
-from .case_event import CaseEvent, CaseEventType
 
 
 @click.group()
@@ -286,7 +276,8 @@ def tests(
                     raise Exception(exceptions)
 
             # generator that creates the payload incrementally
-            def payload(cases: Generator[TestCase, None, None], test_runner, group: str) -> Tuple[Dict[str,  Union[str, List]], List[Exception]]:
+            def payload(cases: Generator[TestCase, None, None],
+                        test_runner, group: str) -> Tuple[Dict[str, Union[str, List]], List[Exception]]:
                 nonlocal count
                 cs = []
                 exs = []

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -25,18 +25,21 @@ from ...utils.session import parse_session, read_build
 from ..helper import find_or_create_session
 from .case_event import CaseEvent, CaseEventType
 
-group_name_rule = re.compile("^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+GROUP_NAME_RULE = re.compile("^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+RESERVED_GROUP_NAMES = ["group", "groups", "nogroup", "nogroups"]
 
 
 def _validate_group(ctx, param, value):
     if value is None:
         return ""
 
-    if group_name_rule.match(value):
+    if str(value).lower() in RESERVED_GROUP_NAMES:
+        raise click.BadParameter("{} is reserved name.".format(value))
+
+    if GROUP_NAME_RULE.match(value):
         return value
     else:
-        raise click.BadParameter(
-            "group option supports only alphabet(a-z, A-Z), number(0-9), '-', and '_'")
+        raise click.BadParameter("group option supports only alphabet(a-z, A-Z), number(0-9), '-', and '_'")
 
 
 @click.group()

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -5,11 +5,7 @@ import responses  # type: ignore
 import gzip
 import os
 import sys
-from pathlib import Path
 from unittest import mock
-
-import responses  # type: ignore
-
 from launchable.commands.record.tests import INVALID_TIMESTAMP, parse_launchable_timeformat
 from launchable.utils.session import write_build, write_session
 from tests.cli_test_case import CliTestCase
@@ -26,14 +22,14 @@ class TestsTest(CliTestCase):
 <testsuite name="example" tests="1" file="test_example.py" time="0.087" timestamp="2020-01-01T12:00:00" failures="0" errors="0" skipped="0">
     <testcase classname="Hoge" name="test_example" time="0.087" timestamp="2020-01-01T12:00:00" file="test_example.py" line="9"/>
 </testsuite>
-        """
+        """  # noqa E501
 
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(bytes(test_result, 'utf-8'))
             tmp.seek(0)
 
             result = self.cli('record', 'tests', '--session',
-                              self.session, '--group', 'hoge',  'file', tmp.name)
+                              self.session, '--group', 'hoge', 'file', tmp.name)
 
             self.assertEqual(result.exit_code, 0)
             # get request body

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -1,10 +1,12 @@
-import json
-from pathlib import Path
-import responses  # type: ignore
 import gzip
+import json
 import os
 import sys
+from pathlib import Path
 from unittest import mock
+
+import responses  # type: ignore
+
 from launchable.commands.record.tests import INVALID_TIMESTAMP, parse_launchable_timeformat
 from launchable.utils.session import write_build, write_session
 from tests.cli_test_case import CliTestCase
@@ -39,12 +41,9 @@ class TestsTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        normal_xml = str(Path(__file__).parent.joinpath(
-            '../../data/broken_xml/normal.xml').resolve())
-        broken_xml = str(Path(__file__).parent.joinpath(
-            '../../data/broken_xml/broken.xml').resolve())
-        result = self.cli('record', 'tests', '--build',
-                          self.build_name, 'file', normal_xml, broken_xml)
+        normal_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/normal.xml').resolve())
+        broken_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/broken.xml').resolve())
+        result = self.cli('record', 'tests', '--build', self.build_name, 'file', normal_xml, broken_xml)
 
         def remove_backslash(input: str) -> str:
             # Hack for Windowns. They containts double escaped backslash such
@@ -55,12 +54,10 @@ class TestsTest(CliTestCase):
                 return input
 
         # making sure the offending file path name is being printed.
-        self.assertIn(remove_backslash(broken_xml),
-                      remove_backslash(result.output))
+        self.assertIn(remove_backslash(broken_xml), remove_backslash(result.output))
 
         # normal.xml
-        self.assertIn('open_class_user_test.rb', gzip.decompress(
-            responses.calls[2].request.body).decode())
+        self.assertIn('open_class_user_test.rb', gzip.decompress(responses.calls[2].request.body).decode())
 
     def test_parse_launchable_timeformat(self):
         t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934

--- a/tests/data/ant/record_test_result.json
+++ b/tests/data/ant/record_test_result.json
@@ -40,5 +40,6 @@
       "data": null
     }
   ],
-  "testRunner": "ant"
+  "testRunner": "ant",
+  "group": ""
 }

--- a/tests/data/bazel/record_test_result.json
+++ b/tests/data/bazel/record_test_result.json
@@ -127,5 +127,6 @@
       "data": null
     }
   ],
-  "testRunner": "bazel"
+  "testRunner": "bazel",
+  "group": ""
 }

--- a/tests/data/bazel/record_test_with_build_event_json_result.json
+++ b/tests/data/bazel/record_test_with_build_event_json_result.json
@@ -43,5 +43,6 @@
       "data": null
     }
   ],
-  "testRunner": "bazel"
+  "testRunner": "bazel",
+  "group": ""
 }

--- a/tests/data/bazel/record_test_with_multiple_build_event_json_result.json
+++ b/tests/data/bazel/record_test_with_multiple_build_event_json_result.json
@@ -71,5 +71,6 @@
       "data": null
     }
   ],
-  "testRunner": "bazel"
+  "testRunner": "bazel",
+  "group": ""
 }

--- a/tests/data/behave/record_test_result.json
+++ b/tests/data/behave/record_test_result.json
@@ -23,5 +23,6 @@
       "data": null
     }
   ],
-  "testRunner": "behave"
+  "testRunner": "behave",
+  "group": ""
 }

--- a/tests/data/ctest/record_test_result.json
+++ b/tests/data/ctest/record_test_result.json
@@ -48,5 +48,6 @@
       "data": null
     }
   ],
-  "testRunner": "ctest"
+  "testRunner": "ctest",
+  "group": ""
 }

--- a/tests/data/cucumber/record_test_json_result.json
+++ b/tests/data/cucumber/record_test_json_result.json
@@ -477,5 +477,6 @@
       "data": null
     }
   ],
-  "testRunner": "cucumber"
+  "testRunner": "cucumber",
+  "group": ""
 }

--- a/tests/data/cucumber/record_test_result.json
+++ b/tests/data/cucumber/record_test_result.json
@@ -287,5 +287,6 @@
       "data": null
     }
   ],
-  "testRunner": "cucumber"
+  "testRunner": "cucumber",
+  "group": ""
 }

--- a/tests/data/cypress/record_test_result.json
+++ b/tests/data/cypress/record_test_result.json
@@ -70,5 +70,6 @@
       "data": null
     }
   ],
-  "testRunner": "cypress"
+  "testRunner": "cypress",
+  "group": ""
 }

--- a/tests/data/go_test/record_test_result.json
+++ b/tests/data/go_test/record_test_result.json
@@ -73,5 +73,6 @@
       "data": null
     }
   ],
-  "testRunner": "go-test"
+  "testRunner": "go-test",
+  "group": ""
 }

--- a/tests/data/googletest/fail/record_test_result.json
+++ b/tests/data/googletest/fail/record_test_result.json
@@ -58,5 +58,6 @@
       "data": null
     }
   ],
-  "testRunner": "googletest"
+  "testRunner": "googletest",
+  "group": ""
 }

--- a/tests/data/googletest/record_test_result.json
+++ b/tests/data/googletest/record_test_result.json
@@ -115,5 +115,6 @@
       "data": null
     }
   ],
-  "testRunner": "googletest"
+  "testRunner": "googletest",
+  "group": ""
 }

--- a/tests/data/gradle/recursion/expected.json
+++ b/tests/data/gradle/recursion/expected.json
@@ -39,5 +39,6 @@
       "data": null
     }
   ],
-  "testRunner": "gradle"
+  "testRunner": "gradle",
+  "group": ""
 }

--- a/tests/data/jest/record_test_result.json
+++ b/tests/data/jest/record_test_result.json
@@ -157,5 +157,6 @@
       "data": null
     }
   ],
-  "testRunner": "jest"
+  "testRunner": "jest",
+  "group": ""
 }

--- a/tests/data/maven/record_test_result.json
+++ b/tests/data/maven/record_test_result.json
@@ -55,5 +55,6 @@
       "data": null
     }
   ],
-  "testRunner": "maven"
+  "testRunner": "maven",
+  "group": ""
 }

--- a/tests/data/minitest/record_test_result.json
+++ b/tests/data/minitest/record_test_result.json
@@ -126,5 +126,6 @@
       "data": null
     }
   ],
-  "testRunner": "minitest"
+  "testRunner": "minitest",
+  "group": ""
 }

--- a/tests/data/nunit/record_test_result.json
+++ b/tests/data/nunit/record_test_result.json
@@ -96,5 +96,6 @@
       "data": null
     }
   ],
-  "testRunner": "nunit"
+  "testRunner": "nunit",
+  "group": ""
 }

--- a/tests/data/pytest/record_test_result.json
+++ b/tests/data/pytest/record_test_result.json
@@ -162,5 +162,6 @@
         "data":null
      }
   ],
-  "testRunner": "pytest"
+  "testRunner": "pytest",
+  "group": ""
 }

--- a/tests/data/robot/record_test_result.json
+++ b/tests/data/robot/record_test_result.json
@@ -109,5 +109,6 @@
       "data": null
     }
   ],
-  "testRunner": "robot"
+  "testRunner": "robot",
+  "group": ""
 }

--- a/tests/data/rspec/record_test_result.json
+++ b/tests/data/rspec/record_test_result.json
@@ -369,5 +369,6 @@
       "data": null
     }
   ],
-  "testRunner": "rspec"
+  "testRunner": "rspec",
+  "group": ""
 }

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -118,7 +118,8 @@ class RawTest(CliTestCase):
                         'type': 'case',
                     },
                 ],
-                "testRunner": "raw"
+                "testRunner": "raw",
+                "group": ""
             })
 
     @responses.activate


### PR DESCRIPTION
Provide a new option as `group` for `launchable record tests` command.
When reports test results, can set the group name using a new option

e.g)
```
$ launchable record tests --group unit-test ./test-reports/unit-test.xml
$ launchable record tests --group e2e ./test-reports/e2e.xml
```