### PR TITLE
Add --output-exclusion-rules support to split-subset

### DIFF
--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -65,7 +65,7 @@ class SplitSubsetTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "test_1.py\ntest_3.py\ntest_5.py\n")
-        self.assertEqual(observation_mode_rest.read().decode(), os.linesep.join(["test_5.py"]))
+        self.assertEqual(observation_mode_rest.read().decode(), "")
         observation_mode_rest.close()
         os.unlink(observation_mode_rest.name)
 

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -8,6 +8,7 @@ import responses  # type: ignore
 
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
+from tests.helper import ignore_warnings
 
 
 class DotnetTest(CliTestCase):
@@ -91,6 +92,55 @@ class DotnetTest(CliTestCase):
             mix_stderr=False)
         self.assertEqual(result.exit_code, 0)
         output = "FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd&FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestDiv\n"  # noqa: E501
+        self.assertEqual(result.output, output)
+
+    @ignore_warnings
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_split_subset(self):
+        responses.replace(
+            responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset/456/slice".format(
+                get_base_url(), self.organization, self.workspace), json={
+                "testPaths": [
+                    [
+                        {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                        {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                        {"type": "TestSuite", "name": "ExampleTest"},
+                        {"type": "TestCase", "name": "TestSub"},
+                    ],
+                ],
+                "rest": [
+                    [
+                        {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                        {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                        {"type": "TestSuite", "name": "ExampleTest"},
+                        {"type": "TestCase", "name": "TestAdd"},
+                    ],
+                ],
+                'subsettingId': 456,
+                'summary': {
+                    'subset': {
+                        'duration': 8, 'candidates': 1, 'rate': 50,
+                    },
+                    'rest': {
+                        'duration': 7, 'candidates': 1, 'rate': 50,
+                    },
+                },
+            },
+            status=200)
+
+        result = self.cli('split-subset', '--subset-id', 'subset/456',
+                          '--bin', '1/2', 'dotnet')
+
+        self.assertEqual(result.exit_code, 0)
+
+        output = "FullyQualifiedName=rocket_car_dotnet.ExampleTest.TestSub\n"  # noqa: E501
+        self.assertEqual(result.output, output)
+
+        result = self.cli('split-subset', '--subset-id', 'subset/456',
+                          '--bin', '1/2', '--output-exclusion-rules', 'dotnet')
+        self.assertEqual(result.exit_code, 0)
+        output = "FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd\n"  # noqa: E501
         self.assertEqual(result.output, output)
 
     @responses.activate

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -134,6 +134,6 @@ class MinitestTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
         output = Path(self.test_files_dir, "test", "example_test.rb")
         self.assertEqual(str(output), result.output.rstrip("\n"))
-        self.assertEqual(rest.read().decode().rstrip("\n"), str(output))
+        self.assertEqual(rest.read().decode().rstrip("\n"), "")
         rest.close()
         os.unlink(rest.name)


### PR DESCRIPTION
* Add `--output-exclusion-rules` support to split-subset
* Allow split-subset to output empty rest files (like regular subset)
* Add split-subset support to dotnet profile