### PR TITLE
add new validation for build name

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -68,7 +68,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
           no_commit_collection: bool, scrub_pii: bool, commits: List[str]):
 
     if "/" in build_name or "%2f" in build_name.lower():
-        sys.exit("--name must not contain a slash")
+        sys.exit("--name must not contain a slash and an encoded slash")
     if not no_commit_collection and len(commits) != 0:
         sys.exit("--no-commit-collection must be specified when --commit is used")
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -66,7 +66,8 @@ from .commit import commit
 @click.pass_context
 def build(ctx: click.core.Context, build_name: str, source: List[str], max_days: int, no_submodules: bool,
           no_commit_collection: bool, scrub_pii: bool, commits: List[str]):
-    if "/" in build_name:
+
+    if "/" in build_name or "%2f" in build_name.lower():
         sys.exit("--name must not contain a slash")
     if not no_commit_collection and len(commits) != 0:
         sys.exit("--no-commit-collection must be specified when --commit is used")

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -119,3 +119,10 @@ class BuildTest(CliTestCase):
             self.assertEqual(read_build(), self.build_name)
         finally:
             os.chdir(orig_dir)
+
+    def test_build_name_validation(self):
+        result = self.cli("record", "build", "--no-commit-collection", "--name", "foo/hoge")
+        self.assertEqual(result.exit_code, 1)
+
+        result = self.cli("record", "build", "--no-commit-collection", "--name", "foo%2Fhoge")
+        self.assertEqual(result.exit_code, 1)


### PR DESCRIPTION
We don't allow to use '/' for the build name. Sometimes encoded '/' (= %2F) is set to a build name, even if '/' is encoded we don't allow it. So, I added a validation for it.