### PR TITLE
Add the migration page to the SUMMARY

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
   * [Recording builds from multiple repositories](sending-data-to-launchable/recording-builds-from-multiple-repositories.md)
   * [Using 'flavors' to run the best tests for an environment](sending-data-to-launchable/use-flavors-to-run-the-best-tests-for-an-environment.md)
   * [Using the CLI with a public repository](sending-data-to-launchable/using-the-cli-with-a-public-repository.md)
+  * [Migrating to the GitHub OIDC Authentication](./sending-data-to-launchable/migration-to-github-oidc-auth.md)
   * [Running under restricted networks](sending-data-to-launchable/running-under-restricted-networks.md)
 
 ## Features


### PR DESCRIPTION
It seems that GitBook won't render a page otherwise.