### PR TITLE
Support zero input subset for raw profile

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -179,6 +179,7 @@ def subset(
             self.output_handler = self._default_output_handler
             self.exclusion_output_handler = self._default_exclusion_output_handler
             self.is_get_tests_from_previous_sessions = is_get_tests_from_previous_sessions
+            self.is_output_exclusion_rules = is_output_exclusion_rules
             super(Optimize, self).__init__(dry_run=dry_run)
 
         def _default_output_handler(self, output: List[TestPath], rests: List[TestPath]):

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -24,6 +24,11 @@ def subset(client, test_path_file):
     if not client.is_get_tests_from_previous_sessions and test_path_file is None:
         raise click.BadArgumentUsage("Missing argument 'TEST_PATH_FILE'.")
 
+    if client.is_output_exclusion_rules:
+        raise click.BadArgumentUsage(
+            "Don't need to use `--output-exclusion-rules` option. Please use `--rest` option and use it for exclusion"
+        )
+
     if not client.is_get_tests_from_previous_sessions:
         tps = [s.strip() for s in test_path_file.readlines()]
         for tp_str in tps:

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -22,8 +22,7 @@ def subset(client, test_path_file):
     """
 
     if not client.is_get_tests_from_previous_sessions and test_path_file is None:
-        raise click.BadArgumentUsage(
-            "Missing argument 'TEST_PATH_FILE'.")
+        raise click.BadArgumentUsage("Missing argument 'TEST_PATH_FILE'.")
 
     if not client.is_get_tests_from_previous_sessions:
         tps = [s.strip() for s in test_path_file.readlines()]
@@ -41,8 +40,7 @@ def subset(client, test_path_file):
     client.run()
 
 
-split_subset = launchable.CommonSplitSubsetImpls(
-    __name__, formatter=unparse_test_path, seperator='\n').split_subset()
+split_subset = launchable.CommonSplitSubsetImpls(__name__, formatter=unparse_test_path, seperator='\n').split_subset()
 
 
 @click.argument('test_result_file', required=True, type=click.Path(exists=True))
@@ -122,8 +120,7 @@ def record_tests(client, test_result_file):
     def parse(test_result_file: str) -> Generator[CaseEventType, None, None]:
         with open(test_result_file, 'r') as f:
             doc = json.load(f)
-        default_created_at = datetime.datetime.now(
-            datetime.timezone.utc).isoformat()
+        default_created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         for case in doc['testCases']:
             test_path = parse_test_path(case['testPath'])
             status = case['status']
@@ -135,8 +132,7 @@ def record_tests(client, test_result_file):
                     "The status of {} should be one of {} (was {})".format(test_path,
                                                                            list(CaseEvent.STATUS_MAP.keys()), status))
             if duration_secs < 0:
-                raise ValueError("The duration of {} should be positive (was {})".format(
-                    test_path, duration_secs))
+                raise ValueError("The duration of {} should be positive (was {})".format(test_path, duration_secs))
             dateutil.parser.parse(created_at)
 
             yield CaseEvent.create(

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -101,13 +101,18 @@ class RawTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '10%', '--get-tests-from-previous-sessions',
-                          '--output-exclusion-rules', 'raw', mix_stderr=False)
+        result = self.cli(
+            'subset',
+            '--target',
+            '10%',
+            '--get-tests-from-previous-sessions',
+            '--output-exclusion-rules',
+            'raw',
+            mix_stderr=False)
         self.assertEqual(result.exit_code, 0)
 
         # Check request body
-        payload = json.loads(gzip.decompress(
-            responses.calls[1].request.body).decode())
+        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
         self.assert_json_orderless_equal(payload, {
             'testPaths': [],
             'testRunner': 'raw',


### PR DESCRIPTION
Now the raw plugin isn't supported [Zero Input Subsetting](https://docs.launchableinc.com/resources/integrations/gradle#using-zero-input-subsetting).
So, I updated the raw plugin to support Zero Input Subsetting.

e.g)
```
$ launchable subset --target 30% --get-tests-from-previous-sessions -rest rest.txt > subset.txt
$ pytest $(cat rest.txt | grep file= | awk -F# '{print $1}' |  awk -F= '{print $2}' | sort | uniq | xargs -I% echo '--ignore %' | tr '\n' ' ')
```
