### PR TITLE
Support --branch name option when --no-commit-collection option is enabled

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -82,9 +82,17 @@ CODE_BUILD_WEBHOOK_HEAD_REF_KEY = "CODEBUILD_WEBHOOK_HEAD_REF"
     default=[],
     cls=KeyValueType,
 )
+@click.option(
+    '--branch',
+    'branches',
+    help="Set repository name and branch name when you use --no-commit-collection option. Please use the same repository name with a commit option",  # noqa: E501
+    multiple=True,
+    default=[],
+    cls=KeyValueType,
+)
 @click.pass_context
 def build(ctx: click.core.Context, build_name: str, source: List[str], max_days: int, no_submodules: bool,
-          no_commit_collection: bool, scrub_pii: bool, commits: List[str], links: List[str]):
+          no_commit_collection: bool, scrub_pii: bool, commits: List[str], links: List[str], branches: List[str]):
 
     if "/" in build_name or "%2f" in build_name.lower():
         sys.exit("--name must not contain a slash and an encoded slash")
@@ -177,6 +185,9 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
             submodules.append((repo_name, "", hash))
         if invalid:
             sys.exit(1)
+
+    if no_commit_collection and len(branches) != 0:
+        branch_name_map = dict(normalize_key_value_types(branches))
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -188,8 +188,8 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
 
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.
-    uniq_submodules = {commit_hash: (name, repo_dist, commit_hash)
-                       for name, repo_dist, commit_hash, in sources + submodules}.values()
+    uniq_submodules = list({commit_hash: (name, repo_dist, commit_hash)
+                            for name, repo_dist, commit_hash, in sources + submodules}.values())
 
     if no_commit_collection and len(branches) != 0:
         branch_name_map = dict(normalize_key_value_types(branches))

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -198,7 +198,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         if len(not_match_branch_repos) > 0:
             click.echo(
                 click.style(
-                    "--branch option has been set for {} but not set in the --commit option".format(not_match_branch_repos),
+                    "--branch option is set for {} but was not set for the --commit option".format(not_match_branch_repos),
                     fg="yellow"),
                 err=True)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -186,13 +186,21 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         if invalid:
             sys.exit(1)
 
-    if no_commit_collection and len(branches) != 0:
-        branch_name_map = dict(normalize_key_value_types(branches))
-
     # Note: currently becomes unique command args and submodules by the hash.
     # But they can be conflict between repositories.
     uniq_submodules = {commit_hash: (name, repo_dist, commit_hash)
                        for name, repo_dist, commit_hash, in sources + submodules}.values()
+
+    if no_commit_collection and len(branches) != 0:
+        branch_name_map = dict(normalize_key_value_types(branches))
+        repo_names = [m[0] for m in uniq_submodules]
+        not_match_branch_repos = set(branch_name_map.keys()) - set(repo_names)
+        if len(not_match_branch_repos) > 0:
+            click.echo(
+                click.style(
+                    "--branch option has been set for {} but not set in the --commit option".format(not_match_branch_repos),
+                    fg="yellow"),
+                err=True)
 
     build_id = None
     try:

--- a/launchable/utils/key_value_type.py
+++ b/launchable/utils/key_value_type.py
@@ -2,10 +2,10 @@ from typing import List, Sequence, Tuple
 
 
 def normalize_key_value_types(kv_types_raw: List[str]) -> List[Tuple[str, str]]:
-    """Normalize flavor list, because the type of the flavor list specified in the command line flags differs depending
+    """Normalize key/value list, because the type of the key/value list specified in the command line flags differs depending
     on the version of the click.
 
-    TODO: handle extraction of flavor tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple
+    TODO: handle extraction of key/value tuple to dict in better way for >=click8.0 that returns tuple of tuples as tuple
     of str
     E.G.
         <click8.0:

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -130,6 +130,121 @@ class BuildTest(CliTestCase):
         finally:
             os.chdir(orig_dir)
 
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_commit_option_and_build_option(self):
+        # case only --commit option
+        result = self.cli("record", "build", "--no-commit-collection", "--commit", "A=abc12", "--name", self.build_name)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {
+                "buildNumber": "123",
+                "commitHashes": [
+                    {
+                        "repositoryName": "A",
+                        "commitHash": "abc12",
+                        "branchName": ""
+                    },
+                ],
+                "links": []
+            }, payload)
+        responses.calls.reset()
+
+        # case --commit option and --branch option
+        result = self.cli(
+            "record",
+            "build",
+            "--no-commit-collection",
+            "--commit",
+            "A=abc12",
+            "--branch",
+            "A=feature-xxx",
+            "--name",
+            self.build_name)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {
+                "buildNumber": "123",
+                "commitHashes": [
+                    {
+                        "repositoryName": "A",
+                        "commitHash": "abc12",
+                        "branchName": "feature-xxx"
+                    },
+                ],
+                "links": []
+            }, payload)
+        responses.calls.reset()
+
+        # case --commit option and --branch option but another one
+        result = self.cli(
+            "record",
+            "build",
+            "--no-commit-collection",
+            "--commit",
+            "A=abc12",
+            "--branch",
+            "B=feature-yyy",
+            "--name",
+            self.build_name)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {
+                "buildNumber": "123",
+                "commitHashes": [
+                    {
+                        "repositoryName": "A",
+                        "commitHash": "abc12",
+                        "branchName": ""
+                    },
+                ],
+                "links": []
+            }, payload)
+        responses.calls.reset()
+
+        # case multiple --commit options and multiple --branch options
+        result = self.cli(
+            "record",
+            "build",
+            "--no-commit-collection",
+            "--commit",
+            "A=abc12",
+            "--branch",
+            "B=feature-yyy",
+            "--commit",
+            "B=56cde",
+            "--branch",
+            "A=feature-xxx",
+            "--name",
+            self.build_name)
+        self.assertEqual(result.exit_code, 0)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal(
+            {
+                "buildNumber": "123",
+                "commitHashes": [
+                    {
+                        "repositoryName": "A",
+                        "commitHash": "abc12",
+                        "branchName": "feature-xxx"
+                    },
+                    {
+                        "repositoryName": "B",
+                        "commitHash": "56cde",
+                        "branchName": "feature-yyy"
+                    },
+                ],
+                "links": []
+            }, payload)
+        responses.calls.reset()
+
     def test_build_name_validation(self):
         result = self.cli("record", "build", "--no-commit-collection", "--name", "foo/hoge")
         self.assertEqual(result.exit_code, 1)

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -132,6 +132,9 @@ class BuildTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    # to tests on GitHub Actions
+    @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
+    @mock.patch.dict(os.environ, {"GITHUB_PULL_REQUEST_URL": ""})
     def test_commit_option_and_build_option(self):
         # case only --commit option
         result = self.cli("record", "build", "--no-commit-collection", "--commit", "A=abc12", "--name", self.build_name)

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -210,6 +210,7 @@ class BuildTest(CliTestCase):
                 "links": []
             }, payload)
         responses.calls.reset()
+        self.assertIn("not set in the --commit option", result.output)
 
         # case multiple --commit options and multiple --branch options
         result = self.cli(

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -210,7 +210,7 @@ class BuildTest(CliTestCase):
                 "links": []
             }, payload)
         responses.calls.reset()
-        self.assertIn("not set in the --commit option", result.output)
+        self.assertIn("was not set for the --commit option", result.output)
 
         # case multiple --commit options and multiple --branch options
         result = self.cli(


### PR DESCRIPTION
The cli collects branch names from git repository information. However, if the `--no-commit-collection` is enabled, cannot collect a branch name.
So, we add a new option `--branch` name.

e.g.)

```sh
$ launchable record build --name <BUILD NAME> \
--no-commit-collection \
--commit a-repo=abc123 \ 
--commit b-repo=56cde \
--branch a-repo=v1.5.2 \
--branch b-repo=v.2.2.4
```