### PR TITLE
Support link option

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,6 +14,7 @@ env:
   LAUNCHABLE_ORGANIZATION: "launchableinc"
   LAUNCHABLE_WORKSPACE: "cli"
   EXPERIMENTAL_GITHUB_OIDC_TOKEN_AUTH: 1
+  GITHUB_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
 
 permissions:
   id-token: write

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import click
 
@@ -12,6 +12,7 @@ def find_or_create_session(
     build_name: Optional[str],
     flavor=[],
     is_observation: bool = False,
+    links: List[str] = [],
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -63,6 +64,7 @@ def find_or_create_session(
                 print_session=False,
                 flavor=flavor,
                 is_observation=is_observation,
+                links=links,
             )
             return read_session(saved_build_name)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -7,6 +7,7 @@ import click
 from tabulate import tabulate
 
 from launchable.utils.key_value_type import normalize_key_value_types
+from launchable.utils.link import capture_link
 
 from ...utils import subprocess
 from ...utils.authentication import get_org_workspace
@@ -176,7 +177,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         payload = {
             "buildNumber": build_name,
             "commitHashes": commitHashes,
-            "links": []
+            "links": capture_link(os.environ)
         }
 
         if len(links) != 0:

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -6,6 +6,8 @@ from typing import List
 import click
 from tabulate import tabulate
 
+from launchable.utils.key_value_type import normalize_key_value_types
+
 from ...utils import subprocess
 from ...utils.authentication import get_org_workspace
 from ...utils.click import KeyValueType
@@ -136,15 +138,8 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
 
     if len(commits) != 0:
         invalid = False
-        _commits = []
-        # TODO: handle extraction of flavor tuple to dict in better way for
-        # >=click8.0 that returns tuple of tuples as tuple of str
-        if isinstance(commits[0], str):
-            for c in commits:
-                k, v = c.replace("(", "").replace(")", "").replace("'", "").split(",")
-                _commits.append((k.strip(), v.strip()))
-        else:
-            _commits = commits
+        _commits = normalize_key_value_types(commits)
+
         for repo_name, hash in _commits:
             if not re.match("[0-9A-Fa-f]{5,40}$", hash):
                 click.echo(click.style(

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -185,6 +185,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 payload["links"].append({
                     "title": link[0],
                     "url": link[1],
+                    "kind": "CUSTOM_LINK"
                 })
 
         client = LaunchableClient(dry_run=ctx.obj.dry_run)

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -185,7 +185,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 _links.append({
                     "title": link[0],
                     "url": link[1],
-                    "kind": LinkKind.CUSTOM_LINK,
+                    "kind": LinkKind.CUSTOM_LINK.name,
                 })
         payload["links"] = _links
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -7,7 +7,7 @@ import click
 from tabulate import tabulate
 
 from launchable.utils.key_value_type import normalize_key_value_types
-from launchable.utils.link import capture_link
+from launchable.utils.link import LinkKind, capture_link
 
 from ...utils import subprocess
 from ...utils.authentication import get_org_workspace
@@ -185,7 +185,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 _links.append({
                     "title": link[0],
                     "url": link[1],
-                    "kind": "CUSTOM_LINK"
+                    "kind": LinkKind.CUSTOM_LINK,
                 })
         payload["links"] = _links
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -65,9 +65,17 @@ from .commit import commit
     default=[],
     cls=KeyValueType,
 )
+@click.option(
+    '--link',
+    'links',
+    help="Set external link of title and url",
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def build(ctx: click.core.Context, build_name: str, source: List[str], max_days: int, no_submodules: bool,
-          no_commit_collection: bool, scrub_pii: bool, commits: List[str]):
+          no_commit_collection: bool, scrub_pii: bool, commits: List[str], links: List[str]):
 
     if "/" in build_name or "%2f" in build_name.lower():
         sys.exit("--name must not contain a slash and an encoded slash")
@@ -167,8 +175,17 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
 
         payload = {
             "buildNumber": build_name,
-            "commitHashes": commitHashes
+            "commitHashes": commitHashes,
+            "links": []
         }
+
+        if len(links) != 0:
+            _links = normalize_key_value_types(links)
+            for link in _links:
+                payload["links"].append({
+                    "title": link[0],
+                    "url": link[1],
+                })
 
         client = LaunchableClient(dry_run=ctx.obj.dry_run)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -177,17 +177,17 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         payload = {
             "buildNumber": build_name,
             "commitHashes": commitHashes,
-            "links": capture_link(os.environ)
         }
 
+        _links = capture_link(os.environ)
         if len(links) != 0:
-            _links = normalize_key_value_types(links)
-            for link in _links:
-                payload["links"].append({
+            for link in normalize_key_value_types(links):
+                _links.append({
                     "title": link[0],
                     "url": link[1],
                     "kind": "CUSTOM_LINK"
                 })
+        payload["links"] = _links
 
         client = LaunchableClient(dry_run=ctx.obj.dry_run)
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -6,7 +6,7 @@ from typing import List
 import click
 
 from launchable.utils.key_value_type import normalize_key_value_types
-from launchable.utils.link import capture_link
+from launchable.utils.link import LinkKind, capture_link
 
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -88,7 +88,7 @@ def session(
             _links.append({
                 "title": link[0],
                 "url": link[1],
-                "kind": "CUSTOM_LINK"
+                "kind": LinkKind.CUSTOM_LINK,
             })
     payload["links"] = _links
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -8,8 +8,8 @@ import click
 from ...utils.ci_provider import CIProvider
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.flavor import normalize_flavors
 from ...utils.http_client import LaunchableClient
+from ...utils.key_value_type import normalize_key_value_types
 from ...utils.session import write_session
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
@@ -73,7 +73,7 @@ def session(
     """
 
     flavor_dict = {}
-    for f in normalize_flavors(flavor):
+    for f in normalize_key_value_types(flavor):
         flavor_dict[f[0]] = f[1]
 
     link = _capture_link(os.environ)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -54,6 +54,14 @@ CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
     help="enable observation mode",
     is_flag=True,
 )
+@click.option(
+    '--link',
+    'links',
+    help="Set external link of title and url",
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def session(
     ctx: click.core.Context,
@@ -62,6 +70,7 @@ def session(
     print_session: bool = True,
     flavor: List[str] = [],
     is_observation: bool = False,
+    links: List[str] = [],
 ):
     """
     print_session is for barckward compatibility.
@@ -80,9 +89,18 @@ def session(
     payload = {
         "flavors": flavor_dict,
         "isObservation": is_observation,
+        "links": [],
     }
     if link:
         payload["link"] = link
+
+    _links = normalize_key_value_types(links)
+    for l in _links:
+        payload["links"].append({
+            "title": l[0],
+            "url": l[1],
+            "kind": "CUSTOM_LINK"
+        })
 
     client = LaunchableClient(dry_run=ctx.obj.dry_run)
     try:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -88,7 +88,7 @@ def session(
             _links.append({
                 "title": link[0],
                 "url": link[1],
-                "kind": LinkKind.CUSTOM_LINK,
+                "kind": LinkKind.CUSTOM_LINK.name,
             })
     payload["links"] = _links
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -80,17 +80,17 @@ def session(
     payload = {
         "flavors": flavor_dict,
         "isObservation": is_observation,
-        "links": capture_link(os.environ)
     }
 
+    _links = capture_link(os.environ)
     if len(links) != 0:
-        _links = normalize_key_value_types(links)
-        for link in _links:
-            payload["links"].append({
+        for link in normalize_key_value_types(links):
+            _links.append({
                 "title": link[0],
                 "url": link[1],
                 "kind": "CUSTOM_LINK"
             })
+    payload["links"] = _links
 
     client = LaunchableClient(dry_run=ctx.obj.dry_run)
     try:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -120,6 +120,14 @@ def _validate_group(ctx, param, value):
     is_flag=True,
     hidden=True,
 )
+@click.option(
+    '--link',
+    'links',
+    help="Set external link of title and url",
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def tests(
     context: click.core.Context,
@@ -133,6 +141,7 @@ def tests(
     report_paths: bool,
     group: str,
     is_allow_test_before_build: bool,
+    links: List[str] = [],
 ):
     logger = Logger()
 
@@ -150,7 +159,12 @@ def tests(
             session_id = result["session"]
             record_start_at = result["start_at"]
         else:
-            session_id = find_or_create_session(context, session, build_name, flavor)
+            session_id = find_or_create_session(
+                context=context,
+                session=session,
+                build_name=build_name,
+                flavor=flavor,
+                links=links)
             build_name = read_build()
             record_start_at = get_record_start_at(session_id, client)
 

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -5,8 +5,8 @@ import click
 
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.flavor import normalize_flavors
 from ...utils.http_client import LaunchableClient
+from ...utils.key_value_type import normalize_key_value_types
 
 
 @click.command()
@@ -37,7 +37,7 @@ def test_sessions(
     # and the check will not pass.
     params = {'days': days, 'flavor': []}
     flavors = []
-    for f in normalize_flavors(flavor):
+    for f in normalize_key_value_types(flavor):
         flavors.append('%s=%s' % (f[0], f[1]))
 
     if flavors:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -126,6 +126,14 @@ from .test_path_writer import TestPathWriter
     help='Ignore flaky tests above the value set by this option.You can confirm flaky scores in WebApp',
     type=click.FloatRange(min=0, max=1.0),
 )
+@click.option(
+    '--link',
+    'links',
+    help="Set external link of title and url",
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -144,6 +152,7 @@ def subset(
     is_get_tests_from_previous_sessions: bool,
     is_output_exclusion_rules: bool,
     ignore_flaky_tests_above: Optional[float],
+    links: List[str] = [],
 ):
 
     if is_observation and is_get_tests_from_previous_sessions:
@@ -161,6 +170,7 @@ def subset(
         build_name=build_name,
         flavor=flavor,
         is_observation=is_observation,
+        links=links,
     )
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 

--- a/launchable/utils/key_value_type.py
+++ b/launchable/utils/key_value_type.py
@@ -1,7 +1,7 @@
 from typing import List, Sequence, Tuple
 
 
-def normalize_flavors(flavors_raw: List[str]) -> List[Tuple[str, str]]:
+def normalize_key_value_types(kv_types_raw: List[str]) -> List[Tuple[str, str]]:
     """Normalize flavor list, because the type of the flavor list specified in the command line flags differs depending
     on the version of the click.
 
@@ -15,12 +15,12 @@ def normalize_flavors(flavors_raw: List[str]) -> List[Tuple[str, str]]:
             `launchable record session --build aaa --flavor os=ubuntu --flavor python=3.8`
             is parsed as build=aaa, flavor=("('os', 'ubuntu')", "('python', '3.8')")
     """
-    flavors = []
-    for f in flavors_raw:
-        if isinstance(f, str):
-            k, v = f.replace("(", "").replace(")", "").replace("'", "").split(",")
-            flavors.append((k.strip(), v.strip()))
-        elif isinstance(f, Sequence):
-            flavors.append((f[0], f[1]))
+    kvs = []
+    for kv in kv_types_raw:
+        if isinstance(kv, str):
+            k, v = kv.replace("(", "").replace(")", "").replace("'", "").split(",")
+            kvs.append((k.strip(), v.strip()))
+        elif isinstance(kv, Sequence):
+            kvs.append((kv[0], kv[1]))
 
-    return flavors
+    return kvs

--- a/launchable/utils/link.py
+++ b/launchable/utils/link.py
@@ -7,6 +7,7 @@ GITHUB_ACTIONS_KEY = 'GITHUB_ACTIONS'
 GITHUB_ACTIONS_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
 GITHUB_ACTIONS_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
 GITHUB_ACTIONS_RUN_ID_KEY = 'GITHUB_RUN_ID'
+GITHUB_PULL_REQUEST_URL_KEY = "GITHUB_PULL_REQUEST_URL"
 CIRCLECI_KEY = 'CIRCLECI'
 CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
 
@@ -28,7 +29,7 @@ def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
         links.append(
             {"kind": LinkKind.JENKINS.value, "url": env.get(JENKINS_BUILD_URL_KEY, ""), "title": ""}
         )
-    elif env.get(GITHUB_ACTIONS_KEY):
+    if env.get(GITHUB_ACTIONS_KEY):
         links.append({
             "kind": LinkKind.GITHUB_ACTIONS.value,
             "url": "{}/{}/actions/runs/{}".format(
@@ -38,7 +39,13 @@ def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
             ),
             "title": ""
         })
-    elif env.get(CIRCLECI_KEY):
+    if env.get(GITHUB_PULL_REQUEST_URL_KEY):
+        links.append({
+            "kind": LinkKind.GITHUB_PULL_REQUEST.value,
+            "url": env.get(GITHUB_PULL_REQUEST_URL_KEY, ""),
+            "title": ""
+        })
+    if env.get(CIRCLECI_KEY):
         links.append(
             {"kind": LinkKind.CIRCLECI.value, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""), "title": ""}
         )

--- a/launchable/utils/link.py
+++ b/launchable/utils/link.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum
 from typing import Dict, List, Mapping
 
 JENKINS_URL_KEY = 'JENKINS_URL'
@@ -14,12 +14,12 @@ CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
 
 class LinkKind(Enum):
 
-    LINK_KIND_UNSPECIFIED = auto()
-    CUSTOM_LINK = auto()
-    JENKINS = auto()
-    GITHUB_ACTIONS = auto()
-    GITHUB_PULL_REQUEST = auto()
-    CIRCLECI = auto()
+    LINK_KIND_UNSPECIFIED = 0
+    CUSTOM_LINK = 1
+    JENKINS = 2
+    GITHUB_ACTIONS = 3
+    GITHUB_PULL_REQUEST = 4
+    CIRCLECI = 5
 
 
 def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:

--- a/launchable/utils/link.py
+++ b/launchable/utils/link.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from typing import Dict, List, Mapping
+
+JENKINS_URL_KEY = 'JENKINS_URL'
+JENKINS_BUILD_URL_KEY = 'BUILD_URL'
+GITHUB_ACTIONS_KEY = 'GITHUB_ACTIONS'
+GITHUB_ACTIONS_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
+GITHUB_ACTIONS_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
+GITHUB_ACTIONS_RUN_ID_KEY = 'GITHUB_RUN_ID'
+CIRCLECI_KEY = 'CIRCLECI'
+CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
+
+
+class LinkKind(Enum):
+
+    LINK_KIND_UNSPECIFIED = "LINK_KIND_UNSPECIFIED"
+    CUSTOM_LINK = "CUSTOM_LINK"
+    JENKINS = "JENKINS"
+    GITHUB_ACTIONS = "GITHUB_ACTIONS"
+    GITHUB_PULL_REQUEST = "GITHUB_PULL_REQUEST"
+    CIRCLECI = "CIRCLECI"
+
+
+def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
+    links = []
+
+    if env.get(JENKINS_URL_KEY):
+        links.append(
+            {"kind": LinkKind.JENKINS.value, "url": env.get(JENKINS_BUILD_URL_KEY, ""), "title": ""}
+        )
+    elif env.get(GITHUB_ACTIONS_KEY):
+        links.append({
+            "kind": LinkKind.GITHUB_ACTIONS.value,
+            "url": "{}/{}/actions/runs/{}".format(
+                env.get(GITHUB_ACTIONS_SERVER_URL_KEY),
+                env.get(GITHUB_ACTIONS_REPOSITORY_KEY),
+                env.get(GITHUB_ACTIONS_RUN_ID_KEY),
+            ),
+            "title": ""
+        })
+    elif env.get(CIRCLECI_KEY):
+        links.append(
+            {"kind": LinkKind.CIRCLECI.value, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""), "title": ""}
+        )
+
+    return links

--- a/launchable/utils/link.py
+++ b/launchable/utils/link.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 from typing import Dict, List, Mapping
 
 JENKINS_URL_KEY = 'JENKINS_URL'
@@ -14,12 +14,12 @@ CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
 
 class LinkKind(Enum):
 
-    LINK_KIND_UNSPECIFIED = "LINK_KIND_UNSPECIFIED"
-    CUSTOM_LINK = "CUSTOM_LINK"
-    JENKINS = "JENKINS"
-    GITHUB_ACTIONS = "GITHUB_ACTIONS"
-    GITHUB_PULL_REQUEST = "GITHUB_PULL_REQUEST"
-    CIRCLECI = "CIRCLECI"
+    LINK_KIND_UNSPECIFIED = auto()
+    CUSTOM_LINK = auto()
+    JENKINS = auto()
+    GITHUB_ACTIONS = auto()
+    GITHUB_PULL_REQUEST = auto()
+    CIRCLECI = auto()
 
 
 def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
@@ -27,11 +27,11 @@ def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
 
     if env.get(JENKINS_URL_KEY):
         links.append(
-            {"kind": LinkKind.JENKINS.value, "url": env.get(JENKINS_BUILD_URL_KEY, ""), "title": ""}
+            {"kind": LinkKind.JENKINS.name, "url": env.get(JENKINS_BUILD_URL_KEY, ""), "title": ""}
         )
     if env.get(GITHUB_ACTIONS_KEY):
         links.append({
-            "kind": LinkKind.GITHUB_ACTIONS.value,
+            "kind": LinkKind.GITHUB_ACTIONS.name,
             "url": "{}/{}/actions/runs/{}".format(
                 env.get(GITHUB_ACTIONS_SERVER_URL_KEY),
                 env.get(GITHUB_ACTIONS_REPOSITORY_KEY),
@@ -41,13 +41,13 @@ def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
         })
     if env.get(GITHUB_PULL_REQUEST_URL_KEY):
         links.append({
-            "kind": LinkKind.GITHUB_PULL_REQUEST.value,
+            "kind": LinkKind.GITHUB_PULL_REQUEST.name,
             "url": env.get(GITHUB_PULL_REQUEST_URL_KEY, ""),
             "title": ""
         })
     if env.get(CIRCLECI_KEY):
         links.append(
-            {"kind": LinkKind.CIRCLECI.value, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""), "title": ""}
+            {"kind": LinkKind.CIRCLECI.name, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""), "title": ""}
         )
 
     return links

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -26,6 +26,7 @@ class BuildTest(CliTestCase):
     @mock.patch('launchable.utils.subprocess.check_output')
     # to tests on GitHub Actions
     @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
+    @mock.patch.dict(os.environ, {"GITHUB_PULL_REQUEST_URL": ""})
     def test_submodule(self, mock_check_output):
         mock_check_output.side_effect = [
             # the first call is git rev-parse HEAD
@@ -72,6 +73,7 @@ class BuildTest(CliTestCase):
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     # to tests on GitHub Actions
     @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
+    @mock.patch.dict(os.environ, {"GITHUB_PULL_REQUEST_URL": ""})
     @mock.patch('launchable.utils.subprocess.check_output')
     def test_no_submodule(self, mock_check_output):
         mock_check_output.side_effect = [
@@ -103,6 +105,7 @@ class BuildTest(CliTestCase):
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     # to tests on GitHub Actions
     @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
+    @mock.patch.dict(os.environ, {"GITHUB_PULL_REQUEST_URL": ""})
     def test_no_git_directory(self):
         orig_dir = os.getcwd()
         try:

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -60,7 +60,8 @@ class BuildTest(CliTestCase):
                         "repositoryName": "./bar-zot",
                         "commitHash": "8bccab48338219e73c3118ad71c8c98fbd32a4be"
                     },
-                ]
+                ],
+                "links": []
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)
@@ -88,7 +89,8 @@ class BuildTest(CliTestCase):
                         "repositoryName": ".",
                         "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
                     },
-                ]
+                ],
+                "links": []
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)
@@ -113,7 +115,8 @@ class BuildTest(CliTestCase):
                             "repositoryName": ".",
                             "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
                         },
-                    ]
+                    ],
+                    "links": []
                 }, payload)
 
             self.assertEqual(read_build(), self.build_name)

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -24,6 +24,8 @@ class BuildTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     @mock.patch('launchable.utils.subprocess.check_output')
+    # to tests on GitHub Actions
+    @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
     def test_submodule(self, mock_check_output):
         mock_check_output.side_effect = [
             # the first call is git rev-parse HEAD
@@ -68,6 +70,8 @@ class BuildTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    # to tests on GitHub Actions
+    @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
     @mock.patch('launchable.utils.subprocess.check_output')
     def test_no_submodule(self, mock_check_output):
         mock_check_output.side_effect = [
@@ -97,6 +101,8 @@ class BuildTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    # to tests on GitHub Actions
+    @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
     def test_no_git_directory(self):
         orig_dir = os.getcwd()
         try:

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -4,9 +4,6 @@ from unittest import mock
 
 import responses  # type: ignore
 
-from launchable.commands.record.session import (CIRCLECI_BUILD_URL_KEY, CIRCLECI_KEY, GITHUB_ACTIONS_KEY,
-                                                GITHUB_ACTIONS_REPOSITORY_KEY, GITHUB_ACTIONS_RUN_ID_KEY,
-                                                GITHUB_ACTIONS_SERVER_URL_KEY, JENKINS_BUILD_URL_KEY, JENKINS_URL_KEY)
 from tests.cli_test_case import CliTestCase
 
 
@@ -29,7 +26,7 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False}, payload)
+        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": []}, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -48,7 +45,9 @@ class SessionTest(CliTestCase):
                 "k": "v",
                 "k e y": "v a l u e",
             },
-            "isObservation": False, }, payload)
+            "isObservation": False,
+            "links": []
+        }, payload)
 
         with self.assertRaises(ValueError):
             result = self.cli("record", "session", "--build", self.build_name, "--flavor", "only-key")
@@ -66,74 +65,4 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": True}, payload)
-
-    @responses.activate
-    @mock.patch.dict(os.environ, {
-        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        JENKINS_URL_KEY: "https://jenkins.example.com/",
-        JENKINS_BUILD_URL_KEY: "https://jenkins.example.com/job/launchableinc/job/example/357/",
-        'LANG': 'C.UTF-8',
-    }, clear=True)
-    def test_run_session_with_jenkins_url(self):
-        result = self.cli("record", "session", "--build", self.build_name)
-        self.assertEqual(result.exit_code, 0)
-
-        payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal(
-            {
-                "flavors": {},
-                "isObservation": False,
-                "link": {
-                    "provider": "jenkins",
-                    "url": "https://jenkins.example.com/job/launchableinc/job/example/357/"},
-            },
-            payload)
-
-    @responses.activate
-    @mock.patch.dict(os.environ, {
-        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
-        GITHUB_ACTIONS_KEY: "true",
-        GITHUB_ACTIONS_SERVER_URL_KEY: "https://github.com",
-        GITHUB_ACTIONS_REPOSITORY_KEY: "launchableinc/example",
-        GITHUB_ACTIONS_RUN_ID_KEY: "2709244304",
-        'LANG': 'C.UTF-8',
-    }, clear=True)
-    def test_run_session_with_github_url(self):
-        result = self.cli("record", "session", "--build", self.build_name)
-        self.assertEqual(result.exit_code, 0)
-
-        payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal(
-            {
-                "flavors": {},
-                "isObservation": False,
-                "link": {
-                    "provider": "github-actions",
-                    "url": "https://github.com/launchableinc/example/actions/runs/2709244304",
-                },
-            }, payload)
-
-    @responses.activate
-    @mock.patch.dict(
-        os.environ,
-        {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token, CIRCLECI_KEY: "true",
-         CIRCLECI_BUILD_URL_KEY:
-         "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935",  # noqa: E501
-         'LANG': 'C.UTF-8', },
-        clear=True)
-    def test_run_session_with_circleci_url(self):
-        result = self.cli("record", "session", "--build", self.build_name)
-        self.assertEqual(result.exit_code, 0)
-
-        payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal(
-            {
-                "flavors": {},
-                "isObservation": False,
-                "link": {
-                    "provider": "circleci",
-                    "url": "https://app.circleci.com/pipelines/github/launchableinc/examples/6221/workflows/990a9987-1a21-42e5-a332-89046125e5ce/jobs/7935",  # noqa: E501
-                },
-            },
-            payload)
+        self.assert_json_orderless_equal({"flavors": {}, "isObservation": True, "links": []}, payload)

--- a/tests/utils/test_key_value_type.py
+++ b/tests/utils/test_key_value_type.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from launchable.utils.key_value_type import normalize_key_value_types
+
+
+class NormalizeKeyValueTest(TestCase):
+    def test_normalize_key_value_types(self):
+        # <click8.0
+        result = normalize_key_value_types((("os", "ubuntu"), ("python", "3.5")))
+        self.assertEqual(result, [("os", "ubuntu"), ("python", "3.5")])
+
+        # >=click8.0
+        result = normalize_key_value_types(("('os', 'ubuntu')", "('python', '3.8')"))
+        self.assertEqual(result, [("os", "ubuntu"), ("python", "3.8")])

--- a/tests/utils/test_link.py
+++ b/tests/utils/test_link.py
@@ -7,7 +7,7 @@ class LinkTest(TestCase):
     def test_jenkins(self):
         envs = {"JENKINS_URL": "https://jenkins.io", "BUILD_URL": "https://jenkins.launchableinc.com/build/123"}
         self.assertEqual(capture_link(envs), [{
-            "kind": LinkKind.JENKINS.value,
+            "kind": LinkKind.JENKINS.name,
             "title": "",
             "url": "https://jenkins.launchableinc.com/build/123",
         }])
@@ -19,7 +19,7 @@ class LinkTest(TestCase):
             "GITHUB_REPOSITORY": "launchable/cli",
             "GITHUB_RUN_ID": 123}
         self.assertEqual(capture_link(envs), [{
-            "kind": LinkKind.GITHUB_ACTIONS.value,
+            "kind": LinkKind.GITHUB_ACTIONS.name,
             "title": "",
             "url": "https://github.com/launchable/cli/actions/runs/123",
         }])
@@ -27,7 +27,7 @@ class LinkTest(TestCase):
     def test_circleci(self):
         envs = {"CIRCLECI": "true", "CIRCLE_BUILD_URL": "https://circleci.com/build/123"}
         self.assertEqual(capture_link(envs), [{
-            "kind": LinkKind.CIRCLECI.value,
+            "kind": LinkKind.CIRCLECI.name,
             "title": "",
             "url": "https://circleci.com/build/123",
         }])

--- a/tests/utils/test_link.py
+++ b/tests/utils/test_link.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+from launchable.utils.link import LinkKind, capture_link
+
+
+class LinkTest(TestCase):
+    def test_jenkins(self):
+        envs = {"JENKINS_URL": "https://jenkins.io", "BUILD_URL": "https://jenkins.launchableinc.com/build/123"}
+        self.assertEqual(capture_link(envs), [{
+            "kind": LinkKind.JENKINS.value,
+            "title": "",
+            "url": "https://jenkins.launchableinc.com/build/123",
+        }])
+
+    def test_github_actions(self):
+        envs = {
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_REPOSITORY": "launchable/cli",
+            "GITHUB_RUN_ID": 123}
+        self.assertEqual(capture_link(envs), [{
+            "kind": LinkKind.GITHUB_ACTIONS.value,
+            "title": "",
+            "url": "https://github.com/launchable/cli/actions/runs/123",
+        }])
+
+    def test_circleci(self):
+        envs = {"CIRCLECI": "true", "CIRCLE_BUILD_URL": "https://circleci.com/build/123"}
+        self.assertEqual(capture_link(envs), [{
+            "kind": LinkKind.CIRCLECI.value,
+            "title": "",
+            "url": "https://circleci.com/build/123",
+        }])


### PR DESCRIPTION
Add `--link` option to the `launchable record` command and `launchable record session` command. Also, `launchable subset` command and `launchable record tests` command support a link option to pass links value to the `launchable record session` command internally too.

e.g)
```sh
# record build
$ launchable record build --name test --link build-url=https://example.launchable.com/job/1 

# record session
$ launchable record build --name test --link commit=https://github.com/owner/repo/commits/123abc456
```

Also, if these values (ref: https://github.com/launchableinc/cli/pull/529/files#diff-280a9bc4f9d9c38c29d666a70adf8c4e216a1abb22f548b3a011f9ac00b6bf10R4-R53) are set in the CI environment, the cli sets custom link data automatically.
