### PR TITLE
Fix to pass stdout to next command

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -281,9 +281,10 @@ def _get_branch_name(repo_dist: str) -> str:
 
     branch_name = ""
     try:
-        refs = subprocess.check_output(
-            "git show-ref | grep '^'$(git rev-parse HEAD)",
-            cwd=repo_dist, shell=True).decode().split("\n")
+        head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_dist).decode().strip()
+        show_ref = subprocess.check_output(["git", "show-ref"], cwd=repo_dist).decode()
+        refs = [ref for ref in show_ref.split("\n") if head in ref]
+
         if len(refs) > 0:
             # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
             branch_name = refs[0].split("/")[-1]

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -283,7 +283,7 @@ def _get_branch_name(repo_dist: str) -> str:
     try:
         refs = subprocess.check_output(
             "git show-ref | grep '^'$(git rev-parse HEAD)",
-            cwd=repo_dist).decode().split("\n")
+            cwd=repo_dist, shell=True).decode().split("\n")
         if len(refs) > 0:
             # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
             branch_name = refs[0].split("/")[-1]

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -21,9 +21,11 @@ class BuildTest(CliTestCase):
         mock_check_output.side_effect = [
             # the first call is git rev-parse HEAD
             ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2').encode(),
-            # the second call is git rev-parse --abbrev-ref HEAD
-            ('ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/head/main\ned6de84bde58d51deebe90e01ddfa5fa78899b1c refs/remotes/origin/main\n').encode(),  # noqa: E501
-            # the third call is git submodule status --recursive
+            # the second call is git rev-parse HEAD for detect branch name
+            ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2').encode(),
+            # the third call is git show-ref for detect branch name
+            ('c50f5de0f06fe16afa4fd1dd615e4903e40b42a2 refs/head/main\nc50f5de0f06fe16afa4fd1dd615e4903e40b42a2 refs/remotes/origin/main\n').encode(),  # noqa: E501
+            # the forth call is git submodule status --recursive
             (
                 ' 491e03096e2234dab9a9533da714fb6eff5dcaa7 foo (v1.51.0-560-g491e030)\n'
                 ' 8bccab48338219e73c3118ad71c8c98fbd32a4be bar-zot (v1.32.0-516-g8bccab4)\n'


### PR DESCRIPTION
I realized this sub process failed with `[Errno2] No such file or directory` message. 
We need to set `shell=True` property to fix it ref: https://stackoverflow.com/questions/18962785/oserror-errno-2-no-such-file-or-directory-while-using-python-subprocess-wit



```
$ launchable record build --name investigate-sub-process
Launchable recorded 2 commits from repository /Users/yabuki-ryosuke/src/github.com/launchableinc/cli
[Errno 2] No such file or directory: "git show-ref | grep '^'$(git rev-parse HEAD)"
Launchable recorded build investigate-sub-process to workspace konboi/test with commits from 1 repository:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 9137f2a04b70d0cb1647f10495e55cec7317764e |
```

<details>
<summary> patch to check it </summary>


```diff
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -283,11 +283,12 @@ def _get_branch_name(repo_dist: str) -> str:
     try:
         refs = subprocess.check_output(
             "git show-ref | grep '^'$(git rev-parse HEAD)",
-            cwd=repo_dist, shell=True).decode().split("\n")
+            cwd=repo_dist).decode().split("\n")
         if len(refs) > 0:
             # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
             branch_name = refs[0].split("/")[-1]
-    except Exception:
+    except Exception as e:
         # cannot get branch name by git command
+        print(e)
         pass
     return branch_name
```

<details>