### PR TITLE
Fix documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Usage
 
-See https://docs.launchableinc.com/cli-reference and
-https://docs.launchableinc.com/getting-started.
+See https://www.launchableinc.com/docs/resources/cli-reference/ and
+https://www.launchableinc.com/docs/getting-started/.
 
 # Development
 


### PR DESCRIPTION
The "Getting started" link was correctly redirected, but the CLI reference one was returning a 404 error.

This PR fixes them.