### PR TITLE
Specify the version of importlib-metadata

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ wheel = "*"
 # 2.7.0, < 2.8.0". The latest autopep8 specifies "pycodestyle >= 2.8.0". This
 # conflict cannot be resolved. Pin the version to resolve this.
 autopep8 = "<=1.5.7"
-importlib-metadata = "*"
+importlib-metadata = "<5.0"
 isort = "*"
 more_itertools = "<8.6"
 mypy = "*"


### PR DESCRIPTION
Currently, python lint fails on the main branch such as https://github.com/launchableinc/cli/actions/runs/5528890710/jobs/10086219577. This PR fixes it