### PR TITLE
Bi-di link between two versions of the Gradle pages

### DIFF
--- a/docs/resources/integrations/gradle+testng.md
+++ b/docs/resources/integrations/gradle+testng.md
@@ -8,6 +8,11 @@ description: This page outlines how the Launchable CLI interfaces with Gradle+Te
 This is a reference page. See [Getting started](../../getting-started.md), [Sending data to Launchable](../../sending-data-to-launchable/), and [Subsetting your test runs](../../features/predictive-test-selection/) for more comprehensive usage guidelines.
 {% endhint %}
 
+{% hint style="info" %}
+This page is for users who use Gradle and TestNG to write tests. If you are not using TestNG, refer to [another page](gradle.md)
+{% endhint %}
+
+
 ## Recording test results
 
 After running tests, point the CLI to your test report files to collect test results and train the model:

--- a/docs/resources/integrations/gradle.md
+++ b/docs/resources/integrations/gradle.md
@@ -2,10 +2,14 @@
 description: This page outlines how the Launchable CLI interfaces with Gradle.
 ---
 
-# Gradle+JUnit
+# Gradle
 
 {% hint style="info" %}
 This is a reference page. See [Getting started](../../getting-started.md), [Sending data to Launchable](../../sending-data-to-launchable/), and [Subsetting your test runs](../../features/predictive-test-selection/) for more comprehensive usage guidelines.
+{% endhint %}
+
+{% hint style="info" %}
+If you are using TestNG with Gradle, refer to [another page](gradle+testng.md) for more robust integration.
 {% endhint %}
 
 ## Recording test results


### PR DESCRIPTION
JUnit is default, and thus people might be using it without knowing it. TestNG is almost always an explicit choice, so I'm framing this as "TestNG vs default", not "TestNG vs JUnit"