### PR TITLE
Support Compatibility Test Suite (cts) profile

### DIFF
--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -1,0 +1,116 @@
+from ast import Dict
+from xml.etree import ElementTree as ET
+
+import click
+
+from launchable.commands.record.case_event import CaseEvent
+
+from . import launchable
+
+
+def build_path(module: str, test_case: str, test: str):
+    return [
+        {"type": "Module", "name": module},
+        {"type": "TestCase", "name": test_case},
+        {"type": "Test", "name": test},
+    ]
+
+
+def parse_func(p: str) -> Dict:
+    """  # noqa: E501
+    # sample report format
+    success case:
+    <Module name="CtsAbiOverrideHostTestCases" abi="arm64-v8a" runtime="1171" done="true" pass="1" total_tests="1">
+      <TestCase name="android.abioverride.cts.AbiOverrideTest">
+        <Test result="pass" name="testAbiIs32bit" />
+      </TestCase>
+    </Module>
+
+    failure case:
+    <Module name="CtsAccountManagerTestCases" abi="arm64-v8a" runtime="13414" done="false" pass="2" total_tests="151">
+      <Reason message="Instrumentation run failed due to 'Process crashed.'" error_name="INSTRUMENTATION_CRASH" error_code="520200" />
+      <TestCase name="android.accounts.cts.AbstractAuthenticatorTests">
+        <Test result="fail" name="testFinishSessionAndStartAddAccountSessionDefaultImpl">
+          <Failure message="android.accounts.OperationCanceledException&#13;">
+            <StackTrace>android.accounts.OperationCanceledException
+          at android.accounts.AccountManager$AmsTask.internalGetResult(AccountManager.java:2393)
+          at android.accounts.AccountManager$AmsTask.getResult(AccountManager.java:2422)
+          at android.accounts.AccountManager$AmsTask.getResult(AccountManager.java:2337)
+          at android.accounts.cts.AbstractAuthenticatorTests.testFinishSessionAndStartAddAccountSessionDefaultImpl(AbstractAuthenticatorTests.java:165)
+            </StackTrace>
+          </Failure>
+        </Test>
+      </TestCase>
+    </Module>
+    """
+    events = []
+    tree = ET.parse(p)
+
+    for module in tree.iter('Module'):
+        test_results = []
+        total_duration = module.get("runtime")
+        module_name = module.get("name")
+
+        for test_case in module.iter("TestCase"):
+            test_case_name = test_case.get('name')
+
+            for test in test_case.iter("Test"):
+                result = test.get('result')
+                test_name = test.get("name")
+                stdout = ""
+                stderr = ""
+
+                failure = test.find('Failure')
+                if failure:
+                    stack_trace = failure.find("StackTrace").text if failure.find("StackTrace") is not None else ""
+
+                    stdout = failure.get("message")
+                    stderr = stack_trace
+
+                test_results.append({
+                    "test_case_name": test_case_name,
+                    "test_name": test_name,
+                    "result": result,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                })
+
+        if len(test_results) == 0:
+            continue
+
+        test_duration_msec_per_test = int(total_duration) / len(test_results)
+
+        for result in test_results:
+            status = CaseEvent.TEST_PASSED
+            if result.get("result") == "fail":
+                status = CaseEvent.TEST_FAILED
+            elif result.get("result") == "ASSUMPTION_FAILURE" or result.get("result") == "IGNORED":
+                status = CaseEvent.TEST_SKIPPED
+
+            events.append(CaseEvent.create(
+                test_path=build_path(module_name, result.get("test_case_name"), result.get("test_name")),
+                duration_secs=float(test_duration_msec_per_test / 1000),
+                status=status,
+                stdout=result.get("stdout"),
+                stderr=result.get("stderr"),
+            ))
+
+    return (x for x in events)
+
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    for r in reports:
+        client.report(r)
+
+    client.parse_func = parse_func
+    client.run()
+
+
+@launchable.subset
+def subset(client):
+
+    print("subset")
+
+    return

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -159,8 +159,9 @@ def subset(client):
         if not start_module:
             continue
 
-        lines = t.rstrip("\n").split()
-        if len(lines) != 2:
+        # e.g) armeabi-v7a CtsAbiOverrideHostTestCases
+        device_and_module = t.rstrip("\n").split()
+        if len(device_and_module) != 2:
             click.echo(
                 click.style(
                     "Warning: {line} is not expected Module format and skipped".format(
@@ -168,7 +169,8 @@ def subset(client):
                     fg="yellow"),
                 err=True)
             continue
-        client.test_path([{"type": "Module", "name": lines[1]}])
+
+        client.test_path([{"type": "Module", "name": device_and_module[1]}])
 
     option = include_option
     if client.is_output_exclusion_rules:

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -1,4 +1,3 @@
-import sys
 from ast import Dict
 from xml.etree import ElementTree as ET
 
@@ -117,7 +116,7 @@ def subset(client):
             "ERROR: cts profile supports only Zero Input Subsetting (ZIS). Please use `--get-tests-from-previous-sessions` option for subsetting",  # noqa E501
             fg="red"),
             err=True)
-        sys.exist(1)
+        exit(1)
 
     include_option = "--include-filter"
     exclude_option = "--exclude-filter"

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -102,6 +102,9 @@ def parse_func(p: str) -> Dict:
 @click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, reports):
+    """
+    Beta: Report test result that Compatibility Test Suite (CTS) produced
+    """
     for r in reports:
         client.report(r)
 
@@ -111,6 +114,9 @@ def record_tests(client, reports):
 
 @launchable.subset
 def subset(client):
+    """
+    Beta: Produces test list from previous test sessions for Compatibility Test Suite (CTS)
+    """
     if not client.is_get_tests_from_previous_sessions:
         click.echo(click.style(
             "ERROR: cts profile supports only Zero Input Subsetting (ZIS). Please use `--get-tests-from-previous-sessions` option for subsetting",  # noqa E501

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -1,5 +1,3 @@
-
-from typing import List
 from xml.etree import ElementTree as ET
 
 import click
@@ -65,7 +63,7 @@ def parse_func(p: str):
     tree = ET.parse(p)
 
     for module in tree.iter('Module'):
-        test_results: List[TestResult] = []
+        test_results = []
         total_duration = module.get("runtime", "0")
         module_name = module.get("name", "")
 

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -136,7 +136,7 @@ def subset(client):
     start_module = False
 
     """ # noqa: E501
-    # This is sample output for `cts-tf > list modules`
+    # This is sample output of `cts-tradefed list modules`
     ==================
     Notice:
     We collect anonymous usage statistics in accordance with our Content Licenses (https://source.android.com/setup/start/licenses), Contributor License Agreement (https://opensource.google.com/docs/cla/), Privacy Policy (https://policies.google.com/privacy) and Terms of Service (https://policies.google.com/terms).

--- a/launchable/test_runners/cts.py
+++ b/launchable/test_runners/cts.py
@@ -119,7 +119,7 @@ def parse_func(p: str):
 @launchable.record.tests
 def record_tests(client, reports):
     """
-    Beta: Report test result that Compatibility Test Suite (CTS) produced
+    Beta: Report test result that Compatibility Test Suite (CTS) produced. Supports only CTS v2
     """
     for r in reports:
         client.report(r)
@@ -131,7 +131,7 @@ def record_tests(client, reports):
 @launchable.subset
 def subset(client):
     """
-    Beta: Produces test list from previous test sessions for Compatibility Test Suite (CTS)
+    Beta: Produces test list from previous test sessions for Compatibility Test Suite (CTS). Supports only CTS v2
     """
     start_module = False
 

--- a/tests/data/cts/record_test_result.json
+++ b/tests/data/cts/record_test_result.json
@@ -1,0 +1,249 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest"
+        },
+        {
+          "type": "Test",
+          "name": "testEmbeddedViewHasCorrectBound"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest"
+        },
+        {
+          "type": "Test",
+          "name": "testEmbeddedViewCanBeFound"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest"
+        },
+        {
+          "type": "Test",
+          "name": "testEmbeddedViewHasCorrectBoundAfterHostViewMove"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest"
+        },
+        {
+          "type": "Test",
+          "name": "testEmbeddedViewCanFindItsHostParent"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest"
+        },
+        {
+          "type": "Test",
+          "name": "testEmbeddedViewIsInvisibleAfterMovingOutOfScreen"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityDragAndDropTest"
+        },
+        {
+          "type": "Test",
+          "name": "testStartDrag_eventSentAndActionsUpdated"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityDragAndDropTest"
+        },
+        {
+          "type": "Test",
+          "name": "testCancelDrag_eventSentAndActionsUpdated"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases[instant]"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityDragAndDropTest"
+        },
+        {
+          "type": "Test",
+          "name": "testDrop_eventSentAndActionsUpdated"
+        }
+      ],
+      "duration": 1.283,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityGlobalActionsTest"
+        },
+        {
+          "type": "Test",
+          "name": "testPerformGlobalActionBack"
+        }
+      ],
+      "duration": 0.01,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityGlobalActionsTest"
+        },
+        {
+          "type": "Test",
+          "name": "testPerformGlobalActionHome"
+        }
+      ],
+      "duration": 0.01,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "Module",
+          "name": "CtsAccessibilityServiceTestCases"
+        },
+        {
+          "type": "TestCase",
+          "name": "android.accessibilityservice.cts.AccessibilityGlobalActionsTest"
+        },
+        {
+          "type": "Test",
+          "name": "testPerformGlobalActionNotifications"
+        }
+      ],
+      "duration": 0.01,
+      "status": 0,
+      "stdout": "java.lang.AssertionError: Unable to reach home screen\r",
+      "stderr": "\n            java.lang.AssertionError: Unable to reach home screen\n            at org.junit.Assert.fail(Assert.java:89)\n            at\n            android.accessibilityservice.cts.utils.ActivityLaunchUtils.homeScreenOrBust(ActivityLaunchUtils.java:161)\n            at\n            android.accessibilityservice.cts.AccessibilityGlobalActionsTest.tearDown(AccessibilityGlobalActionsTest.java:97)\n          ",
+      "data": null
+    }
+  ],
+  "testRunner": "cts",
+  "group": "",
+  "noBuild": false
+}

--- a/tests/data/cts/subset_result.json
+++ b/tests/data/cts/subset_result.json
@@ -1,0 +1,38 @@
+{
+  "testPaths": [
+    [
+      {
+        "type": "Module",
+        "name": "CtsAbiOverrideHostTestCases[instant]"
+      }
+    ],
+    [
+      {
+        "type": "Module",
+        "name": "CtsAbiOverrideHostTestCases[secondary_user]"
+      }
+    ],
+    [
+      {
+        "type": "Module",
+        "name": "CtsAbiOverrideHostTestCases"
+      }
+    ],
+    [
+      {
+        "type": "Module",
+        "name": "CtsAbiOverrideHostTestCases"
+      }
+    ]
+  ],
+  "testRunner": "cts",
+  "session": {
+    "id": "16"
+  },
+  "ignoreNewTests": false,
+  "getTestsFromPreviousSessions": false,
+  "goal": {
+    "type": "subset-by-percentage",
+    "percentage": 0.3
+  }
+}

--- a/tests/data/cts/test_result.xml
+++ b/tests/data/cts/test_result.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?><?xml-stylesheet type="text/xsl" href="compatibility_result.xsl"?>
+<Result start="1680745541059" end="1680745600607" start_display="Thu Apr 06 10:45:41 JST 2023"
+  end_display="Thu Apr 06 10:46:40 JST 2023"
+  suite_name="CTS" suite_variant="CTS" suite_version="12.1_r5" suite_plan="cts"
+  suite_build_number="9566553" report_version="5.0" devices="emulator-5554"
+  host_name="ip-192-168-68-65.us-west-2.compute.internal" os_name="Mac OS X" os_version="13.1"
+  os_arch="aarch64" java_vendor="Eclipse Adoptium" java_version="11.0.17">
+
+  <Summary pass="8" failed="0" modules_done="1" modules_total="1" />
+  <Module name="CtsAccessibilityServiceTestCases[instant]" abi="arm64-v8a" runtime="10264"
+    done="true" pass="8" total_tests="8">
+    <TestCase name="android.accessibilityservice.cts.AccessibilityEmbeddedHierarchyTest">
+      <Test result="pass" name="testEmbeddedViewHasCorrectBound" />
+      <Test result="pass" name="testEmbeddedViewCanBeFound" />
+      <Test result="pass" name="testEmbeddedViewHasCorrectBoundAfterHostViewMove" />
+      <Test result="pass" name="testEmbeddedViewCanFindItsHostParent" />
+      <Test result="pass" name="testEmbeddedViewIsInvisibleAfterMovingOutOfScreen" />
+    </TestCase>
+    <TestCase name="android.accessibilityservice.cts.AccessibilityDragAndDropTest">
+      <Test result="pass" name="testStartDrag_eventSentAndActionsUpdated" />
+      <Test result="pass" name="testCancelDrag_eventSentAndActionsUpdated" />
+      <Test result="pass" name="testDrop_eventSentAndActionsUpdated" />
+    </TestCase>
+  </Module>
+  <Module name="CtsAccessibilityServiceTestCases" abi="arm64-v8a" runtime="30" done="true"
+    pass="2" total_tests="3">
+    <TestCase name="android.accessibilityservice.cts.AccessibilityGlobalActionsTest">
+      <Test result="pass" name="testPerformGlobalActionBack" />
+      <Test result="pass" name="testPerformGlobalActionHome" />
+      <Test result="fail" name="testPerformGlobalActionNotifications">
+        <Failure message="java.lang.AssertionError: Unable to reach home screen&#13;">
+          <StackTrace>
+            java.lang.AssertionError: Unable to reach home screen
+            at org.junit.Assert.fail(Assert.java:89)
+            at
+            android.accessibilityservice.cts.utils.ActivityLaunchUtils.homeScreenOrBust(ActivityLaunchUtils.java:161)
+            at
+            android.accessibilityservice.cts.AccessibilityGlobalActionsTest.tearDown(AccessibilityGlobalActionsTest.java:97)
+          </StackTrace>
+        </Failure>
+      </Test>
+    </TestCase>
+  </Module>
+</Result>

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -1,0 +1,92 @@
+import gzip
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import responses
+
+from launchable.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class CtsTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/cts/').resolve()
+    result_file_path = test_files_dir.joinpath('record_test_result.json')
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset(self):
+        # cts is required using `--get-tests-from-previous-sessions` option
+        result = self.cli("subset", "--target", "30%", "--session", self.session, "cts")
+        self.assertEqual(result.exit_code, 1)
+
+        mock_response = {
+            "testPaths": [
+                [{"type": "Module", "name": "Cts1"}, {"type": "TestCase", "name": "android.example.package1"}],
+                [{"type": "Module", "name": "Cts2"}, {"type": "TestCase", "name": "android.example.package2"}],
+            ],
+            "testRunner": "cts",
+            "rest": [
+                [{"type": "Module", "name": "Cts3"}, {"type": "TestCase", "name": "android.example.package3"}],
+                [{"type": "Module", "name": "Cts4"}, {"type": "TestCase", "name": "android.example.package4"}],
+                [{"type": "Module", "name": "Cts5"}, {"type": "TestCase", "name": "android.example.package5"}],
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 30, "candidates": 2, "rate": 30},
+                "rest": {"duration": 70, "candidates": 3, "rate": 70}
+            },
+            "isObservation": False,
+        }
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_response,
+            status=200)
+
+        result = self.cli(
+            "subset",
+            "--target",
+            "30%",
+            "--session",
+            self.session,
+            "--get-tests-from-previous-sessions",
+            "cts",
+            mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.stdout,
+                         '--include-filter "Cts1 android.example.package1" --include-filter "Cts2 android.example.package2"\n')
+
+        result = self.cli(
+            "subset",
+            "--target",
+            "30%",
+            "--session",
+            self.session,
+            "--get-tests-from-previous-sessions",
+            "--output-exclusion-rules",
+            "cts",
+            mix_stderr=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.stdout,
+            '--exclude-filter "Cts3 android.example.package3" --exclude-filter "Cts4 android.example.package4" --exclude-filter "Cts5 android.example.package5"\n')  # noqa E501
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_tests(self):
+        result = self.cli('record', 'tests', '--session', self.session,
+                          'cts', str(self.test_files_dir) + "/test_result.xml")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        for e in payload["events"]:
+            e.pop("created_at", "")
+
+        expected = self.load_json_from_file(self.result_file_path)
+        self.assert_json_orderless_equal(expected, payload)

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -13,29 +13,41 @@ from tests.cli_test_case import CliTestCase
 class CtsTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/cts/').resolve()
     result_file_path = test_files_dir.joinpath('record_test_result.json')
+    subset_result_test_path = test_files_dir.joinpath('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):
-        # cts is required using `--get-tests-from-previous-sessions` option
-        result = self.cli("subset", "--target", "30%", "--session", self.session, "cts")
-        self.assertEqual(result.exit_code, 1)
+        pipe = """ # noqa: E501
+==================
+Notice:
+We collect anonymous usage statistics in accordance with our Content Licenses (https://source.android.com/setup/start/licenses), Contributor License Agreement (https://opensource.google.com/docs/cla/), Privacy Policy (https://policies.google.com/privacy) and Terms of Service (https://policies.google.com/terms).
+==================
+Android Compatibility Test Suite 12.1_r5 (9566553)
+Use "help" or "help all" to get more information on running commands.
+Non-interactive mode: Running initial command then exiting.
+Using commandline arguments as starting command: [list, modules]
+arm64-v8a CtsAbiOverrideHostTestCases[instant]
+arm64-v8a CtsAbiOverrideHostTestCases[secondary_user]
+arm64-v8a CtsAbiOverrideHostTestCases
+armeabi-v7a CtsAbiOverrideHostTestCases
+        """
 
         mock_response = {
             "testPaths": [
-                [{"type": "Module", "name": "Cts1"}, {"type": "TestCase", "name": "android.example.package1"}],
-                [{"type": "Module", "name": "Cts2"}, {"type": "TestCase", "name": "android.example.package2"}],
+                [{"type": "Module", "name": "CtsAbiOverrideHostTestCases[instant]"}],
+                [{"type": "Module", "name": "CtsAbiOverrideHostTestCases"}],
+
             ],
             "testRunner": "cts",
             "rest": [
-                [{"type": "Module", "name": "Cts3"}, {"type": "TestCase", "name": "android.example.package3"}],
-                [{"type": "Module", "name": "Cts4"}, {"type": "TestCase", "name": "android.example.package4"}],
-                [{"type": "Module", "name": "Cts5"}, {"type": "TestCase", "name": "android.example.package5"}],
+                [{"type": "Module", "name": "CtsAbiOverrideHostTestCases[secondary_user]"}],
+                [{"type": "Module", "name": "CtsAbiOverrideHostTestCases"}],
             ],
             "subsettingId": 123,
             "summary": {
                 "subset": {"duration": 30, "candidates": 2, "rate": 30},
-                "rest": {"duration": 70, "candidates": 3, "rate": 70}
+                "rest": {"duration": 70, "candidates": 2, "rate": 70}
             },
             "isObservation": False,
         }
@@ -53,13 +65,15 @@ class CtsTest(CliTestCase):
             "30%",
             "--session",
             self.session,
-            "--get-tests-from-previous-sessions",
             "cts",
+            input=pipe,
             mix_stderr=False)
-
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.stdout,
-                         '--include-filter "Cts1 android.example.package1" --include-filter "Cts2 android.example.package2"\n')
+        output = "--include-filter \"CtsAbiOverrideHostTestCases[instant]\"\n--include-filter \"CtsAbiOverrideHostTestCases\"\n"
+        self.assertEqual(output, result.stdout)
+        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
+        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
+        self.assert_json_orderless_equal(expected, payload)
 
         result = self.cli(
             "subset",
@@ -67,15 +81,14 @@ class CtsTest(CliTestCase):
             "30%",
             "--session",
             self.session,
-            "--get-tests-from-previous-sessions",
             "--output-exclusion-rules",
             "cts",
+            input=pipe,
             mix_stderr=False)
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(
-            result.stdout,
-            '--exclude-filter "Cts3 android.example.package3" --exclude-filter "Cts4 android.example.package4" --exclude-filter "Cts5 android.example.package5"\n')  # noqa E501
+        output = "--exclude-filter \"CtsAbiOverrideHostTestCases[secondary_user]\"\n--exclude-filter \"CtsAbiOverrideHostTestCases\"\n"  # noqa: E501
+        self.assertEqual(output, result.stdout)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})


### PR DESCRIPTION
I made a new plugin for Compatibility Test Suite (cts)
https://source.android.com/docs/compatibility

# Usage

## record tests

```sh
$ launchable record build --name <NAME>
$ launchable record session --build <NAME> > session.txt
$ launchable record tests --session $(cat session.txt) cts android-cts/results/2023.04.03.02.01.00/test_result.xml
Launchable recorded tests for build 1680844815 (test session 12345) to workspace example/test from 1 files:

|   Files found |   Tests found |   Tests passed |   Tests failed |   Total duration (min) |
|---------------|---------------|----------------|----------------|------------------------|
|             1 |           766 |            481 |            281 |                  12.74 |
```

## subset

Launchable supports `class` level subset. However, `cts` command cannot list the target test classes. 
So, cts profile requires using `--get-tests-from-previous-sessions` and `--output-exclusion-rules` options.

```sh
$ launchable record build --name <NAME>
$ launchable record session --build <NAME> > session.txt
$ /tools/cts-tradefed list modules |  launchable subset --session $(cat session.txt) --target 80% cts > launchable-subset.txt
$ cat ./launchable-subset.txt | xargs ./tools/cts-tradefed run cts 
```