### PR TITLE
add perl profile

### DIFF
--- a/launchable/test_runners/perl.py
+++ b/launchable/test_runners/perl.py
@@ -17,15 +17,6 @@ def subset(client):
 @click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, reports):
-    click.echo(
-        click.style(
-            "Perl profile is made to take Junit report produced by "
-            "TAP::Harness::JUnit (https://metacpan.org/pod/TAP::Harness::JUnit) "
-            "with environment variable of JUNIT_NAME_MANGLE=none. "
-            "If you are not using TAP::Harness::JUnit, "
-            "please change your reporting to TAP::Harness::JUnit.",
-            fg="yellow"),
-        err=False)
 
     def path_builder(case: TestCase, suite: TestSuite,
                      report_file: str) -> TestPath:
@@ -43,7 +34,12 @@ def record_tests(client, reports):
         filepath = find_filename()
         if not filepath:
             raise click.ClickException(
-                "No file name found in %s" % report_file)
+                "No file name found in %s."
+                "Perl profile is made to take Junit report produced by "
+                "TAP::Harness::JUnit (https://metacpan.org/pod/TAP::Harness::JUnit) "
+                "with environment variable of JUNIT_NAME_MANGLE=none. "
+                "If you are not using TAP::Harness::JUnit, "
+                "please change your reporting to TAP::Harness::JUnit." % report_file)
 
         # default test path in `subset` expects to have this file name
         test_path = [client.make_file_path_component(filepath)]

--- a/launchable/test_runners/perl.py
+++ b/launchable/test_runners/perl.py
@@ -17,6 +17,16 @@ def subset(client):
 @click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, reports):
+    click.echo(
+        click.style(
+            "Perl profile is made to take Junit report produced by "
+            "TAP::Harness::JUnit (https://metacpan.org/pod/TAP::Harness::JUnit) "
+            "with environment variable of JUNIT_NAME_MANGLE=none. "
+            "If you are not using TAP::Harness::JUnit, "
+            "please change your reporting to TAP::Harness::JUnit.",
+            fg="yellow"),
+        err=False)
+
     def path_builder(case: TestCase, suite: TestSuite,
                      report_file: str) -> TestPath:
         def find_filename():

--- a/launchable/test_runners/perl.py
+++ b/launchable/test_runners/perl.py
@@ -1,0 +1,52 @@
+import click
+from junitparser import TestCase, TestSuite  # type: ignore
+
+from ..testpath import TestPath
+from . import launchable
+
+
+@launchable.subset
+def subset(client):
+    # read lines as test file names
+    for t in client.stdin():
+        client.test_path(t.rstrip("\n"))
+
+    client.run()
+
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    def path_builder(case: TestCase, suite: TestSuite,
+                     report_file: str) -> TestPath:
+        def find_filename():
+            # find file path from test suite attribute first.
+            filepath = suite._elem.attrib.get("name")
+            if filepath:
+                return filepath
+            # find file path from test case attribute.
+            filepath = case._elem.attrib.get("classname")
+            if filepath:
+                return filepath
+            return None  # failing to find a test name
+
+        filepath = find_filename()
+        if not filepath:
+            raise click.ClickException(
+                "No file name found in %s" % report_file)
+
+        # default test path in `subset` expects to have this file name
+        test_path = [client.make_file_path_component(filepath)]
+        if suite.name:
+            test_path.append({"type": "testsuite", "name": suite.name})
+        if case.name:
+            test_path.append({"type": "testcase", "name": case.name})
+        return test_path
+    client.path_builder = path_builder
+
+    for r in reports:
+        client.report(r)
+    client.run()
+
+
+split_subset = launchable.CommonSplitSubsetImpls(__name__).split_subset()

--- a/launchable/test_runners/perl.py
+++ b/launchable/test_runners/perl.py
@@ -43,8 +43,6 @@ def record_tests(client, reports):
 
         # default test path in `subset` expects to have this file name
         test_path = [client.make_file_path_component(filepath)]
-        if suite.name:
-            test_path.append({"type": "testsuite", "name": suite.name})
         if case.name:
             test_path.append({"type": "testcase", "name": case.name})
         return test_path

--- a/tests/data/perl/record_test_result.json
+++ b/tests/data/perl/record_test_result.json
@@ -1,0 +1,139 @@
+{
+    "events": [
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/00_compile.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/00_compile.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "use Example;"
+                }
+            ],
+            "duration": 0.0860052108764648,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "add(1,2) == 3"
+                }
+            ],
+            "duration": 0.0693521499633789,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "add"
+                }
+            ],
+            "duration": 0.000168085098266602,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "double"
+                }
+            ],
+            "duration": 0.000128984451293945,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/easy/01_easy.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/easy/01_easy.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "a + b = ab"
+                }
+            ],
+            "duration": 0.152199029922485,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/easy/01_easy.t"
+                },
+                {
+                    "type": "testsuite",
+                    "name": "t/easy/01_easy.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "str_concat {"
+                }
+            ],
+            "duration": 0.000449180603027344,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        }
+    ],
+    "testRunner": "perl",
+    "group": "",
+    "noBuild": false
+}

--- a/tests/data/perl/record_test_result.json
+++ b/tests/data/perl/record_test_result.json
@@ -5,98 +5,6 @@
             "testPath": [
                 {
                     "type": "file",
-                    "name": "t/00_compile.t"
-                },
-                {
-                    "type": "testsuite",
-                    "name": "t/00_compile.t"
-                },
-                {
-                    "type": "testcase",
-                    "name": "use Example;"
-                }
-            ],
-            "duration": 0.0860052108764648,
-            "status": 1,
-            "stdout": "",
-            "stderr": "",
-            "data": null
-        },
-        {
-            "type": "case",
-            "testPath": [
-                {
-                    "type": "file",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testsuite",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testcase",
-                    "name": "add(1, 2) == 3"
-                }
-            ],
-            "duration": 0.0693521499633789,
-            "status": 1,
-            "stdout": "",
-            "stderr": "",
-            "data": null
-        },
-        {
-            "type": "case",
-            "testPath": [
-                {
-                    "type": "file",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testsuite",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testcase",
-                    "name": "add"
-                }
-            ],
-            "duration": 0.000168085098266602,
-            "status": 1,
-            "stdout": "",
-            "stderr": "",
-            "data": null
-        },
-        {
-            "type": "case",
-            "testPath": [
-                {
-                    "type": "file",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testsuite",
-                    "name": "t/math/01_math.t"
-                },
-                {
-                    "type": "testcase",
-                    "name": "double"
-                }
-            ],
-            "duration": 0.000128984451293945,
-            "status": 1,
-            "stdout": "",
-            "stderr": "",
-            "data": null
-        },
-        {
-            "type": "case",
-            "testPath": [
-                {
-                    "type": "file",
-                    "name": "t/easy/01_easy.t"
-                },
-                {
-                    "type": "testsuite",
                     "name": "t/easy/01_easy.t"
                 },
                 {
@@ -104,7 +12,7 @@
                     "name": "a + b = ab"
                 }
             ],
-            "duration": 0.152199029922485,
+            "duration": 0.153996229171753,
             "status": 1,
             "stdout": "",
             "stderr": "",
@@ -118,15 +26,101 @@
                     "name": "t/easy/01_easy.t"
                 },
                 {
-                    "type": "testsuite",
-                    "name": "t/easy/01_easy.t"
-                },
-                {
                     "type": "testcase",
                     "name": "str_concat {"
                 }
             ],
-            "duration": 0.000449180603027344,
+            "duration": 0.00043487548828125,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "add(1, 2) == 3"
+                }
+            ],
+            "duration": 0.0723011493682861,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "add"
+                }
+            ],
+            "duration": 0.000227928161621094,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "double"
+                }
+            ],
+            "duration": 7.91549682617188e-05,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/math/01_math.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "double_fail"
+                }
+            ],
+            "duration": 0.000271081924438477,
+            "status": 0,
+            "stdout": "",
+            "stderr": "",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "file",
+                    "name": "t/00_compile.t"
+                },
+                {
+                    "type": "testcase",
+                    "name": "use Example;"
+                }
+            ],
+            "duration": 0.0674030780792236,
             "status": 1,
             "stdout": "",
             "stderr": "",

--- a/tests/data/perl/record_test_result.json
+++ b/tests/data/perl/record_test_result.json
@@ -35,7 +35,7 @@
                 },
                 {
                     "type": "testcase",
-                    "name": "add(1,2) == 3"
+                    "name": "add(1, 2) == 3"
                 }
             ],
             "duration": 0.0693521499633789,

--- a/tests/data/perl/report.xml
+++ b/tests/data/perl/report.xml
@@ -1,12 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
 <testsuites>
-  <testsuite name="t/00_compile.t" errors="0" failures="0" skipped="0" tests="1" time="0.0876882076263428">
-    <system-out>ok 1 - use Example;
-1..1
+  <testsuite name="t/easy/01_easy.t" errors="0" failures="0" skipped="0" tests="2" time="0.157027006149292">
+    <system-out>ok 1 - a + b = ab
+ok 2 - str_concat {
+    ok 1 - a + dddd
+    ok 2 - bb + ccc
+    1..2
+}
+1..2
 </system-out>
-    <testcase name="use Example;" classname="t/00_compile.t" time="0.0860052108764648" />
+    <testcase name="a + b = ab" classname="t/easy/01_easy.t" time="0.153996229171753" />
+    <testcase name="str_concat {" classname="t/easy/01_easy.t" time="0.00043487548828125" />
   </testsuite>
-  <testsuite name="t/math/01_math.t" errors="0" failures="0" skipped="0" tests="3" time="0.0724310874938965">
+  <testsuite name="t/math/01_math.t" errors="0" failures="1" skipped="0" tests="4" time="0.0786290168762207">
     <system-out>ok 1 - add(1, 2) == 3
 # Subtest: add
     ok 1 - 1 + 2
@@ -18,22 +24,28 @@ ok 2 - add
     ok 2 - 3 + 2
     1..2
 ok 3 - double
-1..3
-</system-out>
-    <testcase name="add(1, 2) == 3" classname="t/math/01_math.t" time="0.0693521499633789" />
-    <testcase name="add" classname="t/math/01_math.t" time="0.000168085098266602" />
-    <testcase name="double" classname="t/math/01_math.t" time="0.000128984451293945" />
-  </testsuite>
-  <testsuite name="t/easy/01_easy.t" errors="0" failures="0" skipped="0" tests="2" time="0.154859066009521">
-    <system-out>ok 1 - a + b = ab
-ok 2 - str_concat {
-    ok 1 - a + dddd
-    ok 2 - bb + ccc
+# Subtest: double_fail
+    not ok 1 - fail 1 + 2
+    not ok 2 - fail 3 + 2
     1..2
-}
-1..2
+not ok 4 - double_fail
+1..4
 </system-out>
-    <testcase name="a + b = ab" classname="t/easy/01_easy.t" time="0.152199029922485" />
-    <testcase name="str_concat {" classname="t/easy/01_easy.t" time="0.000449180603027344" />
+    <testcase name="add(1, 2) == 3" classname="t/math/01_math.t" time="0.0723011493682861" />
+    <testcase name="add" classname="t/math/01_math.t" time="0.000227928161621094" />
+    <testcase name="double" classname="t/math/01_math.t" time="7.91549682617188e-05" />
+    <testcase name="double_fail" classname="t/math/01_math.t" time="0.000271081924438477">
+      <failure message="not ok 4 - double_fail" type="TAP::Parser::Result::Test">Subtest: double_fail
+    not ok 1 - fail 1 + 2
+    not ok 2 - fail 3 + 2
+    1..2
+</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="t/00_compile.t" errors="0" failures="0" skipped="0" tests="1" time="0.0689620971679688">
+    <system-out>ok 1 - use Example;
+1..1
+</system-out>
+    <testcase name="use Example;" classname="t/00_compile.t" time="0.0674030780792236" />
   </testsuite>
 </testsuites>

--- a/tests/data/perl/report.xml
+++ b/tests/data/perl/report.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites>
+  <testsuite name="t/00_compile.t" errors="0" failures="0" skipped="0" tests="1" time="0.0876882076263428">
+    <system-out>ok 1 - use Example;
+1..1
+</system-out>
+    <testcase name="use Example;" classname="t/00_compile.t" time="0.0860052108764648" />
+  </testsuite>
+  <testsuite name="t/math/01_math.t" errors="0" failures="0" skipped="0" tests="3" time="0.0724310874938965">
+    <system-out>ok 1 - add(1, 2) == 3
+# Subtest: add
+    ok 1 - 1 + 2
+    ok 2 - 3 + 4
+    1..2
+ok 2 - add
+# Subtest: double
+    ok 1 - 1 + 2
+    ok 2 - 3 + 2
+    1..2
+ok 3 - double
+1..3
+</system-out>
+    <testcase name="add(1, 2) == 3" classname="t/math/01_math.t" time="0.0693521499633789" />
+    <testcase name="add" classname="t/math/01_math.t" time="0.000168085098266602" />
+    <testcase name="double" classname="t/math/01_math.t" time="0.000128984451293945" />
+  </testsuite>
+  <testsuite name="t/easy/01_easy.t" errors="0" failures="0" skipped="0" tests="2" time="0.154859066009521">
+    <system-out>ok 1 - a + b = ab
+ok 2 - str_concat {
+    ok 1 - a + dddd
+    ok 2 - bb + ccc
+    1..2
+}
+1..2
+</system-out>
+    <testcase name="a + b = ab" classname="t/easy/01_easy.t" time="0.152199029922485" />
+    <testcase name="str_concat {" classname="t/easy/01_easy.t" time="0.000449180603027344" />
+  </testsuite>
+</testsuites>

--- a/tests/test_runners/test_perl.py
+++ b/tests/test_runners/test_perl.py
@@ -29,8 +29,6 @@ class GoTestTest(CliTestCase):
         for c in payload['events']:
             del c['created_at']
 
-        print(payload)
-
         expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
         self.assert_json_orderless_equal(expected, payload)
 

--- a/tests/test_runners/test_perl.py
+++ b/tests/test_runners/test_perl.py
@@ -10,7 +10,7 @@ from launchable.utils.session import read_session, write_build
 from tests.cli_test_case import CliTestCase
 
 
-class GoTestTest(CliTestCase):
+class PerlTestTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/perl/').resolve()
 
     @responses.activate

--- a/tests/test_runners/test_perl.py
+++ b/tests/test_runners/test_perl.py
@@ -1,0 +1,37 @@
+import gzip
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import responses  # type: ignore
+
+from launchable.utils.session import read_session, write_build
+from tests.cli_test_case import CliTestCase
+
+
+class GoTestTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/perl/').resolve()
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_tests(self):
+        # emulate launchable record build
+        write_build(self.build_name)
+
+        result = self.cli('record', 'tests', 'perl', str(self.test_files_dir.joinpath('report.xml')))
+        self.assertEqual(result.exit_code, 0)
+
+        self.assertEqual(read_session(self.build_name), self.session)
+
+        self.assertIn('events', responses.calls[2].request.url, 'call events API')
+        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
+        for c in payload['events']:
+            del c['created_at']
+
+        print(payload)
+
+        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
+        self.assert_json_orderless_equal(expected, payload)
+
+        self.assertIn('close', responses.calls[4].request.url, 'call close API')


### PR DESCRIPTION
# What
- Add Perl profile to support Perl test.
- The Perl profile is made to take a Junit report produced by [TAP::Harness::JUnit](https://metacpan.org/pod/TAP::Harness::JUnit) with environment variable of `JUNIT_NAME_MANGLE=none`. Otherwise, Launchable cannot support Perl test since the report produced may not contain test file path or duration.