### PR TITLE
Removing WMI dependency.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     more_itertools>=7.1.0;python_version>='3.6'
 # more_itertools dropped python 3.5 support since v8.6
     more_itertools>=7.1.0,<8.6;python_version<'3.6'
-    wmi;platform_system=='Windows'
     python-dateutil
     tabulate
 python_requires = >=3.5


### PR DESCRIPTION
WMI is built on top of COM, and we suspect this is causing CoInitializeEx error on Windows nanoserver docker image:

```
python.exe -m launchable --version
 pythoncom error: CoInitializeEx failed (0x80004001)
 pythoncom error: OLE initialization failed! (0x80004005)
 launchable-cli, version 1.63.0
```