### PR TITLE
Validate if the repository uses shallow clones

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -62,7 +62,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
             universal_newlines=True).strip()
         if is_shallow == "true":
             click.echo(click.style(
-                "Can't collect all commits from {} since it is the shallow repository. "
+                "Can't collect commit history from {} since it is the shallow repository. "
                 "Please use full clone or disable commit collection by --no-commit-collection option."
                 .format(cwd),
                 fg='yellow'),

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -53,8 +53,22 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
         _import_git_log(import_git_log_output, ctx.obj.dry_run)
         return
 
+    cwd = os.path.abspath(source)
     try:
-        exec_jar(os.path.abspath(source), max_days, ctx.obj.dry_run)
+        is_shallow = subprocess.check_output(
+            ['git', 'rev-parse', '--is-shallow-repository'],
+            stderr=subprocess.DEVNULL,
+            cwd=cwd,
+            universal_newlines=True).strip()
+        if is_shallow == "true":
+            click.echo(click.style(
+                "Can't collect all commits from {} since it is the shallow repository. "
+                "Please use full clone or disable commit collection by --no-commit-collection option."
+                .format(cwd),
+                fg='yellow'),
+                err=True)
+            sys.exit(1)
+        exec_jar(cwd, max_days, ctx.obj.dry_run)
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -62,7 +76,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
             click.echo(click.style(
                 "Can't get commit history from `{}`. Do you run command root of git-controlled directory? "
                 "If not, please set a directory use by --source option."
-                .format(os.path.abspath(source)),
+                .format(cwd),
                 fg='yellow'),
                 err=True)
             print(e)

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -65,7 +65,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
                 "Can't collect commit history from {} since it is the shallow repository. "
                 "Please use full clone or disable commit collection by --no-commit-collection option."
                 .format(cwd),
-                fg='yellow'),
+                fg='red'),
                 err=True)
             sys.exit(1)
         exec_jar(cwd, max_days, ctx.obj.dry_run)


### PR DESCRIPTION
Currently, we send one commit which has no parents when the repository is a shallow clone. However, we can't collect all commits data in this case. Thus, we need to ask users to use full clone or disable commit collection by --no-commit-collection option. I added this feature in this PR.

## Example

```shell
$ /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable --log-level=audit record build --name "testbuild" --max-days 90
Can't collect all commits from /Users/ono-max/workspace/example since it is the shallow repository. Please use full clone or disable commit collection by --no-commit-collection option.
```