### PR TITLE
[WA-77] format with fixed point notation

### DIFF
--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -47,7 +47,7 @@ def subset(subset_id: int):
     rest_row = convert_row(rest, len(subset) + 1, False)
     rows = subset_row + rest_row
 
-    click.echo(tabulate(rows, header, tablefmt="github"))
+    click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
 
 
 def convert_row(data_list: List[Dict], order: int, is_subset: bool):
@@ -65,7 +65,7 @@ def convert_row(data_list: List[Dict], order: int, is_subset: bool):
                     "#".join([path["type"] + "=" + path["name"]
                               for path in l["testPath"] if path.keys() >= {"type", "name"}]),
                     "✔" if is_subset else "",
-                    "{:0.4f}".format(l.get("duration", 0.0) / 1000),
+                    l.get("duration", 0.0) / 1000,
                 ]
             )
     return data

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -52,10 +52,10 @@ def tests(test_session_id: int):
                 [
                     "#".join([path["type"] + "=" + path["name"]
                              for path in result["testPath"] if path.keys() >= {"type", "name"}]),
-                    "{:0.4f}".format(result.get("duration", 0.0)),
+                    result.get("duration", 0.0),
                     result.get("status", ""),
                     result.get("createdAt", None),
                 ]
             )
 
-    click.echo(tabulate(rows, header, tablefmt="github"))
+    click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -430,8 +430,8 @@ def tests(
 
             header = ["Files found", "Tests found", "Tests passed", "Tests failed", "Total duration (min)"]
 
-            rows = [[file_count, test_count, success_count, fail_count, "{:0.4f}".format(duration)]]
-            click.echo(tabulate(rows, header, tablefmt="github"))
+            rows = [[file_count, test_count, success_count, fail_count, duration]]
+            click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
 
             click.echo(
                 "\nVisit https://app.launchableinc.com/organizations/{organization}/workspaces/"

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -439,7 +439,7 @@ def subset(
                     err=True)
 
             click.echo("", err=True)
-            click.echo(tabulate(rows, header, tablefmt="github"), err=True)
+            click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"), err=True)
 
             click.echo(
                 "\nRun `launchable inspect subset --subset-id {}` to view full subset details".format(subset_id),

--- a/tests/commands/inspect/test_subset.py
+++ b/tests/commands/inspect/test_subset.py
@@ -32,10 +32,10 @@ class SubsetTest(CliTestCase):
         result = self.cli('inspect', 'subset', '--subset-id', subset_id, mix_stderr=False)
         expect = """|   Order | Test Path          | In Subset   |   Estimated duration (sec) |
 |---------|--------------------|-------------|----------------------------|
-|       1 | file=test_file1.py | ✔           |                        1.2 |
-|       2 | file=test_file3.py | ✔           |                        0.6 |
-|       3 | file=test_file4.py |             |                        1.8 |
-|       4 | file=test_file2.py |             |                        0.1 |
+|       1 | file=test_file1.py | ✔           |                       1.20 |
+|       2 | file=test_file3.py | ✔           |                       0.60 |
+|       3 | file=test_file4.py |             |                       1.80 |
+|       4 | file=test_file2.py |             |                       0.10 |
 """
 
         self.assertEqual(result.stdout, expect)

--- a/tests/commands/inspect/test_tests.py
+++ b/tests/commands/inspect/test_tests.py
@@ -73,10 +73,10 @@ class SubsetTest(CliTestCase):
         result = self.cli('inspect', 'tests', '--test-session-id', test_session_id, mix_stderr=False)
         expect = """| Test Path          |   Duration (sec) | Status   | Uploaded At                   |
 |--------------------|------------------|----------|-------------------------------|
-| file=test_file1.py |              1.2 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file3.py |              0.6 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file4.py |              1.8 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
-| file=test_file2.py |              0.1 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file1.py |             1.20 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file3.py |             0.60 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file4.py |             1.80 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file2.py |             0.10 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
 """
 
         self.assertEqual(result.stdout, expect)


### PR DESCRIPTION
Estimated duration of "3.33333e-05" is silly. Our valid value range is far limited, and the precision at those small numbers are illusions.

Better to use a fixed point precision. Also limit the number of precision digits. There's enough measurement margin errors, so added digits do not add any real value.

Briefly I was looking to print "3" as "3", not "3.00" but I don't think there's any predefined formatter that does it.

See: https://docs.python.org/3/library/string.html#format-specification-mini-language