### PR TITLE
Do not print a newline in `launchable record session`

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -174,7 +174,7 @@ def session(
         if print_session:
             # what we print here gets captured and passed to `--session` in
             # later commands
-            click.echo("{}/{}".format(sub_path, session_id))
+            click.echo("{}/{}".format(sub_path, session_id), nl=False)
 
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):


### PR DESCRIPTION
The output of `launchable record session` is expected to be passed in to `--session` in later commands, and the examples in the documentation suggest that this output should be piped to a file and read back in. This output includes a newline character, which makes working with it annoying: you need to ensure your shell removes the newline with proper quoting. By removing the newline, we make this easier to work with. For example, it can be read in by a Jenkins `readFile` Pipeline step and then passed through to a shell step without quoting.