### PR TITLE
Supports dotnet profile

### DIFF
--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -1,0 +1,11 @@
+from launchable.test_runners import launchable
+
+
+@launchable.subset
+def subset(client):
+    print("hi")
+
+
+@launchable.record.tests
+def record_tests(client):
+    print("hi")

--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -39,9 +39,9 @@ def subset(client):
     def exclusion_output_handler(subset_tests: List[TestPath], rest_tests: List[TestPath]):
         if client.rest:
             with open(client.rest, "w+", encoding="utf-8") as fp:
-                fp.write(client.separator.join(formatter(t) for t in rest_tests))
+                fp.write(client.separator.join(formatter(t) for t in subset_tests))
 
-        click.echo(client.separator.join(formatter(t) for t in subset_tests))
+        click.echo(client.separator.join(formatter(t) for t in rest_tests))
 
     client.separator = separator
     client.formatter = formatter

--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -32,7 +32,7 @@ def subset(client):
             t = path.get("type", "")
             if t == 'Assembly':
                 continue
-            paths.append(path.get("name"))
+            paths.append(path.get("name", ""))
 
         return prefix + ".".join(paths)
 

--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -11,6 +11,9 @@ from launchable.testpath import TestPath
 
 @launchable.subset
 def subset(client):
+    """
+    Alpha: Supports only Zero Input Subsetting
+    """
     if not client.is_get_tests_from_previous_sessions:
         click.echo(
             click.style(
@@ -18,6 +21,7 @@ def subset(client):
                 fg="red"),
             err=True)
 
+    # ref: https://github.com/Microsoft/vstest-docs/blob/main/docs/filter.md
     separator = "|"
     prefix = "FullyQualifiedName="
 
@@ -52,7 +56,9 @@ def subset(client):
 @click.argument('files', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, files):
-    # TODO: copied from ctest -- promote this pattern
+    """
+    Alpha: Supports only NUnit report formats.
+    """
     for file in files:
         match = False
         for t in glob.iglob(file, recursive=True):

--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -1,11 +1,70 @@
+import glob
+import os
+from typing import List
+
+import click
+
 from launchable.test_runners import launchable
+from launchable.test_runners.nunit import nunit_parse_func
+from launchable.testpath import TestPath
 
 
 @launchable.subset
 def subset(client):
-    print("hi")
+    if not client.is_get_tests_from_previous_sessions:
+        click.echo(
+            click.style(
+                "The dotnet profile only supports Zero Input Subsetting.\nMake sure to use `--get-tests-from-previous-sessions` opton",  # noqa: E501
+                fg="red"),
+            err=True)
+
+    separator = "|"
+    prefix = "FullyQualifiedName="
+
+    if client.is_output_exclusion_rules:
+        separator = "&"
+        prefix = "FullyQualifiedName!="
+
+    def formatter(test_path: TestPath):
+        paths = []
+
+        for path in test_path:
+            t = path.get("type", "")
+            if t == 'Assembly':
+                continue
+            paths.append(path.get("name"))
+
+        return prefix + ".".join(paths)
+
+    def exclusion_output_handler(subset_tests: List[TestPath], rest_tests: List[TestPath]):
+        if client.rest:
+            with open(client.rest, "w+", encoding="utf-8") as fp:
+                fp.write(client.separator.join(formatter(t) for t in rest_tests))
+
+        click.echo(client.separator.join(formatter(t) for t in subset_tests))
+
+    client.separator = separator
+    client.formatter = formatter
+    client.exclusion_output_handler = exclusion_output_handler
+    client.run()
 
 
+@click.argument('files', required=True, nargs=-1)
 @launchable.record.tests
-def record_tests(client):
-    print("hi")
+def record_tests(client, files):
+    # TODO: copied from ctest -- promote this pattern
+    for file in files:
+        match = False
+        for t in glob.iglob(file, recursive=True):
+            match = True
+            if os.path.isdir(t):
+                client.scan(t, "*.xml")
+            else:
+                client.report(t)
+        if not match:
+            click.echo("No matches found: {}".format(file), err=True)
+
+    # Note: we support only Nunit test report format now.
+    # If we need to support another format e.g) JUnit, trc, then we'll add a option
+    client.parse_func = nunit_parse_func
+    client.run()

--- a/tests/data/dotnet/record_test_result.json
+++ b/tests/data/dotnet/record_test_result.json
@@ -1,0 +1,115 @@
+{
+    "events": [
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "Assembly",
+                    "name": "rocket-car-dotnet.dll"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "rocket_car_dotnet"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "ExampleTest"
+                },
+                {
+                    "type": "TestCase",
+                    "name": "TestAdd"
+                }
+            ],
+            "duration": 0.006132,
+            "status": 1,
+            "stdout": "",
+            "stderr": "",
+            "created_at": "2023-05-15T 08:22:02Z",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "Assembly",
+                    "name": "rocket-car-dotnet.dll"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "rocket_car_dotnet"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "ExampleTest"
+                },
+                {
+                    "type": "TestCase",
+                    "name": "TestDiv"
+                }
+            ],
+            "duration": 0.016795,
+            "status": 0,
+            "stdout": "",
+            "stderr": "",
+            "created_at": "2023-05-15T 08:22:02Z",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "Assembly",
+                    "name": "rocket-car-dotnet.dll"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "rocket_car_dotnet"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "ExampleTest"
+                },
+                {
+                    "type": "TestCase",
+                    "name": "TestMul"
+                }
+            ],
+            "duration": 0.0003959,
+            "status": 0,
+            "stdout": "",
+            "stderr": "",
+            "created_at": "2023-05-15T 08:22:02Z",
+            "data": null
+        },
+        {
+            "type": "case",
+            "testPath": [
+                {
+                    "type": "Assembly",
+                    "name": "rocket-car-dotnet.dll"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "rocket_car_dotnet"
+                },
+                {
+                    "type": "TestSuite",
+                    "name": "ExampleTest"
+                },
+                {
+                    "type": "TestCase",
+                    "name": "TestSub"
+                }
+            ],
+            "duration": 0.000308,
+            "status": 0,
+            "stdout": "",
+            "stderr": "",
+            "created_at": "2023-05-15T 08:22:02Z",
+            "data": null
+        }
+    ],
+    "testRunner": "dotnet",
+    "group": "",
+    "noBuild": false
+}

--- a/tests/data/dotnet/test-result.xml
+++ b/tests/data/dotnet/test-result.xml
@@ -1,0 +1,37 @@
+<test-run id="2" duration="0.023630900000000003" testcasecount="4" total="4" passed="1" failed="3" inconclusive="0" skipped="0" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z">
+  <test-suite type="Assembly" name="rocket-car-dotnet.dll" fullname="/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/bin/Debug/net7.0/rocket-car-dotnet.dll" total="4" passed="1" failed="3" inconclusive="0" skipped="0" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.0236309">
+    <test-suite type="TestSuite" name="rocket_car_dotnet" fullname="rocket_car_dotnet" total="4" passed="1" failed="3" inconclusive="0" skipped="0" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.0236309">
+      <test-suite type="TestFixture" name="ExampleTest" fullname="rocket_car_dotnet.ExampleTest" total="4" passed="1" failed="3" inconclusive="0" skipped="0" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.0236309">
+        <test-case name="TestAdd" fullname="rocket_car_dotnet.ExampleTest.TestAdd" methodname="TestAdd" classname="ExampleTest" result="Passed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.006132" asserts="0" />
+        <test-case name="TestDiv" fullname="rocket_car_dotnet.ExampleTest.TestDiv" methodname="TestDiv" classname="ExampleTest" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.016795" asserts="0">
+          <failure>
+            <message>  Expected: 0.5d
+  But was:  0
+</message>
+            <stack-trace>   at rocket_car_dotnet.ExampleTest.TestDiv() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 35
+</stack-trace>
+          </failure>
+        </test-case>
+        <test-case name="TestMul" fullname="rocket_car_dotnet.ExampleTest.TestMul" methodname="TestMul" classname="ExampleTest" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.0003959" asserts="0">
+          <failure>
+            <message>  Expected: 10
+  But was:  25
+</message>
+            <stack-trace>   at rocket_car_dotnet.ExampleTest.TestMul() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 28
+</stack-trace>
+          </failure>
+        </test-case>
+        <test-case name="TestSub" fullname="rocket_car_dotnet.ExampleTest.TestSub" methodname="TestSub" classname="ExampleTest" result="Failed" start-time="2023-05-15T 08:22:02Z" end-time="2023-05-15T 08:22:02Z" duration="0.000308" asserts="0">
+          <failure>
+            <message>  Expected: 2
+  But was:  6
+</message>
+            <stack-trace>   at rocket_car_dotnet.ExampleTest.TestSub() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 21
+</stack-trace>
+          </failure>
+        </test-case>
+      </test-suite>
+    </test-suite>
+    <errors />
+  </test-suite>
+</test-run>

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -1,0 +1,89 @@
+import os
+from unittest import mock
+
+import responses  # type: ignore
+
+from launchable.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class DotnetTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset(self):
+        mock_response = {
+            "testPaths": [
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestSub"},
+                ],
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestMul"},
+                ],
+            ],
+            "rest": [
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestAdd"},
+                ],
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestDiv"},
+                ],
+            ],
+            "testRunner": "dotnet",
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 25, "candidates": 1, "rate": 25},
+                "rest": {"duration": 78, "candidates": 3, "rate": 75}
+            },
+            "isObservation": False,
+        }
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_response,
+            status=200)
+
+        # dotnet profiles requires Zero Input Subsetting
+        result = self.cli('subset', '--target', '25%', '--session', self.session, 'dotnet')
+        self.assertEqual(result.exit_code, 1)
+
+        result = self.cli(
+            'subset',
+            '--target',
+            '25%',
+            '--session',
+            self.session,
+            '--get-tests-from-previous-sessions',
+            'dotnet',
+            mix_stderr=False)
+        self.assertEqual(result.exit_code, 0)
+
+        output = "FullyQualifiedName=rocket_car_dotnet.ExampleTest.TestSub|FullyQualifiedName=rocket_car_dotnet.ExampleTest.TestMul\n"  # noqa: E501
+        self.assertEqual(result.output, output)
+
+        result = self.cli(
+            'subset',
+            '--target',
+            '25%',
+            '--session',
+            self.session,
+            '--get-tests-from-previous-sessions',
+            '--output-exclusion-rules',
+            'dotnet',
+            mix_stderr=False)
+        self.assertEqual(result.exit_code, 0)
+        output = "FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd&FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestDiv\n"  # noqa: E501
+        self.assertEqual(result.output, output)


### PR DESCRIPTION
# Usage

```
# record tests
$ launchable record tests dotnet **/*.xml

# subet
$ launchable subset --target 25% --get-tests-from-previous-sessions --output-exclusion-rules dotnet > subset.txt
$ cat subset.txt FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd&FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestSub&FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestDiv

$ dotnet test --filter $(cat subset.txt)
```

## Note

We collect NUnit test reports like below

```
 Assembly=rocket-car-dotnet.dll#TestSuite=rocket_car_dotnet#TestSuite=ExampleTest#TestCase=TestSub
 Assembly=rocket-car-dotnet.dll#TestSuite=rocket_car_dotnet#TestSuite=ExampleTest#TestCase=TestMul
 Assembly=rocket-car-dotnet.dll#TestSuite=rocket_car_dotnet#TestSuite=ExampleTest#TestCase=TestDiv
 Assembly=rocket-car-dotnet.dll#TestSuite=rocket_car_dotnet#TestSuite=ExampleTest#TestCase=TestAdd
```

However, `dotnet test -t --  NUnit.DisplayName=FullNameSep` will produce like below

```
$ dotnet test -t  -- NUnit.DisplayName=FullNameSep
...
The following Tests are available:
    rocket_car_dotnet:ExampleTest:TestAdd
    rocket_car_dotnet:ExampleTest:TestDiv
    rocket_car_dotnet:ExampleTest:TestMul
    rocket_car_dotnet:ExampleTest:TestSub
```

It means that it's difficult to map test paths of record tests and test paths of subset. So, we’ll suport only Zero Input Subsetting, for now.