### PR TITLE
Support lineage option

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -16,6 +16,7 @@ def find_or_create_session(
     is_observation: bool = False,
     links: List[str] = [],
     is_no_build: bool = False,
+    lineage: Optional[str] = None,
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -45,6 +46,7 @@ def find_or_create_session(
             is_observation=is_observation,
             links=links,
             is_no_build=is_no_build,
+            lineage=lineage,
         )
         saved_build_name = read_build()
         return read_session(str(saved_build_name))
@@ -83,6 +85,7 @@ def find_or_create_session(
                 is_observation=is_observation,
                 links=links,
                 is_no_build=is_no_build,
+                lineage=lineage,
             )
             return read_session(saved_build_name)
 

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -29,6 +29,11 @@ def find_or_create_session(
     Args:
         session: The --session option value
         build_name: The --build option value
+        flavor: The --flavor option values
+        is_observation: The --observation value
+        links: The --link option values
+        is_no_build: The --no-build option value
+        lineage: lineage option value
     """
     from .record.session import session as session_command
 

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -85,7 +85,7 @@ def _validate_session_name(ctx, param, value):
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name. A lineage is a set of test sessions grouped and this option value will be used for grouping.',
+    help='Set lineage name. A lineage is a set of test sessions grouped and this option value will be used for a lineage name.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -82,6 +82,14 @@ def _validate_session_name(ctx, param, value):
     metavar='SESSION_NAME',
     callback=_validate_session_name,
 )
+@click.option(
+    '--lineage',
+    'lineage',
+    help='Set lineage name',
+    required=False,
+    type=str,
+    metavar='LINEAGE',
+)
 @click.pass_context
 def session(
     ctx: click.core.Context,
@@ -93,6 +101,7 @@ def session(
     links: List[str] = [],
     is_no_build: bool = False,
     session_name: Optional[str] = None,
+    lineage: Optional[str] = None,
 ):
     """
     print_session is for backward compatibility.
@@ -132,6 +141,7 @@ def session(
         "flavors": flavor_dict,
         "isObservation": is_observation,
         "noBuild": is_no_build,
+        "lineage": lineage,
     }
 
     _links = capture_link(os.environ)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -141,7 +141,7 @@ def session(
         "flavors": flavor_dict,
         "isObservation": is_observation,
         "noBuild": is_no_build,
-        "lineage": lineage,
+        "lineage": lineage if lineage else "",
     }
 
     _links = capture_link(os.environ)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -85,7 +85,7 @@ def _validate_session_name(ctx, param, value):
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name',
+    help='Set lineage name. A lineage is a set of test sessions grouped and this option value will be used for grouping.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -141,7 +141,7 @@ def session(
         "flavors": flavor_dict,
         "isObservation": is_observation,
         "noBuild": is_no_build,
-        "lineage": lineage if lineage else "",
+        "lineage": lineage,
     }
 
     _links = capture_link(os.environ)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -143,6 +143,14 @@ def _validate_group(ctx, param, value):
     type=str,
     metavar='SESSION_NAME',
 )
+@click.option(
+    '--lineage',
+    'lineage',
+    help='Set lineage name',
+    required=False,
+    type=str,
+    metavar='LINEAGE',
+)
 @click.pass_context
 def tests(
     context: click.core.Context,
@@ -158,7 +166,8 @@ def tests(
     is_allow_test_before_build: bool,
     links: List[str] = [],
     is_no_build: bool = False,
-    session_name: Optional[str] = None
+    session_name: Optional[str] = None,
+    lineage: Optional[str] = None,
 ):
     logger = Logger()
 
@@ -200,7 +209,8 @@ def tests(
                 session=session,
                 build_name=build_name,
                 flavor=flavor,
-                links=links))
+                links=links,
+                lineage=lineage))
             build_name = read_build()
             record_start_at = get_record_start_at(session_id, client)
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -146,7 +146,7 @@ def _validate_group(ctx, param, value):
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name. This option value will be passed the record session command if a session isn\'t created yet.',
+    help='Set lineage name. This option value will be passed to the record session command if a session isn\'t created yet.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -146,7 +146,7 @@ def _validate_group(ctx, param, value):
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name',
+    help='Set lineage name. This option value will be passed the record session command if a session isn\'t created yet.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -144,7 +144,7 @@ from .test_path_writer import TestPathWriter
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name',
+    help='Set lineage name. This option value will be passed the record session command if a session isn\'t created yet.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -144,7 +144,7 @@ from .test_path_writer import TestPathWriter
 @click.option(
     '--lineage',
     'lineage',
-    help='Set lineage name. This option value will be passed the record session command if a session isn\'t created yet.',
+    help='Set lineage name. This option value will be passed to the record session command if a session isn\'t created yet.',
     required=False,
     type=str,
     metavar='LINEAGE',

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -141,6 +141,14 @@ from .test_path_writer import TestPathWriter
     help="If you want to only send test reports, please use this option",
     is_flag=True,
 )
+@click.option(
+    '--lineage',
+    'lineage',
+    help='Set lineage name',
+    required=False,
+    type=str,
+    metavar='LINEAGE',
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -161,6 +169,7 @@ def subset(
     ignore_flaky_tests_above: Optional[float],
     links: List[str] = [],
     is_no_build: bool = False,
+    lineage: Optional[str] = None,
 ):
 
     if is_observation and is_get_tests_from_previous_sessions:
@@ -180,6 +189,7 @@ def subset(
         is_observation=is_observation,
         links=links,
         is_no_build=is_no_build,
+        lineage=lineage
     )
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -113,3 +113,22 @@ class SessionTest(CliTestCase):
              "isObservation": False, "links": [],
              "noBuild": False, "lineage": ""},
             payload)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
+    }, clear=True)
+    def test_run_session_with_lineage(self):
+        result = self.cli("record", "session", "--build", self.build_name,
+                          "--lineage", "example-lineage")
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": False,
+            "links": [],
+            "noBuild": False,
+            "lineage": "example-lineage",
+        }, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -30,7 +30,7 @@ class SessionTest(CliTestCase):
         self.assert_json_orderless_equal(
             {"flavors": {},
              "isObservation": False, "links": [],
-             "noBuild": False, "lineage": ""},
+             "noBuild": False, "lineage": None},
             payload)
 
     @responses.activate
@@ -53,7 +53,7 @@ class SessionTest(CliTestCase):
             "isObservation": False,
             "links": [],
             "noBuild": False,
-            "lineage": "",
+            "lineage": None,
         }, payload)
 
         with self.assertRaises(ValueError):
@@ -76,7 +76,7 @@ class SessionTest(CliTestCase):
         self.assert_json_orderless_equal(
             {"flavors": {},
              "isObservation": True, "links": [],
-             "noBuild": False, "lineage": ""},
+             "noBuild": False, "lineage": None},
             payload)
 
     @responses.activate
@@ -111,7 +111,7 @@ class SessionTest(CliTestCase):
         self.assert_json_orderless_equal(
             {"flavors": {},
              "isObservation": False, "links": [],
-             "noBuild": False, "lineage": ""},
+             "noBuild": False, "lineage": None},
             payload)
 
     @responses.activate

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -27,7 +27,11 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": [], "noBuild": False}, payload)
+        self.assert_json_orderless_equal(
+            {"flavors": {},
+             "isObservation": False, "links": [],
+             "noBuild": False, "lineage": ""},
+            payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -49,6 +53,7 @@ class SessionTest(CliTestCase):
             "isObservation": False,
             "links": [],
             "noBuild": False,
+            "lineage": "",
         }, payload)
 
         with self.assertRaises(ValueError):
@@ -68,7 +73,11 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
 
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": True, "links": [], "noBuild": False}, payload)
+        self.assert_json_orderless_equal(
+            {"flavors": {},
+             "isObservation": True, "links": [],
+             "noBuild": False, "lineage": ""},
+            payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -99,4 +108,8 @@ class SessionTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(responses.calls[2].request.body.decode())
-        self.assert_json_orderless_equal({"flavors": {}, "isObservation": False, "links": [], "noBuild": False}, payload)
+        self.assert_json_orderless_equal(
+            {"flavors": {},
+             "isObservation": False, "links": [],
+             "noBuild": False, "lineage": ""},
+            payload)


### PR DESCRIPTION
Support `--lineage` option.

e.g)
```
$ launchable record session --build <BUILD NAME> --lineage feature-xxx
```