### PR TITLE
Fix separator and add test

### DIFF
--- a/launchable/test_runners/dotnet.py
+++ b/launchable/test_runners/dotnet.py
@@ -12,7 +12,7 @@ from launchable.testpath import TestPath
 # main subset logic
 def do_subset(client, bare):
     if bare:
-        separator = "."
+        separator = "\n"
         prefix = ""
     else:
         # LEGACY: we recommend the bare mode with native NUnit integration

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -94,6 +94,84 @@ class DotnetTest(CliTestCase):
         output = "FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd&FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestDiv\n"  # noqa: E501
         self.assertEqual(result.output, output)
 
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_bare_option(self):
+        mock_response = {
+            "testPaths": [
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestSub"},
+                ],
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestMul"},
+                ],
+            ],
+            "rest": [
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestAdd"},
+                ],
+                [
+                    {"type": "Assembly", "name": "rocket-car-dotnet.dll"},
+                    {"type": "TestSuite", "name": "rocket_car_dotnet"},
+                    {"type": "TestSuite", "name": "ExampleTest"},
+                    {"type": "TestCase", "name": "TestDiv"},
+                ],
+            ],
+            "testRunner": "dotnet",
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 25, "candidates": 1, "rate": 25},
+                "rest": {"duration": 78, "candidates": 3, "rate": 75}
+            },
+            "isObservation": False,
+        }
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_response,
+            status=200)
+
+        result = self.cli(
+            'subset',
+            '--target',
+            '25%',
+            '--session',
+            self.session,
+            '--get-tests-from-previous-sessions',
+            'dotnet',
+            '--bare',
+            mix_stderr=False)
+        self.assertEqual(result.exit_code, 0)
+
+        output = "rocket_car_dotnet.ExampleTest.TestSub\nrocket_car_dotnet.ExampleTest.TestMul\n"
+        self.assertEqual(result.output, output)
+
+        result = self.cli(
+            'subset',
+            '--target',
+            '25%',
+            '--session',
+            self.session,
+            '--get-tests-from-previous-sessions',
+            '--output-exclusion-rules',
+            'dotnet',
+            '--bare',
+            mix_stderr=False)
+        self.assertEqual(result.exit_code, 0)
+        output = "rocket_car_dotnet.ExampleTest.TestAdd\nrocket_car_dotnet.ExampleTest.TestDiv\n"
+        self.assertEqual(result.output, output)
+
     @ignore_warnings
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})


### PR DESCRIPTION
the [launchableinc/nunit](https://github.com/launchableinc/nunit) custom plugin reads a subset(or rest) file and filters tests. 
However, before fixing this change, all test lists are put together by `.`

e.g.) as is
`rocket_car_dotnet.ExampleTest.TestSub.rocket_car_dotnet.ExampleTest.TestMul.`

e.g.) to be
```
rocket_car_dotnet.ExampleTest.TestSub
rocket_car_dotnet.ExampleTest.TestMul
```

So, I fixed it