### PR TITLE
Don't pass a relative path

### DIFF
--- a/docs/resources/integrations/maven.md
+++ b/docs/resources/integrations/maven.md
@@ -60,7 +60,7 @@ The `launchable subset` command outputs a file called `launchable-subset.txt` th
 ### Maven + JUnit
 
 ```bash
-mvn test -Dsurefire.includesFile=launchable-subset.txt
+mvn test -Dsurefire.includesFile=$PWD/launchable-subset.txt
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
A recent customer troubleshooting suggests Maven doesn't handle relative path here very well. Instead of interpreting it against the current directory, it interprets it against the module top level directory.