### PR TITLE
Add some validations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,9 @@ types-pkg_resources = "*"
 types-python-dateutil = "*"
 types-requests = "*"
 types-tabulate = "*"
+# Faced an error when try to install lxml v4.9.2. So, fixed the lxml version.
+# ref: https://github.com/launchableinc/cli/actions/runs/3691265723
+lxml = "<=4.9.1"
 unittest-xml-reporting = "*"
 
 [packages]

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -345,8 +345,8 @@ def subset(
 
                     original_subset = res.json().get("testPaths", [])
                     original_rests = res.json().get("rest", [])
-                    subset_id = res.json()["subsettingId"]
-                    summary = res.json()["summary"]
+                    subset_id = res.json().get("subsettingId", 0)
+                    summary = res.json().get("summary", {})
                     is_brainless = res.json().get("isBrainless", False)
                     is_observation = res.json().get("isObservation", False)
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -308,6 +308,13 @@ def subset(
 
         def run(self):
             """called after tests are scanned to compute the optimized order"""
+            if not is_get_tests_from_previous_sessions and len(self.test_paths) == 0:
+                click.echo(
+                    click.style(
+                        "ERROR: subset candidates are empty. Please set subset candidates or use `--get-tests-from-previous-sessions` option",  # noqa E501
+                        fg="red"),
+                    err=True)
+                exit(1)
 
             # When Error occurs, return the test name as it is passed.
             original_subset = self.test_paths
@@ -348,6 +355,7 @@ def subset(
                         raise e
                     else:
                         click.echo(e, err=True)
+
                     click.echo(click.style(
                         "Warning: the service failed to subset. Falling back to running all tests", fg='yellow'),
                         err=True)

--- a/launchable/test_runners/maven.py
+++ b/launchable/test_runners/maven.py
@@ -69,6 +69,11 @@ def subset(client, source_roots, test_compile_created_file):
             return None
 
     if len(test_compile_created_file) > 0:
+        if len(source_roots) != 0:
+            click.echo(click.style(
+                "Warning: SOURCE_ROOTS are ignored when --test-compile-created-file is used", fg="yellow"),
+                err=True)
+
         for file in test_compile_created_file:
             with open(file, 'r') as f:
                 lines = f.readlines()

--- a/launchable/test_runners/maven.py
+++ b/launchable/test_runners/maven.py
@@ -77,6 +77,11 @@ def subset(client, source_roots, test_compile_created_file):
         for file in test_compile_created_file:
             with open(file, 'r') as f:
                 lines = f.readlines()
+                if len(lines) == 0:
+                    click.echo(click.style(
+                        "Warning: --test-compile-created-file {} is empty".format(file), fg="yellow"),
+                        err=True)
+
                 for l in lines:
                     # trim trailing newline
                     l = l.strip()

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -169,6 +169,7 @@ class SubsetTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_targetless(self):
+        pipe = "test_aaa.py\ntest_bbb.py\ntest_ccc.py\ntest_eee.py\ntest_fff.py\ntest_ggg.py"
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(
@@ -200,6 +201,7 @@ class SubsetTest(CliTestCase):
             "--session",
             self.session,
             "file",
+            input=pipe,
             mix_stderr=False)
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -209,6 +209,11 @@ class SubsetTest(CliTestCase):
     @ responses.activate
     @ mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_with_get_tests_from_previous_full_runs(self):
+        # check error when input candidates are empty without --get-tests-from-previous-sessions option
+        result = self.cli("subset", "--target", "30%", "--session", self.session, "file")
+        self.assertEqual(result.exit_code, 1)
+        self.assertTrue("Please set subset candidates or use `--get-tests-from-previous-sessions` option" in result.stdout)
+
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(


### PR DESCRIPTION
I realized some users faced some integration issues, so I edited that easy to notice the cause of issues.

## Changes

1. If subset candidates are empty and isn't set `--get-tests-from-previous-sessions` option, it's usually integration miss. So, I changed it to an error.
2. In the maven profile, when they set `--test-compile-created-file` and source_roots both, source_roots will be ignored so I updated to show the warning message.
3. Even if `--test-compile-created-file` is set but the file is empty, to show a warning message. 

## Others

Also, I fixed some minor changes
