### PR TITLE
remove lint-warn from github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,8 +62,6 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         pipenv run lint
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        pipenv run lint-warn
     - name: Pull request validation
       run: |
         # Install Launchable CLI from this repos's code

--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,7 @@ launchable = {editable = true, path = "."}
 build = "python setup.py sdist bdist_wheel"
 format = "/bin/bash -c 'isort -l 130 --balanced launchable/*.py tests/*.py && autopep8 --in-place --recursive --aggressive --experimental --max-line-length=130 --verbose launchable/ tests/'"
 install = "pip install -U ."
-lint = "flake8 --count --ignore=C901,E741 --show-source --max-line-length=130 --statistics launchable/ tests/"
+lint = "flake8 --count --ignore=C901,E741,F401 --show-source --max-line-length=130 --statistics launchable/ tests/"
 lint-warn = "flake8 --count --exit-zero --max-complexity=15 --max-line-length=130 --statistics launchable/ tests/"
 test = "python -m unittest"
 test-xml = "python -m test-runner"


### PR DESCRIPTION
# What
- Remove lint-warn from GitHub Actions because it is too much.
- Add F401 to ignore in lint since it does not support commented type hinting in Python>=3.7.