### PR TITLE
Support --session-name option to `record session` and `record tests` commands

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -207,7 +207,7 @@ def add_session_name(
     payload = {
         "name": session_name
     }
-    res = client.request("put", sub_path, payload=payload)
+    res = client.request("patch", sub_path, payload=payload)
 
     if res.status_code == HTTPStatus.NOT_FOUND:
         click.echo(

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from http import HTTPStatus
 from typing import List, Optional
@@ -15,6 +16,18 @@ from ...utils.no_build import NO_BUILD_BUILD_NAME
 from ...utils.session import read_build, write_session
 
 LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
+
+TEST_SESSION_NAME_RULE = re.compile("^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+
+
+def _validate_session_name(ctx, param, value):
+    if value is None:
+        return ""
+
+    if TEST_SESSION_NAME_RULE.match(value):
+        return value
+    else:
+        raise click.BadParameter("--session-name option supports only alphabet(a-z, A-Z), number(0-9), '-', and '_'")
 
 
 @click.command()
@@ -66,8 +79,10 @@ LAUNCHABLE_SESSION_DIR_KEY = 'LAUNCHABLE_SESSION_DIR'
     'session_name',
     help='test session name',
     required=False,
+    hidden=True,
     type=str,
-    metavar='SESSION_NAME'
+    metavar='SESSION_NAME',
+    callback=_validate_session_name,
 )
 @click.pass_context
 def session(
@@ -99,7 +114,6 @@ def session(
             raise click.UsageError(
                 'The cli already created `.launchable file`. If you want to use `--no-build option`, please remove `.launchable` file before executing.')  # noqa: E501
 
-    if is_no_build:
         build_name = NO_BUILD_BUILD_NAME
 
     flavor_dict = {}

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -212,7 +212,7 @@ def add_session_name(
     if res.status_code == HTTPStatus.NOT_FOUND:
         click.echo(
             click.style(
-                "Test session {} was not found. Record session may be failed.".format(session_id),
+                "Test session {} was not found. Record session may have failed.".format(session_id),
                 'yellow'),
             err=True,
         )
@@ -220,7 +220,7 @@ def add_session_name(
     if res.status_code == HTTPStatus.BAD_REQUEST:
         click.echo(
             click.style(
-                "You cannot use test session name {} since it is already used by other test session in your workspace."
+                "You cannot use test session name {} since it is already used by other test session in your workspace. The record session is completed successfully without session name."  # noqa: E501
                 .format(session_name),
                 'yellow'),
             err=True,)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -182,7 +182,7 @@ def session(
         else:
             click.echo(e, err=True)
 
-    if session_name is not None:
+    if session_name:
         try:
             add_session_name(
                 client=client,

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -162,6 +162,7 @@ def session(
     if session_name is not None:
         try:
             add_session_name(
+                client=client,
                 build_name=build_name,
                 session_id=session_id,
                 session_name=session_name,

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -116,6 +116,16 @@ def session(
 
         build_name = NO_BUILD_BUILD_NAME
 
+    client = LaunchableClient(dry_run=ctx.obj.dry_run)
+
+    if session_name:
+        sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
+        res = client.request("get", sub_path)
+
+        if res.status_code != 404:
+            raise click.UsageError(
+                'This session name ({}) is already used. Please set another name.'.format(session_name))
+
     flavor_dict = {}
     for f in normalize_key_value_types(flavor):
         flavor_dict[f[0]] = f[1]
@@ -136,7 +146,6 @@ def session(
             })
     payload["links"] = _links
 
-    client = LaunchableClient(dry_run=ctx.obj.dry_run)
     try:
         sub_path = "builds/{}/test_sessions".format(build_name)
         res = client.request("post", sub_path, payload=payload)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -185,6 +185,7 @@ def add_session_name(
         "name": session_name
     }
     res = client.request("put", sub_path, payload=payload)
+
     if res.status_code == HTTPStatus.NOT_FOUND:
         click.echo(
             click.style(
@@ -196,10 +197,10 @@ def add_session_name(
     if res.status_code == HTTPStatus.BAD_REQUEST:
         click.echo(
             click.style(
-                "You cannot use test session name {} since it is already used by other test session.".format(session_name),
+                "You cannot use test session name {} since it is already used by other test session in your workspace."
+                .format(session_name),
                 'yellow'),
-            err=True,
-        )
+            err=True,)
         sys.exit(1)
 
     res.raise_for_status()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -136,6 +136,15 @@ def _validate_group(ctx, param, value):
     is_flag=True,
     hidden=True,
 )
+@click.option(
+    '--session-name',
+    'session_name',
+    help='test session name',
+    required=False,
+    hidden=True,
+    type=str,
+    metavar='SESSION_NAME',
+)
 @click.pass_context
 def tests(
     context: click.core.Context,
@@ -151,6 +160,7 @@ def tests(
     is_allow_test_before_build: bool,
     links: List[str] = [],
     is_no_build: bool = False,
+    session_name: Optional[str] = None
 ):
     logger = Logger()
 
@@ -174,6 +184,16 @@ def tests(
             result = get_session_and_record_start_at_from_subsetting_id(subsetting_id, client)
             session_id = result["session"]
             record_start_at = result["start_at"]
+        elif session_name:
+            if not build_name:
+                raise click.UsageError(
+                    '--build-name is required when you uses a --session-name option ')
+
+            sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
+            res = client.request("get", sub_path)
+            res.raise_for_status()
+
+            session_id = "builds/{}/test_sessions/{}".format(build_name, res.json().get("id"))
         else:
             # The session_id must be back, so cast to str
             session_id = str(find_or_create_session(

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -194,6 +194,7 @@ def tests(
             res.raise_for_status()
 
             session_id = "builds/{}/test_sessions/{}".format(build_name, res.json().get("id"))
+            record_start_at = get_record_start_at(session_id, client)
         else:
             # The session_id must be back, so cast to str
             session_id = str(find_or_create_session(

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -24,6 +24,7 @@ class CliTestCase(unittest.TestCase):
     launchable_token = "v1:{}/{}:auth-token-sample".format(organization, workspace)
     session_id = 16
     build_name = "123"
+    session_name = "test_session_name"
     subsetting_id = 456
     session = "builds/{}/test_sessions/{}".format(build_name, session_id)
 
@@ -107,6 +108,19 @@ class CliTestCase(unittest.TestCase):
             json={
                 'id': self.session_id,
                 'isObservation': False,
+            },
+            status=200)
+        responses.add(
+            responses.PUT,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.build_name,
+                self.session_id),
+            json={
+                'id': self.session_id,
+                'name': self.session_name,
             },
             status=200)
         responses.add(

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -118,10 +118,7 @@ class CliTestCase(unittest.TestCase):
                 self.workspace,
                 self.build_name,
                 self.session_id),
-            json={
-                'id': self.session_id,
-                'name': self.session_name,
-            },
+            json={'name': self.session_name},
             status=200)
         responses.add(
             responses.PATCH,

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -111,7 +111,20 @@ class CliTestCase(unittest.TestCase):
             },
             status=200)
         responses.add(
-            responses.PUT,
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_session_names/{}".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.build_name,
+                self.session_name),
+            json={
+                'id': self.session_id,
+                'isObservation': False,
+            },
+            status=200)
+        responses.add(
+            responses.PATCH,
             "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions/{}".format(
                 get_base_url(),
                 self.organization,

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -76,6 +76,10 @@ class SessionTest(CliTestCase):
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_session_name(self):
+        # session name is already exist
+        result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
+        self.assertEqual(result.exit_code, 2)
+
         responses.replace(
             responses.GET,
             "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_session_names/{}".format(
@@ -87,9 +91,12 @@ class SessionTest(CliTestCase):
             ),
             status=404,
         )
+        # invalid session name
+        result = self.cli("record", "session", "--build", self.build_name, "--session-name", "invalid/name")
+        self.assertEqual(result.exit_code, 2)
 
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
         self.assertEqual(result.exit_code, 0)
 
-        payload = json.loads(responses.calls[1].request.body.decode())
+        payload = json.loads(responses.calls[2].request.body.decode())
         self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": [], "noBuild": False}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -79,4 +79,4 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": []}, payload)
+        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": [], "noBuild": False}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -79,4 +79,4 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"name": self.session_name}, payload)
+        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": []}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -66,4 +66,17 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
+
         self.assert_json_orderless_equal({"flavors": {}, "isObservation": True, "links": [], "noBuild": False}, payload)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
+    }, clear=True)
+    def test_run_session_with_session_name(self):
+        result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal({"name": self.session_name}, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import responses  # type: ignore
 
+from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 
 
@@ -75,8 +76,20 @@ class SessionTest(CliTestCase):
         'LANG': 'C.UTF-8',
     }, clear=True)
     def test_run_session_with_session_name(self):
+        responses.replace(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_session_names/{}".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                self.build_name,
+                self.session_name,
+            ),
+            status=404,
+        )
+
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
         self.assertEqual(result.exit_code, 0)
 
-        payload = json.loads(responses.calls[0].request.body.decode())
+        payload = json.loads(responses.calls[1].request.body.decode())
         self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": [], "noBuild": False}, payload)


### PR DESCRIPTION
I supported `--session-name` option to `record session` and `record tests` commands.
Previously, the user needed to pass a test-session-id 
to other machines. The user doesn’t need to pass it if using a `—session-name` option.

# Usage

```
# create build
$  launchable record build --name with-session-name
Launchable recorded 22 commits from repository /Users/yabuki-ryosuke/src/github.com/launchableinc/cli
Launchable recorded build with-session-name to workspace example/test with commits from 1 repository:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 14c0b210c606bf9a4744167064d282318142511d |

# create session with name
$ launchable record session --build with-session-name --session-name example-name
builds/with-session-name/test_sessions/1065

# record tests with session name
$  launchable record tests --build with-session-name --session-name example-name file ./test-results/*.xml
Launchable recorded tests for build with-session-name (test session 1065) to workspace example/test from 45 files:

|   Files found |   Tests found |   Tests passed |   Tests failed |   Total duration (min) |
|---------------|---------------|----------------|----------------|------------------------|
|            45 |           143 |            142 |              1 |                   0.13 |

Visit https://app.launchableinc.com/organizations/example/workspaces/test/test-sessions/1065 to view uploaded test results (or run `launchable inspect tests --test-session-id 1065`)
```

However, the session name must be unique. So if the user set the same session name, the command will fail like below.

```
$ launchable record session --build example-build  --session-name same-build-name
Usage: launchable record session [OPTIONS]
Try 'launchable record session --help' for help.

Error: This session name (same-build-name) is already used. Please set another name.
```
