### PR TITLE
fix prove test report

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -119,10 +119,14 @@ class CaseEvent:
             return stderr
 
         return CaseEvent.create(
-            path_canonicalizer(path_builder(case, suite, report_file)), case.time, status,
+            path_canonicalizer(path_builder(case, suite, report_file)),
+            case.time,
+            status,
             stdout(case),
             stderr(case),
-            suite.timestamp, data)
+            suite.timestamp,
+            data,
+        )
 
     @classmethod
     def create(cls, test_path: TestPath, duration_secs: float, status,

--- a/launchable/test_runners/prove.py
+++ b/launchable/test_runners/prove.py
@@ -53,7 +53,8 @@ def record_tests(client, reports):
         # default test path in `subset` expects to have this file name
         test_path = [client.make_file_path_component(filepath)]
         if case.name and case.name != TEARDOWN:
-            test_path.append({"type": "testcase", "name": case.name})
+            case_name = remove_leading_number_and_dash(input_string=case.name)
+            test_path.append({"type": "testcase", "name": case_name})
         return test_path
     client.path_builder = path_builder
 

--- a/launchable/test_runners/prove.py
+++ b/launchable/test_runners/prove.py
@@ -52,10 +52,11 @@ def record_tests(client, reports):
 
         # default test path in `subset` expects to have this file name
         test_path = [client.make_file_path_component(filepath)]
-        if case.name and case.name != TEARDOWN:
+        if case.name:
             case_name = remove_leading_number_and_dash(input_string=case.name)
             test_path.append({"type": "testcase", "name": case_name})
         return test_path
+
     client.path_builder = path_builder
 
     for r in reports:

--- a/tests/data/prove/record_test_result.json
+++ b/tests/data/prove/record_test_result.json
@@ -5,14 +5,14 @@
         "testPath": [
           {
             "type": "file",
-            "name": "t/easy/01_easy.t"
+            "name": "t/00_compile.t"
           },
           {
             "type": "testcase",
-            "name": "a + b = ab"
+            "name": "use Example;"
           }
         ],
-        "duration": 0.153996229171753,
+        "duration": 0.070734977722168,
         "status": 1,
         "stdout": "",
         "stderr": "",
@@ -23,17 +23,35 @@
         "testPath": [
           {
             "type": "file",
-            "name": "t/easy/01_easy.t"
+            "name": "t/fail/01_fail.t"
           },
           {
             "type": "testcase",
-            "name": "str_concat {"
+            "name": "add(1, 2) == 5"
           }
         ],
-        "duration": 0.00043487548828125,
+        "duration": 2.0633590221405,
         "status": 1,
         "stdout": "",
-        "stderr": "",
+        "stderr": "not ok 1 - add(1, 2) == 5\nnot ok 1 - add(1, 2) == 5",
+        "data": null
+      },
+      {
+        "type": "case",
+        "testPath": [
+          {
+            "type": "file",
+            "name": "t/fail/01_fail.t"
+          },
+          {
+            "type": "testcase",
+            "name": "add"
+          }
+        ],
+        "duration": 2.1068799495697,
+        "status": 1,
+        "stdout": "",
+        "stderr": "not ok 2 - add\nnot ok 2 - add",
         "data": null
       },
       {
@@ -48,7 +66,7 @@
             "name": "add(1, 2) == 3"
           }
         ],
-        "duration": 0.0723011493682861,
+        "duration": 2.08377385139465,
         "status": 1,
         "stdout": "",
         "stderr": "",
@@ -66,7 +84,7 @@
             "name": "add"
           }
         ],
-        "duration": 0.000227928161621094,
+        "duration": 4.00751399993896,
         "status": 1,
         "stdout": "",
         "stderr": "",
@@ -84,7 +102,7 @@
             "name": "double"
           }
         ],
-        "duration": 7.91549682617188e-05,
+        "duration": 2.01006603240967,
         "status": 1,
         "stdout": "",
         "stderr": "",
@@ -99,28 +117,10 @@
           },
           {
             "type": "testcase",
-            "name": "double_fail"
+            "name": "add(3, 2) == 5"
           }
         ],
-        "duration": 0.000271081924438477,
-        "status": 0,
-        "stdout": "",
-        "stderr": "not ok 4 - double_fail\nSubtest: double_fail\n    not ok 1 - fail 1 + 2\n    not ok 2 - fail 3 + 2\n    1..2\n",
-        "data": null
-      },
-      {
-        "type": "case",
-        "testPath": [
-          {
-            "type": "file",
-            "name": "t/00_compile.t"
-          },
-          {
-            "type": "testcase",
-            "name": "use Example;"
-          }
-        ],
-        "duration": 0.0674030780792236,
+        "duration": 2.00167012214661,
         "status": 1,
         "stdout": "",
         "stderr": "",

--- a/tests/data/prove/record_test_result.json
+++ b/tests/data/prove/record_test_result.json
@@ -33,7 +33,7 @@
         "duration": 2.0633590221405,
         "status": 0,
         "stdout": "",
-        "stderr": "not ok 1 - add(1, 2) == 5\nnot ok 1 - add(1, 2) == 5",
+        "stderr": "not ok 1 - add(1, 2) == 5\nnot ok 1 - add(1, 2) == 5\n# Subtest: add\n    not ok 1 - 1 + 2\n    1..1",
         "data": null
       },
       {

--- a/tests/data/prove/record_test_result.json
+++ b/tests/data/prove/record_test_result.json
@@ -31,7 +31,7 @@
           }
         ],
         "duration": 2.0633590221405,
-        "status": 1,
+        "status": 0,
         "stdout": "",
         "stderr": "not ok 1 - add(1, 2) == 5\nnot ok 1 - add(1, 2) == 5",
         "data": null
@@ -49,7 +49,7 @@
           }
         ],
         "duration": 2.1068799495697,
-        "status": 1,
+        "status": 0,
         "stdout": "",
         "stderr": "not ok 2 - add\nnot ok 2 - add",
         "data": null

--- a/tests/data/prove/report.xml
+++ b/tests/data/prove/report.xml
@@ -1,19 +1,55 @@
 <?xml version='1.0' encoding='utf-8'?>
 <testsuites>
-  <testsuite name="t/easy/01_easy.t" errors="0" failures="0" skipped="0" tests="2" time="0.157027006149292">
-    <system-out>ok 1 - a + b = ab
-ok 2 - str_concat {
-    ok 1 - a + dddd
-    ok 2 - bb + ccc
-    1..2
-}
-1..2
-</system-out>
-    <testcase name="a + b = ab" classname="t/easy/01_easy.t" time="0.153996229171753" />
-    <testcase name="str_concat {" classname="t/easy/01_easy.t" time="0.00043487548828125" />
+  <testsuite errors="0"
+             failures="0"
+             time="0.0722179412841797"
+             tests="1"
+             name="t/00_compile.t">
+    <testcase time="0.070734977722168" name="1 - use Example;"></testcase>
+    <testcase name="(teardown)" time="0.000190973281860352" />
+    <system-out><![CDATA[ok 1 - use Example;
+1..1
+]]></system-out>
+    <system-err></system-err>
   </testsuite>
-  <testsuite name="t/math/01_math.t" errors="0" failures="1" skipped="0" tests="4" time="0.0786290168762207">
-    <system-out>ok 1 - add(1, 2) == 3
+  <testsuite errors="1"
+             failures="2"
+             tests="2"
+             time="4.17059588432312"
+             name="t/fail/01_fail.t">
+    <testcase name="1 - add(1, 2) == 5" time="2.0633590221405">
+      <failure type="TestFailed"
+               message="not ok 1 - add(1, 2) == 5"><![CDATA[not ok 1 - add(1, 2) == 5
+# Subtest: add
+    not ok 1 - 1 + 2
+    1..1]]></failure>
+    </testcase>
+    <testcase time="2.1068799495697" name="2 - add">
+      <failure type="TestFailed"
+               message="not ok 2 - add"><![CDATA[not ok 2 - add]]></failure>
+    </testcase>
+    <testcase name="(teardown)" time="0.000356912612915039" />
+    <system-out><![CDATA[not ok 1 - add(1, 2) == 5
+# Subtest: add
+    not ok 1 - 1 + 2
+    1..1
+not ok 2 - add
+]]></system-out>
+    <system-err><![CDATA[Dubious, test returned 2 (wstat 512, 0x200)
+]]></system-err>
+    <error message="Dubious, test returned 2 (wstat 512, 0x200)" />
+  </testsuite>
+  <testsuite failures="0"
+             errors="0"
+             name="t/math/01_math.t"
+             time="10.105495929718"
+             tests="4">
+    <testcase name="1 - add(1, 2) == 3" time="2.08377385139465"></testcase>
+    <testcase time="4.00751399993896" name="2 - add"></testcase>
+    <testcase name="3 - double" time="2.01006603240967"></testcase>
+    <testcase name="4 - add(3, 2) == 5" time="2.00167012214661"></testcase>
+    <testcase time="0.00212502479553223" name="(teardown)" />
+    <system-out><![CDATA[ok 1 - add(1, 2) == 3
 # Subtest: add
     ok 1 - 1 + 2
     ok 2 - 3 + 4
@@ -24,28 +60,9 @@ ok 2 - add
     ok 2 - 3 + 2
     1..2
 ok 3 - double
-# Subtest: double_fail
-    not ok 1 - fail 1 + 2
-    not ok 2 - fail 3 + 2
-    1..2
-not ok 4 - double_fail
+ok 4 - add(3, 2) == 5
 1..4
-</system-out>
-    <testcase name="add(1, 2) == 3" classname="t/math/01_math.t" time="0.0723011493682861" />
-    <testcase name="add" classname="t/math/01_math.t" time="0.000227928161621094" />
-    <testcase name="double" classname="t/math/01_math.t" time="7.91549682617188e-05" />
-    <testcase name="double_fail" classname="t/math/01_math.t" time="0.000271081924438477">
-      <failure message="not ok 4 - double_fail" type="TAP::Parser::Result::Test">Subtest: double_fail
-    not ok 1 - fail 1 + 2
-    not ok 2 - fail 3 + 2
-    1..2
-</failure>
-    </testcase>
-  </testsuite>
-  <testsuite name="t/00_compile.t" errors="0" failures="0" skipped="0" tests="1" time="0.0689620971679688">
-    <system-out>ok 1 - use Example;
-1..1
-</system-out>
-    <testcase name="use Example;" classname="t/00_compile.t" time="0.0674030780792236" />
+]]></system-out>
+    <system-err></system-err>
   </testsuite>
 </testsuites>

--- a/tests/data/prove/report.xml
+++ b/tests/data/prove/report.xml
@@ -6,7 +6,6 @@
              tests="1"
              name="t/00_compile.t">
     <testcase time="0.070734977722168" name="1 - use Example;"></testcase>
-    <testcase name="(teardown)" time="0.000190973281860352" />
     <system-out><![CDATA[ok 1 - use Example;
 1..1
 ]]></system-out>
@@ -28,7 +27,6 @@
       <failure type="TestFailed"
                message="not ok 2 - add"><![CDATA[not ok 2 - add]]></failure>
     </testcase>
-    <testcase name="(teardown)" time="0.000356912612915039" />
     <system-out><![CDATA[not ok 1 - add(1, 2) == 5
 # Subtest: add
     not ok 1 - 1 + 2
@@ -48,7 +46,6 @@ not ok 2 - add
     <testcase time="4.00751399993896" name="2 - add"></testcase>
     <testcase name="3 - double" time="2.01006603240967"></testcase>
     <testcase name="4 - add(3, 2) == 5" time="2.00167012214661"></testcase>
-    <testcase time="0.00212502479553223" name="(teardown)" />
     <system-out><![CDATA[ok 1 - add(1, 2) == 3
 # Subtest: add
     ok 1 - 1 + 2

--- a/tests/test_runners/test_prove.py
+++ b/tests/test_runners/test_prove.py
@@ -2,12 +2,33 @@ import gzip
 import json
 import os
 from pathlib import Path
-from unittest import mock
+from unittest import mock, TestCase
 
 import responses  # type: ignore
 
 from launchable.utils.session import read_session, write_build
+from launchable.test_runners.prove import remove_leading_number_and_dash
 from tests.cli_test_case import CliTestCase
+
+
+class remove_leading_number_and_dash_Test(TestCase):
+    def test_remove_leading_number_and_dash(self):
+        self.assertEqual(
+            remove_leading_number_and_dash(input_string="1 - add"),
+            "add",
+        )
+        self.assertEqual(
+            remove_leading_number_and_dash(input_string="3 - add"),
+            "add",
+        )
+        self.assertEqual(
+            remove_leading_number_and_dash(input_string="100 - add"),
+            "add",
+        )
+        self.assertEqual(
+            remove_leading_number_and_dash(input_string="1 - 1 - add"),
+            "1 - add",
+        )
 
 
 class ProveTestTest(CliTestCase):


### PR DESCRIPTION
# What
- This is to remove unnecessary prefix like `1 - ` that happens to be added to the test names produced by [TAP-Formatter-JUnit](https://github.com/bleargh45/TAP-Formatter-JUnit) for Perl Prove.