### PR TITLE
Handle exceptions in requests package

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -142,7 +142,6 @@ def session(
                 raise e
             else:
                 click.echo(e, err=True)
-                return
 
     flavor_dict = {}
     for f in normalize_key_value_types(flavor):

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -127,11 +127,22 @@ def session(
 
     if session_name:
         sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
-        res = client.request("get", sub_path)
+        try:
+            res = client.request("get", sub_path)
 
-        if res.status_code != 404:
-            raise click.UsageError(
-                'This session name ({}) is already used. Please set another name.'.format(session_name))
+            if res.status_code != 404:
+                click.echo(click.style(
+                    "This session name ({}) is already used. Please set another name."
+                    .format(session_name),
+                    fg='red'),
+                    err=True)
+                sys.exit(2)
+        except Exception as e:
+            if os.getenv(REPORT_ERROR_KEY):
+                raise e
+            else:
+                click.echo(e, err=True)
+                return
 
     flavor_dict = {}
     for f in normalize_key_value_types(flavor):

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -9,7 +9,7 @@ import click
 from launchable.utils.key_value_type import normalize_key_value_types
 from launchable.utils.link import LinkKind, capture_link
 
-from ...utils.click import KeyValueType
+from ...utils.click import KeyValueType, ignorable_error
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.http_client import LaunchableClient
 from ...utils.no_build import NO_BUILD_BUILD_NAME
@@ -141,7 +141,7 @@ def session(
             if os.getenv(REPORT_ERROR_KEY):
                 raise e
             else:
-                click.echo(e, err=True)
+                click.echo(ignorable_error(e))
 
     flavor_dict = {}
     for f in normalize_key_value_types(flavor):

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -181,16 +181,24 @@ def subset(
         )
         sys.exit(1)
 
-    session_id = find_or_create_session(
-        context=context,
-        session=session,
-        build_name=build_name,
-        flavor=flavor,
-        is_observation=is_observation,
-        links=links,
-        is_no_build=is_no_build,
-        lineage=lineage
-    )
+    session_id = None
+    try:
+        session_id = find_or_create_session(
+            context=context,
+            session=session,
+            build_name=build_name,
+            flavor=flavor,
+            is_observation=is_observation,
+            links=links,
+            is_no_build=is_no_build,
+            lineage=lineage
+        )
+    except Exception as e:
+        if os.getenv(REPORT_ERROR_KEY):
+            raise e
+        else:
+            click.echo(e, err=True)
+
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -12,7 +12,7 @@ from launchable.utils.authentication import get_org_workspace
 from launchable.utils.session import parse_session
 
 from ..testpath import FilePathNormalizer, TestPath
-from ..utils.click import DURATION, PERCENTAGE, DurationType, KeyValueType, PercentageType
+from ..utils.click import DURATION, PERCENTAGE, DurationType, KeyValueType, PercentageType, ignorable_error
 from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.http_client import LaunchableClient
 from .helper import find_or_create_session
@@ -197,7 +197,7 @@ def subset(
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
-            click.echo(e, err=True)
+            click.echo(ignorable_error(e))
 
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -92,7 +92,7 @@ def verify():
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
-            click.echo(e, err=True)
+            click.echo(ignorable_error(e))
 
     if java is None:
         raise click.UsageError(click.style(

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -85,7 +85,7 @@ def verify():
         res = client.request("get", "verification")
         if res.status_code == 401:
             click.echo(click.style("Authentication failed. Most likely the value for the LAUNCHABLE_TOKEN "
-                                            "environment variable is invalid.", fg="red"), err=True)
+                                   "environment variable is invalid.", fg="red"), err=True)
             sys.exit(2)
         res.raise_for_status()
     except Exception as e:

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -10,7 +10,7 @@ import click
 from launchable.utils.env_keys import REPORT_ERROR_KEY
 
 from ..utils.authentication import get_org_workspace
-from ..utils.click import emoji
+from ..utils.click import emoji, ignorable_error
 from ..utils.http_client import LaunchableClient
 from ..utils.java import get_java_command
 from ..version import __version__ as version

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -169,5 +169,6 @@ def convert_to_seconds(s: str):
 
     return float(duration)
 
+
 def ignorable_error(e: Exception):
     return "An error occurred on Launchable CLI. You can ignore this message since the process will continue. Error: {}".format(e)

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -168,3 +168,6 @@ def convert_to_seconds(s: str):
         duration += int(val) * u
 
     return float(duration)
+
+def ignorable_error(e: Exception):
+    return "An error occurred on Launchable CLI. You can ignore this message since the process will continue. Error: {}".format(e)

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -290,7 +290,7 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             body=ReadTimeout("error"))
-        with tempfile.NamedTemporaryFile() as rest_file:
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             self.assert_exit_code(["subset",
                                    "--target",
                                    "30%",

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -197,7 +197,7 @@ class APIErrorTest(CliTestCase):
 
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             self.assert_exit_code(["subset", "--target", "30%", "--session", self.session, "--rest", rest_file.name,
-                              "minitest", str(self.test_files_dir) + "/test/**/*.rb"], {"mix_stderr": False}, 0)
+                                   "minitest", str(self.test_files_dir) + "/test/**/*.rb"], {"mix_stderr": False}, 0)
 
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
             self.assertTrue(subset_file in result.stdout)
@@ -213,8 +213,18 @@ class APIErrorTest(CliTestCase):
                 session_id=self.session_id),
             body=ReadTimeout("error"))
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
-            self.assert_exit_code(["subset", "--target", "30%", "--session", self.session, "--rest", rest_file.name, "--observation",
-                              "minitest", str(self.test_files_dir) + "/test/**/*.rb"], {"mix_stderr": False}, 0)
+            self.assert_exit_code(["subset",
+                                   "--target",
+                                   "30%",
+                                   "--session",
+                                   self.session,
+                                   "--rest",
+                                   rest_file.name,
+                                   "--observation",
+                                   "minitest",
+                                   str(self.test_files_dir) + "/test/**/*.rb"],
+                                  {"mix_stderr": False},
+                                  0)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -281,8 +291,18 @@ class APIErrorTest(CliTestCase):
                 session_id=self.session_id),
             body=ReadTimeout("error"))
         with tempfile.NamedTemporaryFile() as rest_file:
-            self.assert_exit_code(["subset", "--target", "30%", "--session", self.session, "--rest", rest_file.name, "--observation",
-                              "minitest", str(self.test_files_dir) + "/test/**/*.rb"], {"mix_stderr": False}, 0)
+            self.assert_exit_code(["subset",
+                                   "--target",
+                                   "30%",
+                                   "--session",
+                                   self.session,
+                                   "--rest",
+                                   rest_file.name,
+                                   "--observation",
+                                   "minitest",
+                                   str(self.test_files_dir) + "/test/**/*.rb"],
+                                  {"mix_stderr": False},
+                                  0)
 
         responses.replace(
             responses.POST,

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -6,7 +6,6 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from unittest import mock
 from requests.exceptions import ReadTimeout
-from typing import Any, Dict, List
 
 import responses  # type: ignore
 
@@ -203,6 +202,7 @@ class APIErrorTest(CliTestCase):
             result = self.cli("subset", "--target", "30%", "--session", self.session, "--rest", rest_file.name,
                               "minitest", str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
+
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
             self.assertTrue(subset_file in result.stdout)
             self.assertEqual(Path(rest_file.name).read_text(), "")

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -290,6 +290,7 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             body=ReadTimeout("error"))
+        # set delete=False to solve the error `PermissionError: [Errno 13] Permission denied:`.
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             self.assert_exit_code(["subset",
                                    "--target",

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -256,7 +256,7 @@ class APIErrorTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_all_workflow_when_server_down(self):
-        # setup
+        # setup verify
         responses.add(
             responses.GET,
             "{base}/intake/organizations/{org}/workspaces/{ws}/verification".format(
@@ -264,6 +264,7 @@ class APIErrorTest(CliTestCase):
                 org=self.organization,
                 ws=self.workspace),
             body=ReadTimeout("error"))
+        # setup build
         responses.replace(
             responses.POST,
             "{base}/intake/organizations/{org}/workspaces/{ws}/builds".format(
@@ -271,6 +272,7 @@ class APIErrorTest(CliTestCase):
                 org=self.organization,
                 ws=self.workspace),
             body=ReadTimeout("error"))
+        # setup subset
         responses.replace(
             responses.POST,
             "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
@@ -287,6 +289,7 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             body=ReadTimeout("error"))
+        # setup recording tests
         responses.replace(
             responses.POST,
             "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}/test_sessions/{session_id}/events".format(

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -299,7 +299,7 @@ class APIErrorTest(CliTestCase):
 
         # test commands
         self.assert_exit_code(["verify"], {}, 0)
-        
+
         self.assert_exit_code(["record", "build", "--name", "example"], {}, 0)
 
         # set delete=False to solve the error `PermissionError: [Errno 13] Permission denied:`.


### PR DESCRIPTION
Basically, we should not stop users' CI pipeline. Thus, we should use exit code 0 unless it is an intentional notification. This PR fixes it by catching exception in client.request.