### PR TITLE
collect branch name

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -115,23 +115,24 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
             fg='yellow'), err=True)
 
     sources = []
-    branch_map = {}
+    branch_name_map = {}
     if detect_sources:
         try:
-            for name, repo_dist in repos:
+            for repo_name, repo_dist in repos:
                 hash = subprocess.check_output("git rev-parse HEAD".split(), cwd=repo_dist).decode().replace("\n", "")
-                sources.append((name, repo_dist, hash))
+                sources.append((repo_name, repo_dist, hash))
 
-                branch = None
+                branch_name = None
                 try:
-                    branch = subprocess.check_output(
+                    # TODO: Sometimes cannot get an actual branch name on GitHub Actions. Need to improve this method
+                    branch_name = subprocess.check_output(
                         "git rev-parse --abbrev-ref HEAD".split(),
                         cwd=repo_dist).decode().replace(
                         "\n", "")
                 except Exception:
-                    branch = ""
+                    branch_name = ""
 
-                branch_map[name] = branch
+                branch_name_map[repo_name] = branch_name
 
         except Exception as e:
             click.echo(
@@ -187,7 +188,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         commitHashes = [{
             'repositoryName': name,
             'commitHash': commit_hash,
-            'branchName': branch_map.get(name, "")
+            'branchName': branch_name_map.get(name, "")
         } for name, _, commit_hash in uniq_submodules]
 
         if not (commitHashes[0]['repositoryName'] and commitHashes[0]['commitHash']):

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -20,15 +20,16 @@ class BuildTest(CliTestCase):
         mock_check_output.side_effect = [
             # the first call is git rev-parse HEAD
             ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2').encode(),
-            # the second call is git submodule status --recursive
+            # the second call is git rev-parse --abbrev-ref HEAD
+            ('main').encode(),
+            # the third call is git submodule status --recursive
             (
                 ' 491e03096e2234dab9a9533da714fb6eff5dcaa7 foo (v1.51.0-560-g491e030)\n'
                 ' 8bccab48338219e73c3118ad71c8c98fbd32a4be bar-zot (v1.32.0-516-g8bccab4)\n'
-            ).encode()
+            ).encode(),
         ]
 
         self.assertEqual(read_build(), None)
-
         result = self.cli("record", "build", "--no-commit-collection", "--name", self.build_name)
         self.assertEqual(result.exit_code, 0)
 
@@ -42,15 +43,18 @@ class BuildTest(CliTestCase):
                 "commitHashes": [
                     {
                         "repositoryName": ".",
-                        "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
+                        "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
+                        "branchName": "main"
                     },
                     {
                         "repositoryName": "./foo",
-                        "commitHash": "491e03096e2234dab9a9533da714fb6eff5dcaa7"
+                        "commitHash": "491e03096e2234dab9a9533da714fb6eff5dcaa7",
+                        "branchName": ""
                     },
                     {
                         "repositoryName": "./bar-zot",
-                        "commitHash": "8bccab48338219e73c3118ad71c8c98fbd32a4be"
+                        "commitHash": "8bccab48338219e73c3118ad71c8c98fbd32a4be",
+                        "branchName": ""
                     },
                 ],
                 "links": []

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -82,7 +82,8 @@ class BuildTest(CliTestCase):
                 "commitHashes": [
                     {
                         "repositoryName": ".",
-                        "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
+                        "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
+                        "branchName": ""
                     },
                 ],
                 "links": []
@@ -111,7 +112,8 @@ class BuildTest(CliTestCase):
                     "commitHashes": [
                         {
                             "repositoryName": ".",
-                            "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2"
+                            "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
+                            "branchName": "",
                         },
                     ],
                     "links": []


### PR DESCRIPTION
Update to collect git branch names.

However, this method cannot collect the correct branch name in some environments. 
So, I commented it, and I'll fix it another PR

e.g) GitHub Actions

result at local 
![image](https://github.com/launchableinc/cli/assets/536667/e6cd7d3f-d384-4862-b3e4-6a2327e42128)

on GithubAction
![image](https://github.com/launchableinc/cli/assets/536667/4458f865-8f03-4487-8ae5-5b37a9b0a252)

