### PR TITLE
Fix way of collecting git branch names

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-from typing import List, Optional
+from typing import List
 
 import click
 from tabulate import tabulate
@@ -250,34 +250,34 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
     write_build(build_name)
 
 
-def _get_branch_name(repo_dist: str) -> Optional[str]:
+def _get_branch_name(repo_dist: str) -> str:
 
     # Jenkins
     # ref:
     # https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/Complete-Jenkins-Git-environment-variables-list-for-batch-jobs-and-shell-script-builds
     if os.environ.get(JENKINS_URL_KEY):
         if os.environ.get(JENKINS_GIT_BRANCH_KEY):
-            return os.environ.get(JENKINS_GIT_BRANCH_KEY)
-        elif os.environ.get(JENKINS_GIT_LOCAL_BRANCH_KEY):
-            return os.environ.get(JENKINS_GIT_LOCAL_BRANCH_KEY)
+            return os.environ[JENKINS_GIT_BRANCH_KEY]
+        elif os.environ[JENKINS_GIT_LOCAL_BRANCH_KEY]:
+            return os.environ[JENKINS_GIT_LOCAL_BRANCH_KEY]
     # Github Actions
     # ref: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
     if os.environ.get(GITHUB_ACTIONS_KEY):
         if os.environ.get(GITHUB_ACTIONS_GITHUB_HEAD_REF_KEY):
-            return os.environ.get(GITHUB_ACTIONS_GITHUB_HEAD_REF_KEY)
+            return os.environ[GITHUB_ACTIONS_GITHUB_HEAD_REF_KEY]
         elif os.environ.get(GITHUB_ACTIONS_GITHUB_BASE_REF_KEY):
-            return os.environ.get(GITHUB_ACTIONS_GITHUB_BASE_REF_KEY)
+            return os.environ[GITHUB_ACTIONS_GITHUB_BASE_REF_KEY]
     # CircleCI
     # ref: https://circleci.com/docs/variables/
     if os.environ.get(CIRCLECI_KEY):
         if os.environ.get(CIRCLECI_CIRCLE_BRANCH_KEY):
-            return os.environ.get(CIRCLECI_CIRCLE_BRANCH_KEY)
+            return os.environ[CIRCLECI_CIRCLE_BRANCH_KEY]
     # AWS CodeBuild
     # ref: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
     if os.environ.get(CODE_BUILD_BUILD_ID_KEY):
         if os.environ.get(CODE_BUILD_WEBHOOK_HEAD_REF_KEY):
             # refs/head/<branch name>
-            return os.environ.get(CODE_BUILD_WEBHOOK_HEAD_REF_KEY, "").split("/")[-1]
+            return os.environ[CODE_BUILD_WEBHOOK_HEAD_REF_KEY].split("/")[-1]
 
     branch_name = ""
     try:

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -282,13 +282,12 @@ def _get_branch_name(repo_dist: str) -> Optional[str]:
     branch_name = ""
     try:
         refs = subprocess.check_output(
-            "git show-ref | grep '^'$(git rev-parse HEAD)".split(),
-            cwd=repo_dist).decode()
+            "git show-ref | grep '^'$(git rev-parse HEAD)",
+            cwd=repo_dist).decode().split("\n")
         if len(refs) > 0:
             # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
             branch_name = refs[0].split("/")[-1]
     except Exception:
         # cannot get branch name by git command
         pass
-
     return branch_name

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -12,6 +12,7 @@ class BuildTest(CliTestCase):
     # make sure the output of git-submodule is properly parsed
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
     @mock.patch('launchable.utils.subprocess.check_output')
     # to tests on GitHub Actions
     @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -22,7 +22,7 @@ class BuildTest(CliTestCase):
             # the first call is git rev-parse HEAD
             ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2').encode(),
             # the second call is git rev-parse --abbrev-ref HEAD
-            ('main').encode(),
+            ('ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/head/main\ned6de84bde58d51deebe90e01ddfa5fa78899b1c refs/remotes/origin/main\n').encode(),  # noqa: E501
             # the third call is git submodule status --recursive
             (
                 ' 491e03096e2234dab9a9533da714fb6eff5dcaa7 foo (v1.51.0-560-g491e030)\n'


### PR DESCRIPTION
We used `git rev-parse --abbrev-ref HEAD` to collect a git branch name. However, in detached HEAD case, this command couldn't get a collect branch name and got `HEAD`.  e.g) https://stackoverflow.com/questions/6059336/how-to-find-the-current-git-branch-in-detached-head-state

So, we changed to use environment variables that each CI provider provides and `git show-ref | grep '^'$(git rev-parse HEAD)`