### PR TITLE
change git status name to allign jgit.diff.DiffEntity.ChangeType

### DIFF
--- a/launchable/utils/commit_ingester.py
+++ b/launchable/utils/commit_ingester.py
@@ -25,7 +25,7 @@ def _convert_git_commit(commit: GitCommit) -> Dict:
         cf = dict()
         cf['linesAdded'] = changed_file.added
         cf['linesDeleted'] = changed_file.deleted
-        cf['status'] = 'M'
+        cf['status'] = 'MODIFY'
         cf['path'] = changed_file.path
         cf['pathTo'] = changed_file.path
         changed_files.append(cf)


### PR DESCRIPTION
When we collect git commit logs use by exec.jar, then the status will be `MODIFY`. So, I changed the status to align it when the user collecting using the  `launchable record commit` with `--import-git-log-output` option

![image](https://github.com/launchableinc/cli/assets/536667/55b021a7-11f4-49c2-82d7-2f5f88515154)

https://javadoc.io/doc/org.eclipse.jgit/org.eclipse.jgit/5.13.1.202206130422-r/index.html