### PR TITLE
Change these options to public

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -72,14 +72,12 @@ def _validate_session_name(ctx, param, value):
     "is_no_build",
     help="If you want to only send test reports, please use this option",
     is_flag=True,
-    hidden=True,
 )
 @click.option(
     '--session-name',
     'session_name',
     help='test session name',
     required=False,
-    hidden=True,
     type=str,
     metavar='SESSION_NAME',
     callback=_validate_session_name,

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -134,14 +134,12 @@ def _validate_group(ctx, param, value):
     'is_no_build',
     help="If you want to only send test reports, please use this option",
     is_flag=True,
-    hidden=True,
 )
 @click.option(
     '--session-name',
     'session_name',
     help='test session name',
     required=False,
-    hidden=True,
     type=str,
     metavar='SESSION_NAME',
 )

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -139,7 +139,6 @@ from .test_path_writer import TestPathWriter
     "is_no_build",
     help="If you want to only send test reports, please use this option",
     is_flag=True,
-    hidden=True,
 )
 @click.pass_context
 def subset(


### PR DESCRIPTION
We shipped these options as hidden options at first for a safe landing.
But we could confirm it works well, so I changed them from hidden to the public.