### PR TITLE
Split subset by group

### DIFF
--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -264,7 +264,7 @@ def split_subset(
                           "w+", encoding="utf-8") as f:
                     f.write("\n".join(rest_group_names))
 
-        def split_by_group_namess(self):
+        def split_by_group_names(self):
             try:
                 res = client.request("POST", "{}/split-by-groups".format(subset_id))
                 res.raise_for_status()
@@ -312,7 +312,7 @@ def split_subset(
                     "Missing option '--bin' or '--split-by-groups/--split-by-groups-with-rest'")
 
             if self._is_split_by_groups():
-                self.split_by_group_namess()
+                self.split_by_group_names()
             else:
                 self.split_by_bin()
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -100,7 +100,7 @@ def split_subset(
             self.split_by_groups_output_dir = split_by_groups_output_dir
 
         def _default_split_by_groups_output_handler(self, group_name: str, subset: List[TestPath], rests: List[TestPath]):
-            if is_split_by_groups_with_rest and len(rests) > 0:
+            if is_split_by_groups_with_rest:
                 self.write_file("{}/rest-{}.txt".format(split_by_groups_output_dir, group_name), rests)
 
             if len(subset) > 0:
@@ -259,7 +259,7 @@ def split_subset(
                           "w+", encoding="utf-8") as f:
                     f.write("\n".join(subset_group_names))
 
-            if is_split_by_groups_with_rest and len(rest_group_names) > 0:
+            if is_split_by_groups_with_rest:
                 with open("{}/{}".format(split_by_groups_output_dir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME),
                           "w+", encoding="utf-8") as f:
                     f.write("\n".join(rest_group_names))
@@ -291,7 +291,7 @@ def split_subset(
                     if len(subset) > 0 and group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                         subset_group_names.append(group_name)
 
-                    if len(rests) > 0 and group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
+                    if group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                         rest_group_names.append(group_name)
 
                     if is_output_exclusion_rules:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -93,11 +93,11 @@ def split_subset(
 
     class SplitSubset(TestPathWriter):
         def __init__(self, dry_run: bool = False):
+            super(SplitSubset, self).__init__(dry_run=dry_run)
             self.split_by_groups_output_handler = self._default_split_by_groups_output_handler
             self.split_by_groups_exclusion_output_handler = self._default_split_by_groups_exclusion_output_handler
             self.is_split_by_groups_with_rest = is_split_by_groups_with_rest
             self.split_by_groups_output_dir = split_by_groups_output_dir
-            super(SplitSubset, self).__init__(dry_run=dry_run)
 
         def _default_split_by_groups_output_handler(self, group_name: str, subset: List[TestPath], rests: List[TestPath]):
             if is_split_by_groups_with_rest and len(rests) > 0:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -84,7 +84,7 @@ def split_subset(
             super(SplitSubset, self).__init__(dry_run=dry_run)
 
         def run(self):
-            if not is_split_by_groups and bin_target is None:
+            if (not is_split_by_groups and bin_target is None) or (is_split_by_groups and bin_target):
                 raise click.BadOptionUsage("--bin or --split-by-groups", "Missing option '--bin' or '--split-by-groups'")
 
             index, count = 0, 0

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -205,6 +205,7 @@ def split_subset(
                     return
 
             if is_split_by_groups:
+                subset_groups = []
                 for group in split_groups:
                     group_name = group.get("groupName", "")
                     subset = group.get("subset", [])
@@ -216,11 +217,12 @@ def split_subset(
                         subset, rests = rests, subset
 
                     if len(subset) > 0:
-                        self.write_file(
-                            "subset-{}.txt".format(group_name), subset)
+                        self.write_file("subset-{}.txt".format(group_name), subset)
+                        subset_groups.append(group_name)
                     if len(rests) > 0:
-                        self.write_file(
-                            "rest-{}.txt".format(group_name), rests)
+                        self.write_file("rest-{}.txt".format(group_name), rests)
+                if len(subset_groups) > 0:
+                    open("subset-groups.txt", "w+", encoding="utf-8").write("\n".join(subset_groups))
             else:
                 if len(output) == 0:
                     click.echo(click.style(

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -232,9 +232,9 @@ def split_subset(
                         self.write_file("{}/rest-{}.txt".format(split_by_groups_output_dir, group_name), rests)
 
                 if len(group_names) > 0:
-                    open(
-                        "{}/{}".format(split_by_groups_output_dir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME), "w+",
-                        encoding="utf-8").write("\n".join(group_names))
+                    with open("{}/{}".format(split_by_groups_output_dir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME),
+                              "w+", encoding="utf-8") as f:
+                        f.write("\n".join(group_names))
             else:
                 if len(output) == 0:
                     click.echo(click.style(

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -74,8 +74,7 @@ def split_subset(
 
         def run(self):
             if not is_split_by_groups and bin_target is None:
-                raise click.BadOptionUsage("--bin or --split-by-groups",
-                                           "Missing option '--bin' or '--split-by-groups'")
+                raise click.BadOptionUsage("--bin or --split-by-groups", "Missing option '--bin' or '--split-by-groups'")
 
             index, count = 0, 0
             if not is_split_by_groups:
@@ -107,8 +106,7 @@ def split_subset(
             is_observation = False
 
             try:
-                client = LaunchableClient(
-                    test_runner=context.invoked_subcommand, dry_run=context.obj.dry_run)
+                client = LaunchableClient(test_runner=context.invoked_subcommand, dry_run=context.obj.dry_run)
 
                 payload = {
                     "sliceCount": count,
@@ -179,14 +177,12 @@ def split_subset(
                                         raise ValueError(
                                             "Error: you cannot have one test, {}, in multiple same-bins.".format(test))
                             tests_in_files.append(tests)
-                            test_data = [
-                                self.same_bin_formatter(s) for s in tests]
+                            test_data = [self.same_bin_formatter(s) for s in tests]
                             same_bins.append(test_data)
 
                     payload["sameBins"] = same_bins
 
-                res = client.request(
-                    "POST", "{}/slice".format(subset_id), payload=payload)
+                res = client.request("POST", "{}/slice".format(subset_id), payload=payload)
                 res.raise_for_status()
 
                 output = res.json().get("testPaths", [])

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -8,7 +8,8 @@ from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.http_client import LaunchableClient
 from .test_path_writer import TestPathWriter
 
-TEST_GROUP_NO_GROUP_NAME = "nogroup"
+SPLIT_BY_GROUPS_NO_GROUP_NAME = "nogroup"
+SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME = "subset-groups.txt"
 
 
 @click.group(help="Split subsetting tests")
@@ -224,7 +225,7 @@ def split_subset(
 
                     if len(subset) > 0:
                         self.write_file("{}/subset-{}.txt".format(split_by_groups_output_dir, group_name), subset)
-                        if group_name != TEST_GROUP_NO_GROUP_NAME:
+                        if group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                             group_names.append(group_name)
 
                     if len(rests) > 0:
@@ -232,7 +233,7 @@ def split_subset(
 
                 if len(group_names) > 0:
                     open(
-                        "{}/subset-groups.txt".format(split_by_groups_output_dir), "w+",
+                        "{}/{}".format(split_by_groups_output_dir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME), "w+",
                         encoding="utf-8").write("\n".join(group_names))
             else:
                 if len(output) == 0:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -283,11 +283,6 @@ def split_subset(
                     if is_observation:
                         subset, rests = subset + rests, []
 
-                    if is_output_exclusion_rules:
-                        for g in split_groups:
-                            if g.get("groupName", "") != group_name:
-                                rests = rests + g.get("subset", []) + g.get("rest", [])
-
                     if len(subset) > 0 and group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                         subset_group_names.append(group_name)
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -241,8 +241,12 @@ def split_subset(
 
                     if is_observation:
                         subset, rests = subset + rests, []
+
                     if is_output_exclusion_rules:
-                        subset, rests = rests, subset
+                        for g in split_groups:
+                            if g.get("groupName", "") != group_name:
+                                rests = rests + g.get("subset", []) + g.get("rest", [])
+                        rests, subset = subset, rests
 
                     if len(subset) > 0:
                         self.write_file("{}/subset-{}.txt".format(split_by_groups_output_dir, group_name), subset)

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -285,8 +285,7 @@ def split_subset(
 
                     if len(subset) > 0 and group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                         subset_group_names.append(group_name)
-
-                    if group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
+                    elif group_name != SPLIT_BY_GROUPS_NO_GROUP_NAME:
                         rest_group_names.append(group_name)
 
                     if is_output_exclusion_rules:

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -264,7 +264,7 @@ def split_subset(
                           "w+", encoding="utf-8") as f:
                     f.write("\n".join(rest_group_names))
 
-        def split_by_groups(self):
+        def split_by_group_namess(self):
             try:
                 res = client.request("POST", "{}/split-by-groups".format(subset_id))
                 res.raise_for_status()
@@ -318,7 +318,7 @@ def split_subset(
                     "Missing option '--bin' or '--split-by-groups/--split-by-groups-with-rest'")
 
             if self._is_split_by_groups():
-                self.split_by_groups()
+                self.split_by_group_namess()
             else:
                 self.split_by_bin()
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -95,6 +95,8 @@ def split_subset(
         def __init__(self, dry_run: bool = False):
             self.split_by_groups_output_handler = self._default_split_by_groups_output_handler
             self.split_by_groups_exclusion_output_handler = self._default_split_by_groups_exclusion_output_handler
+            self.is_split_by_groups_with_rest = is_split_by_groups_with_rest
+            self.split_by_groups_output_dir = split_by_groups_output_dir
             super(SplitSubset, self).__init__(dry_run=dry_run)
 
         def _default_split_by_groups_output_handler(self, group_name: str, subset: List[TestPath], rests: List[TestPath]):

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -270,7 +270,7 @@ def split_subset(
                 res.raise_for_status()
 
                 is_observation = res.json().get("isObservation", False)
-                split_groups = res.json().get("splitGroups", {})
+                split_groups = res.json().get("splitGroups", [])
 
                 subset_group_names = []
                 rest_group_names = []

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -79,7 +79,23 @@ def split_subset(client, bare):
     def format_same_bin(s: str) -> List[Dict[str, str]]:
         return [{"type": "class", "name": s}]
 
+    def exclusion_output_handler(group_name, subset, rests):
+        if client.is_split_by_groups_with_rest:
+            with open("{}/rest-{}.txt".format(client.split_by_groups_output_dir, group_name), "w+", encoding="utf-8") as fp:
+                if not bare and len(subset) == 0:
+                    fp.write('-PdummyPlaceHolder')
+                else:
+                    fp.write(client.separator.join(client.formatter(t) for t in subset))
+
+        classes = [to_class_file(tp[0]['name']) for tp in rests]
+        with open("{}/subset-{}.txt".format(client.split_by_groups_output_dir, group_name), "w+", encoding="utf-8") as fp:
+            if bare:
+                fp.write(','.join(classes))
+            else:
+                fp.write('-PexcludeTests=' + (','.join(classes)))
+
     client.same_bin_formatter = format_same_bin
+    client.split_by_groups_exclusion_output_handler = exclusion_output_handler
 
     client.run()
 

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -60,6 +60,15 @@ class CliTestCase(unittest.TestCase):
             json={'testPaths': [], 'rest': [], 'subsettingId': 456},
             status=200)
         responses.add(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset/{}/split-by-groups".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.subsetting_id),
+            json={'subsettingId': self.subsetting_id, 'isObservation': False, 'splitGroups': []},
+            status=200)
+        responses.add(
             responses.GET,
             "{}/intake/organizations/{}/workspaces/{}/subset/{}".format(
                 get_base_url(),

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -208,3 +208,52 @@ class SplitSubsetTest(CliTestCase):
 
             with open("{}/rest-groups.txt".format(tmpdir)) as f:
                 self.assertEqual(f.read(), "e2e\nunit-test")
+
+        # with output-exclusion-rules
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.cli("split-subset", "--subset-id", "subset/{}".format(self.subsetting_id),
+                              "--split-by-groups", "--split-by-groups-output-dir", tmpdir, '--output-exclusion-rules', "file")
+
+            self.assertEqual(result.exit_code, 0)
+            with open("{}/subset-e2e.txt".format(tmpdir)) as f:
+                self.assertCountEqual(f.read().splitlines(),
+                                      ["e2e-ccc.py",
+                                       "e2e-ddd.py",
+                                       "unit-test-111.py",
+                                       "unit-test-222.py",
+                                       "aaa.py",
+                                       "bbb.py",
+                                       "111.py",
+                                       "222.py"])
+
+            self.assertFalse(os.path.exists("{}/rest-e2e.txt".format(tmpdir)))
+
+            with open("{}/subset-unit-test.txt".format(tmpdir)) as f:
+                self.assertCountEqual(f.read().splitlines(),
+                                      ["e2e-aaa.py",
+                                       "e2e-bbb.py",
+                                       "e2e-ccc.py",
+                                       "e2e-ddd.py",
+                                       "unit-test-111.py",
+                                       "unit-test-222.py",
+                                       "aaa.py",
+                                       "bbb.py",
+                                       "111.py",
+                                       "222.py"])
+            self.assertFalse(os.path.exists("{}/rest-unit-test.txt".format(tmpdir)))
+
+            with open("{}/subset-nogroup.txt".format(tmpdir)) as f:
+                self.assertCountEqual(f.read().splitlines(),
+                                      ["e2e-aaa.py",
+                                       "e2e-bbb.py",
+                                       "e2e-ccc.py",
+                                       "e2e-ddd.py",
+                                       "unit-test-111.py",
+                                       "unit-test-222.py",
+                                       "111.py",
+                                       "222.py"])
+            self.assertFalse(os.path.exists("{}/rest-nogroup.txt".format(tmpdir)))
+
+            with open("{}/subset-groups.txt".format(tmpdir)) as f:
+                self.assertEqual(f.read(), "e2e\nunit-test")
+            self.assertFalse(os.path.exists("{}/rest-groups.txt".format(tmpdir)))

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -183,7 +183,7 @@ class SplitSubsetTest(CliTestCase):
         # with rest option
         with tempfile.TemporaryDirectory() as tmpdir:
             result = self.cli("split-subset", "--subset-id", "subset/{}".format(self.subsetting_id),
-                              "--split-by-groups", "--split-by-groups-output-dir", tmpdir, "--rest", tmpdir, "file")
+                              "--split-by-groups-with-rest", "--split-by-groups-output-dir", tmpdir, "file")
 
             self.assertEqual(result.exit_code, 0)
             with open("{}/subset-e2e.txt".format(tmpdir)) as f:

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -209,7 +209,7 @@ class SplitSubsetTest(CliTestCase):
                 self.assertEqual(f.read(), "e2e")
 
             with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME)) as f:
-                self.assertEqual(f.read(), "e2e\nunit-test")
+                self.assertEqual(f.read(), "unit-test")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -282,5 +282,5 @@ class SplitSubsetTest(CliTestCase):
             self.assertFalse(os.path.exists("{}/rest-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)))
 
             with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME)) as f:
-                self.assertEqual(f.read(), "e2e\nunit-test")
+                self.assertEqual(f.read(), "unit-test")
             self.assertFalse(os.path.exists("{}/{}".format(tmpdir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME)))

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -106,7 +106,7 @@ class SplitSubsetTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_split_by_groups(self):
+    def test_split_by_group_names(self):
         mock_json_response = {
             "subsettingId": self.subsetting_id,
             "isObservation": False,

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -269,42 +269,16 @@ class SplitSubsetTest(CliTestCase):
 
             self.assertEqual(result.exit_code, 0)
             with open("{}/subset-e2e.txt".format(tmpdir)) as f:
-                self.assertCountEqual(f.read().splitlines(),
-                                      ["e2e-ccc.py",
-                                       "e2e-ddd.py",
-                                       "unit-test-111.py",
-                                       "unit-test-222.py",
-                                       "aaa.py",
-                                       "bbb.py",
-                                       "111.py",
-                                       "222.py"])
+                self.assertCountEqual(f.read().splitlines(), ["e2e-ccc.py", "e2e-ddd.py", ])
 
             self.assertFalse(os.path.exists("{}/rest-e2e.txt".format(tmpdir)))
 
             with open("{}/subset-unit-test.txt".format(tmpdir)) as f:
-                self.assertCountEqual(f.read().splitlines(),
-                                      ["e2e-aaa.py",
-                                       "e2e-bbb.py",
-                                       "e2e-ccc.py",
-                                       "e2e-ddd.py",
-                                       "unit-test-111.py",
-                                       "unit-test-222.py",
-                                       "aaa.py",
-                                       "bbb.py",
-                                       "111.py",
-                                       "222.py"])
+                self.assertCountEqual(f.read().splitlines(), ["unit-test-111.py", "unit-test-222.py"])
             self.assertFalse(os.path.exists("{}/rest-unit-test.txt".format(tmpdir)))
 
             with open("{}/subset-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)) as f:
-                self.assertCountEqual(f.read().splitlines(),
-                                      ["e2e-aaa.py",
-                                       "e2e-bbb.py",
-                                       "e2e-ccc.py",
-                                       "e2e-ddd.py",
-                                       "unit-test-111.py",
-                                       "unit-test-222.py",
-                                       "111.py",
-                                       "222.py"])
+                self.assertCountEqual(f.read().splitlines(), ["111.py", "222.py"])
             self.assertFalse(os.path.exists("{}/rest-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)))
 
             with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME)) as f:

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -4,6 +4,8 @@ from unittest import mock
 
 import responses  # type: ignore
 
+from launchable.commands.split_subset import (SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME,
+                                              SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME, SPLIT_BY_GROUPS_NO_GROUP_NAME)
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 
@@ -170,15 +172,15 @@ class SplitSubsetTest(CliTestCase):
 
             self.assertFalse(os.path.exists("{}/rest-unit-test.txt".format(tmpdir)))
 
-            with open("{}/subset-nogroup.txt".format(tmpdir)) as f:
+            with open("{}/subset-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)) as f:
                 self.assertEqual(f.read(), "aaa.py\nbbb.py")
 
-            self.assertFalse(os.path.exists("{}/rest-nogroup.txt".format(tmpdir)))
+            self.assertFalse(os.path.exists("{}/rest-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)))
 
-            with open("{}/subset-groups.txt".format(tmpdir)) as f:
+            with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME)) as f:
                 self.assertEqual(f.read(), "e2e")
 
-            self.assertFalse(os.path.exists("{}/rest-groups.txt".format(tmpdir)))
+            self.assertFalse(os.path.exists("{}/{}".format(tmpdir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME)))
 
         # with rest option
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -197,16 +199,16 @@ class SplitSubsetTest(CliTestCase):
             with open("{}/rest-unit-test.txt".format(tmpdir)) as f:
                 self.assertEqual(f.read(), "unit-test-111.py\nunit-test-222.py")
 
-            with open("{}/subset-nogroup.txt".format(tmpdir)) as f:
+            with open("{}/subset-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)) as f:
                 self.assertEqual(f.read(), "aaa.py\nbbb.py")
 
-            with open("{}/rest-nogroup.txt".format(tmpdir)) as f:
+            with open("{}/rest-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)) as f:
                 self.assertEqual(f.read(), "111.py\n222.py")
 
-            with open("{}/subset-groups.txt".format(tmpdir)) as f:
+            with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME)) as f:
                 self.assertEqual(f.read(), "e2e")
 
-            with open("{}/rest-groups.txt".format(tmpdir)) as f:
+            with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME)) as f:
                 self.assertEqual(f.read(), "e2e\nunit-test")
 
     @responses.activate
@@ -293,7 +295,7 @@ class SplitSubsetTest(CliTestCase):
                                        "222.py"])
             self.assertFalse(os.path.exists("{}/rest-unit-test.txt".format(tmpdir)))
 
-            with open("{}/subset-nogroup.txt".format(tmpdir)) as f:
+            with open("{}/subset-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)) as f:
                 self.assertCountEqual(f.read().splitlines(),
                                       ["e2e-aaa.py",
                                        "e2e-bbb.py",
@@ -303,8 +305,8 @@ class SplitSubsetTest(CliTestCase):
                                        "unit-test-222.py",
                                        "111.py",
                                        "222.py"])
-            self.assertFalse(os.path.exists("{}/rest-nogroup.txt".format(tmpdir)))
+            self.assertFalse(os.path.exists("{}/rest-{}.txt".format(tmpdir, SPLIT_BY_GROUPS_NO_GROUP_NAME)))
 
-            with open("{}/subset-groups.txt".format(tmpdir)) as f:
+            with open("{}/{}".format(tmpdir, SPLIT_BY_GROUP_SUBSET_GROUPS_FILE_NAME)) as f:
                 self.assertEqual(f.read(), "e2e\nunit-test")
-            self.assertFalse(os.path.exists("{}/rest-groups.txt".format(tmpdir)))
+            self.assertFalse(os.path.exists("{}/{}".format(tmpdir, SPLIT_BY_GROUP_REST_GROUPS_FILE_NAME)))


### PR DESCRIPTION
Add `--split-by-groups` option to the `split-subset` command

e.g)

```sh
$ launchable record tests --group e2e ./e2e-test-result.xml
$ find ./tests/**/test_*.py  | launchable subset --split --target 40% file > subset_id.txt
$ launchable split-subset --subset-id $(cat subset-id.txt) --split-by-groups file
$ ls -l 
rest-e2e.txt
rest-nogroup.txt
subset-e2e.txt 
subset-groups.txt
subset-nogroup.txt
```