### PR TITLE
zero input subset + TestNG support documentation

### DIFF
--- a/docs/resources/integrations/gradle+testng.md
+++ b/docs/resources/integrations/gradle+testng.md
@@ -36,7 +36,7 @@ First, you need to add a dependency declaration to `build.gradle` so that the ri
 ```
 dependencies {
     ...
-    testRuntime 'com.launchableinc:launchable-testng:1.0.0'
+    testRuntime 'com.launchableinc:launchable-testng:1.2.1'
 }
 ```
 
@@ -64,8 +64,8 @@ launchable subset \
 This creates a file called `launchable-subset.txt`. For Gradle, this file is formatted like:
 
 ```
-MyTestClass1
-MyTestClass2
+com.example.FooTest
+com.example.BarTest
 ...
 ```
 
@@ -82,4 +82,53 @@ Note: The **Gradle plugin for Android** requires a different command, because th
 ./gradlew testDebugUnitTest
 # or
 ./gradlew testReleaseUnitTest
+```
+
+### Using Zero Input Subsetting
+
+To use [Zero Input Subsetting](../../features/predictive-test-selection/requesting-and-running-a-subset-of-tests/zero-input-subsetting/), follow these instructions.
+
+First, you need to add a dependency declaration to `build.gradle` so that the right subset of tests get executed when TestNG runs:
+
+```
+dependencies {
+    ...
+    testRuntime 'com.launchableinc:launchable-testng:1.2.1'
+}
+```
+
+Then, to retrieve a list of non-prioritized tests (per [Zero Input Subsetting](../../features/predictive-test-selection/requesting-and-running-a-subset-of-tests/zero-input-subsetting/)), run:
+
+```bash
+launchable subset \
+  --build <BUILD NAME> \
+  --confidence <TARGET> \ # or another optimization target
+  --get-tests-from-previous-sessions \
+  --output-exclusion-rules \
+  gradle --bare . > launchable-exclusion-list.txt
+```
+
+* The `--build` should use the same `<BUILD NAME>` value that you used before in `launchable record build`.
+* The `--confidence` option should be a percentage; we suggest `90%` to start. You can also use `--time` or `--target`; see [Choosing a subset optimization target](../../features/predictive-test-selection/requesting-and-running-a-subset-of-tests/choosing-a-subset-optimization-target/) for more info.
+
+This creates a file called `launchable-exclusion-list.txt`. For Gradle, this file is formatted like:
+
+```
+com.example.FooTest
+com.example.BarTest
+```
+
+You can pass this file into the Gradle launchable extension through an environment variable:
+
+```bash
+export LAUNCHABLE_REST_FILE_PATH=$PWD/launchable-exclusion-list.txt
+gradle test
+```
+
+Note: The **Gradle plugin for Android** requires a different command, because the built-in `test` task does not support the `--tests` option. Use `testDebugUnitTest` or `testReleaseUnitTest` instead:
+
+```bash
+./gradlew testDebugUnitTest $(cat launchable-exclusion-list.txt)
+# or
+./gradlew testReleaseUnitTest $(cat launchable-exclusion-list.txt)
 ```

--- a/docs/resources/integrations/maven.md
+++ b/docs/resources/integrations/maven.md
@@ -69,10 +69,6 @@ The `launchable subset` command outputs a file called `launchable-subset.txt` th
 mvn test -Dsurefire.includesFile=$PWD/launchable-subset.txt
 ```
 
-{% hint style="warning" %}
-If your build already depends on `surefire.includesFile`, or `<includes>/<includesFile>`, those and our subset will collide and not work as expected. [Contact us](https://www.launchableinc.com/support) to resolve this problem.
-{% endhint %}
-
 #### Maven + TestNG
 
 Modify your `pom.xml` so that it includes Launchable TestNG integration as a test scope dependency:
@@ -81,7 +77,7 @@ Modify your `pom.xml` so that it includes Launchable TestNG integration as a tes
 <dependency>
   <groupId>com.launchableinc</groupId>
   <artifactId>launchable-testng</artifactId>
-  <version>1.0.0</version>
+  <version>1.2.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -91,10 +87,6 @@ Pass the location of `launchable-subset.txt` as an environment variable. The abo
 ```bash
 export LAUNCHABLE_SUBSET_FILE_PATH=$PWD/launchable-subset.txt
 ```
-
-#### Maven + JUnit & TestNG
-
-If your multi-module project mixes JUnit and TestNG in different modules, follow "Maven + JUnit" guide above. The caveat is that modules using `testng.xml` to specify the tests to run will not work correctly because `testng.xml` and `surefire.includesFile` interferes.
 
 ### Zero Input Subsetting
 
@@ -119,7 +111,9 @@ launchable subset \
 See also [using-groups-to-split-subsets.md](../../features/predictive-test-selection/requesting-and-running-a-subset-of-tests/zero-input-subsetting/using-groups-to-split-subsets.md "mention"), which can split a large exclusion list into several lists, one per test group.
 {% endhint %}
 
-This creates a list of classes you can pass into Maven for exclusion:
+#### Maven + JUnit
+
+The resulting list of classes can be passed into Maven for exclusion.
 
 ```
 mvn test -Dsurefire.excludesFile=$PWD/launchable-exclusion-list.txt
@@ -128,3 +122,35 @@ mvn test -Dsurefire.excludesFile=$PWD/launchable-exclusion-list.txt
 {% hint style="warning" %}
 If your build already depends on `surefire.includesFile`, or `<includes>/<includesFile>`, those and our exclusion list will collide and not work as expected. [Contact us](https://www.launchableinc.com/support) to resolve this problem.
 {% endhint %}
+
+#### Maven + TestNG
+
+Modify your `pom.xml` so that it includes Launchable TestNG integration as a test scope dependency:
+
+```xml
+<dependency>
+  <groupId>com.launchableinc</groupId>
+  <artifactId>launchable-testng</artifactId>
+  <version>1.2.1</version>
+  <scope>test</scope>
+</dependency>
+```
+
+Pass the location of `launchable-exclusion-list.txt` as an environment variable. The abovementioned module will process this:
+
+```bash
+export LAUNCHABLE_REST_FILE_PATH=$PWD/launchable-exclusion-list.txt
+```
+### Off the beaten path
+#### Mixing JUnit & TestNG
+
+If your multi-module project mixes JUnit and TestNG in different modules, follow the "Maven + JUnit" part of this guide. The caveat is that modules using `testng.xml` to specify the tests to run will not work correctly because `testng.xml` and `surefire.includesFile`/`surefire.excludesFile` interferes.
+
+#### Surefire's inclusion/exclusion mechanism already in use
+
+If your build already depends on `<includes>/<includesFile>` in the Surefire configuration, the `-Dsurefire.includesFile=...` option you specify from the command line will overrides them, which results in unintended set of tests running.
+
+To resolve this, concatenate your inclusion with what Launchable produces, then pass the combined file to Maven.
+If this gets too hairly, [contact us](https://www.launchableinc.com/support) so that we can figure something out.
+
+The same applies with exclusion.


### PR DESCRIPTION
Documenting how to use Zero Input Subset with TestNG, which impacts both Maven & Gradle.

I created a separate section in Maven to discuss various complications, as opposed to duplicating this twice. Probably a matter of taste, but I made this change based on my thinking that there will be more complications to be added in the future.