### PR TITLE
Use realpath to resolve Symbolic link

### DIFF
--- a/tests/test_testpath.py
+++ b/tests/test_testpath.py
@@ -89,7 +89,7 @@ class TestFilePathNormalizer(unittest.TestCase):
             self._run_command(['git', 'init', base])
 
             n = FilePathNormalizer()
-            self.assertEqual(relpath, n.relativize(abspath))
+            self.assertEqual(relpath, n.relativize(os.path.realpath(abspath)))
 
     @unittest.skipIf(
         sys.platform.startswith("win"),
@@ -116,7 +116,7 @@ class TestFilePathNormalizer(unittest.TestCase):
             abspath = os.path.join(base, 'submod', 'foo', 'bar', 'baz')
 
             n = FilePathNormalizer()
-            self.assertEqual(relpath, n.relativize(abspath))
+            self.assertEqual(relpath, n.relativize(os.path.realpath(abspath)))
 
     def _run_command(self, args, cwd=None):
         # Use check_output here to capture stderr for a better error message.


### PR DESCRIPTION
When I run `pipenv run test tests/test_testpath.py`, I got the following error:
```shell
$ pipenv run test tests/test_testpath.py
.EE.....
======================================================================
ERROR: test_inference_git (tests.test_testpath.TestFilePathNormalizer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ono-max/workspace/cli/tests/test_testpath.py", line 92, in test_inference_git
    self.assertEqual(relpath, n.relativize(abspath))
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 113, in relativize
    return str(self._relativize(pathlib.Path(os.path.normpath(p))))
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 129, in _relativize
    return _relative_to(p, self._inferred_base_path)
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 95, in _relative_to
    return resolved.relative_to(base)
  File "/Users/ono-max/.pyenv/versions/3.5.10/lib/python3.5/pathlib.py", line 864, in relative_to
    .format(str(self), str(formatted)))
ValueError: '/var/folders/91/83jcgpkd5lxd39tt_1rtdqb40000gn/T/tmps7bsjdvx/gitrepo/foo/bar/baz' does not start with '/private/var/folders/91/83jcgpkd5lxd39tt_1rtdqb40000gn/T/tmps7bsjdvx/gitrepo'

======================================================================
ERROR: test_inference_git_submodule (tests.test_testpath.TestFilePathNormalizer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ono-max/workspace/cli/tests/test_testpath.py", line 119, in test_inference_git_submodule
    self.assertEqual(relpath, n.relativize(abspath))
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 113, in relativize
    return str(self._relativize(pathlib.Path(os.path.normpath(p))))
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 129, in _relativize
    return _relative_to(p, self._inferred_base_path)
  File "/Users/ono-max/workspace/cli/launchable/testpath.py", line 95, in _relative_to
    return resolved.relative_to(base)
  File "/Users/ono-max/.pyenv/versions/3.5.10/lib/python3.5/pathlib.py", line 864, in relative_to
    .format(str(self), str(formatted)))
ValueError: '/var/folders/91/83jcgpkd5lxd39tt_1rtdqb40000gn/T/tmpcv2pl7dg/gitrepo/submod/foo/bar/baz' does not start with '/private/var/folders/91/83jcgpkd5lxd39tt_1rtdqb40000gn/T/tmpcv2pl7dg/gitrepo'

----------------------------------------------------------------------
Ran 8 tests in 0.191s

FAILED (errors=2)
```

The reason of this error is because `abspath` in https://github.com/launchableinc/cli/blob/main/tests/test_testpath.py#L116 is symbolic link, which is `/var/folders~`. We need to resolve it. This PR fixes it. Here is a result.

```shell
pipenv run test tests/test_testpath.py               
........
----------------------------------------------------------------------
Ran 8 tests in 0.213s

OK
```