### PR TITLE
Add the ability to collect telemetry data in verify command

### DIFF
--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -9,7 +9,7 @@ from requests.exceptions import ConnectionError, Timeout, RequestException
 import click
 
 from launchable.utils.env_keys import REPORT_ERROR_KEY
-from launchable.utils.telemtry import TelemetryClient, Telemetry
+from launchable.utils.tracking import TrackingClient, Tracking
 
 from ..utils.authentication import get_org_workspace
 from ..utils.click import emoji, ignorable_error
@@ -63,7 +63,7 @@ def verify():
     org, workspace = get_org_workspace()
     client = LaunchableClient()
     java = get_java_command()
-    telemetry_client = TelemetryClient(client)
+    tracking_client = TrackingClient(client)
 
     # Print the system information first so that we can get them even if there's
     # an issue.
@@ -82,9 +82,9 @@ def verify():
             "Please confirm if you set LAUNCHABLE_TOKEN or LAUNCHABLE_ORGANIZATION and LAUNCHABLE_WORKSPACE "
             "environment variables"
         )
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_CLI_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_CLI_ERROR,
             msg
         )
         raise click.UsageError(
@@ -98,36 +98,36 @@ def verify():
             sys.exit(2)
         res.raise_for_status()
     except ConnectionError as e:
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.NETWORK_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.NETWORK_ERROR,
             str(e),
             org,
             workspace,
             "verification",
         )
     except Timeout as e:
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.TIMEOUT_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.TIMEOUT_ERROR,
             str(e),
             org,
             workspace,
             "verification",
         )
     except RequestException as e:
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_ERROR,
             str(e),
             org,
             workspace,
             "verification",
         )
     except Exception as e:
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_CLI_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_CLI_ERROR,
             str(e),
             org,
             workspace,
@@ -140,9 +140,9 @@ def verify():
 
     if java is None:
         msg = "Java is not installed. Install Java version 8 or newer to use the Launchable CLI."
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_CLI_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_CLI_ERROR,
             msg
         )
         raise click.UsageError(click.style(msg, fg="red"))
@@ -152,18 +152,18 @@ def verify():
 
     if compare_version([int(x) for x in platform.python_version().split('.')], [3, 6]) < 0:
         msg = "Python 3.6 or later is required"
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_CLI_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_CLI_ERROR,
             msg
         )
         raise click.UsageError(click.style(msg, fg="red"))
 
     if check_java_version(java) < 0:
         msg = "Java 8 or later is required"
-        telemetry_client.send_error_event(
-            Telemetry.Command.VERIFY,
-            Telemetry.ExceptionEvent.INTERNAL_CLI_ERROR,
+        tracking_client.send_error_event(
+            Tracking.Command.VERIFY,
+            Tracking.ExceptionEvent.INTERNAL_CLI_ERROR,
             msg
         )
         raise click.UsageError(click.style(msg, fg="red"))

--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -73,10 +73,10 @@ class LaunchableClient:
         params: Optional[Dict] = None,
         timeout: Tuple[int, int] = (5, 60),
         compress: bool = False,
+        base_path: str = "",
     ):
-        url = _join_paths(
-            self.base_url, "/intake/organizations/{}/workspaces/{}".format(self.organization, self.workspace),
-            sub_path)
+        base = base_path or "/intake/organizations/{}/workspaces/{}".format(self.organization, self.workspace)
+        url = _join_paths(self.base_url, base, sub_path)
 
         headers = self._headers(compress)
 
@@ -91,15 +91,12 @@ class LaunchableClient:
 
         data = _build_data(payload, compress)
 
-        try:
-            response = self.session.request(method, url, headers=headers, timeout=timeout, data=data, params=params)
-            Logger().debug(
-                "received response status:{} message:{} headers:{}".format(response.status_code, response.reason,
-                                                                           response.headers)
-            )
-            return response
-        except Exception as e:
-            raise Exception("unable to post to %s" % url) from e
+        response = self.session.request(method, url, headers=headers, timeout=timeout, data=data, params=params)
+        Logger().debug(
+            "received response status:{} message:{} headers:{}".format(response.status_code, response.reason,
+                                                                       response.headers)
+        )
+        return response
 
     def _headers(self, compress):
         h = {

--- a/launchable/utils/telemtry.py
+++ b/launchable/utils/telemtry.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 from requests import Session
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from launchable.utils.http_client import LaunchableClient
 
@@ -36,7 +36,7 @@ class TelemetryClient:
     def send_error_event(
         self,
         command: Telemetry.Command,
-        event_name: Telemetry.Event | Telemetry.ExceptionEvent,
+        event_name: Union[Telemetry.Event, Telemetry.ExceptionEvent],
         stack_trace: str,
         organization: str = "",
         workspace: str = "",

--- a/launchable/utils/telemtry.py
+++ b/launchable/utils/telemtry.py
@@ -55,5 +55,5 @@ class TelemetryClient:
         }
         try:
             self.http_client.request('post', 'tracking', payload=payload, base_path='/intake')
-        except Exception as e:
+        except Exception:
             pass

--- a/launchable/utils/telemtry.py
+++ b/launchable/utils/telemtry.py
@@ -1,0 +1,61 @@
+from enum import Enum
+from typing import Optional
+from requests import Session
+from typing import Dict, Any
+
+from launchable.utils.http_client import LaunchableClient
+
+
+class Telemetry:
+    # General events
+    class Event(Enum):
+        SHALLOW_CLONE = 'shallow_clone'  # this event is an example
+
+    # Error events
+    class ExceptionEvent(Enum):
+        UNKNOWN_ERROR = 'unknownError'
+        INTERNAL_CLI_ERROR = 'internalCliError'
+        # Errors related to requests package
+        NETWORK_ERROR = 'networkError'
+        TIMEOUT_ERROR = 'timeoutError'
+        INTERNAL_ERROR = 'internalError'
+        UNEXPECTED_HTTP_STATUS_ERROR = 'unexpectedHttpStatusError'
+
+    class Command(Enum):
+        VERIFY = 'verify'
+        TESTS = 'tests'
+        BUILD = 'build'
+        SESSION = 'session'
+        SUBSET = 'subset'
+
+
+class TelemetryClient:
+    def __init__(self, http_client: LaunchableClient) -> None:
+        self.http_client = http_client
+
+    def send_error_event(
+        self,
+        command: Telemetry.Command,
+        event_name: Telemetry.Event | Telemetry.ExceptionEvent,
+        stack_trace: str,
+        organization: str = "",
+        workspace: str = "",
+        api: str = "",
+        metadata: Dict[str, Any] = {}
+    ):
+        metadata["stacktrace"] = stack_trace
+        if organization:
+            metadata["organization"] = organization
+        if workspace:
+            metadata["workspace"] = workspace
+        if api:
+            metadata["api"] = api
+        payload = {
+            "command": command.value,
+            "eventName": event_name.value,
+            "metadata": metadata,
+        }
+        try:
+            self.http_client.request('post', 'tracking', payload=payload, base_path='/intake')
+        except Exception as e:
+            pass

--- a/launchable/utils/telemtry.py
+++ b/launchable/utils/telemtry.py
@@ -1,6 +1,4 @@
 from enum import Enum
-from typing import Optional
-from requests import Session
 from typing import Dict, Any, Union
 
 from launchable.utils.http_client import LaunchableClient

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -40,8 +40,10 @@ class TrackingClient:
         organization: str = "",
         workspace: str = "",
         api: str = "",
-        metadata: Dict[str, Any] = {}
+        metadata: Dict[str, Any] = None
     ):
+        if metadata is None:
+            metadata = {}
         metadata["stackTrace"] = stack_trace
         if organization:
             metadata["organization"] = organization

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -2,46 +2,47 @@ from enum import Enum
 from typing import Dict, Any, Union
 
 from launchable.utils.http_client import LaunchableClient
+from launchable.version import __version__
 
 
-class Telemetry:
+class Tracking:
     # General events
     class Event(Enum):
         SHALLOW_CLONE = 'shallow_clone'  # this event is an example
 
     # Error events
     class ExceptionEvent(Enum):
-        UNKNOWN_ERROR = 'unknownError'
-        INTERNAL_CLI_ERROR = 'internalCliError'
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+        INTERNAL_CLI_ERROR = 'INTERNAL_CLI_ERROR'
         # Errors related to requests package
-        NETWORK_ERROR = 'networkError'
-        TIMEOUT_ERROR = 'timeoutError'
-        INTERNAL_ERROR = 'internalError'
-        UNEXPECTED_HTTP_STATUS_ERROR = 'unexpectedHttpStatusError'
+        NETWORK_ERROR = 'NETWORK_ERROR'
+        TIMEOUT_ERROR = 'TIMEOUT_ERROR'
+        INTERNAL_ERROR = 'INTERNAL_ERROR'
+        UNEXPECTED_HTTP_STATUS_ERROR = 'UNEXPECTED_HTTP_STATUS_ERROR'
 
     class Command(Enum):
-        VERIFY = 'verify'
-        TESTS = 'tests'
-        BUILD = 'build'
-        SESSION = 'session'
-        SUBSET = 'subset'
+        VERIFY = 'VERIFY'
+        TESTS = 'TESTS'
+        BUILD = 'BUILD'
+        SESSION = 'SESSION'
+        SUBSET = 'SUBSET'
 
 
-class TelemetryClient:
+class TrackingClient:
     def __init__(self, http_client: LaunchableClient) -> None:
         self.http_client = http_client
 
     def send_error_event(
         self,
-        command: Telemetry.Command,
-        event_name: Union[Telemetry.Event, Telemetry.ExceptionEvent],
+        command: Tracking.Command,
+        event_name: Union[Tracking.Event, Tracking.ExceptionEvent],
         stack_trace: str,
         organization: str = "",
         workspace: str = "",
         api: str = "",
         metadata: Dict[str, Any] = {}
     ):
-        metadata["stacktrace"] = stack_trace
+        metadata["stackTrace"] = stack_trace
         if organization:
             metadata["organization"] = organization
         if workspace:
@@ -51,9 +52,10 @@ class TelemetryClient:
         payload = {
             "command": command.value,
             "eventName": event_name.value,
+            "cliVersion": __version__,
             "metadata": metadata,
         }
         try:
-            self.http_client.request('post', 'tracking', payload=payload, base_path='/intake')
+            self.http_client.request('post', 'cli_tracking', payload=payload, base_path='/intake')
         except Exception:
             pass

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -73,7 +73,7 @@ class APIErrorTest(CliTestCase):
             body=ConnectionError("error"))
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/tracking".format(
+            "{base}/intake/cli_tracking".format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
         result = self.cli("verify")
@@ -291,7 +291,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/tracking".format(
+            "{base}/intake/cli_tracking".format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
         # setup build

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import tempfile
 import threading
 from http.server import HTTPServer, SimpleHTTPRequestHandler
@@ -12,6 +13,7 @@ import responses  # type: ignore
 from launchable.utils.env_keys import BASE_URL_KEY
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
+from launchable.commands.verify import compare_version
 
 
 # dummy server for exe.jar
@@ -76,7 +78,9 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
-        assert tracking.call_count == 1
+        # responses package requires Python 3.7.
+        if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
+            assert tracking.call_count == 1
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -329,7 +333,9 @@ class APIErrorTest(CliTestCase):
         # test commands
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
-        assert tracking.call_count == 1
+        # responses package requires Python 3.7.
+        if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
+            assert tracking.call_count == 1
 
         result = self.cli("record", "build", "--name", "example")
         self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -54,22 +54,20 @@ class APIErrorTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_verify(self):
+        verification_url = "{base}/intake/organizations/{org}/workspaces/{ws}/verification".format(
+            base=get_base_url(),
+            org=self.organization,
+            ws=self.workspace)
         responses.add(
             responses.GET,
-            "{base}/intake/organizations/{org}/workspaces/{ws}/verification".format(
-                base=get_base_url(),
-                org=self.organization,
-                ws=self.workspace),
+            verification_url,
             body=ReadTimeout("error"))
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
 
         responses.add(
             responses.GET,
-            "{base}/intake/organizations/{org}/workspaces/{ws}/verification".format(
-                base=get_base_url(),
-                org=self.organization,
-                ws=self.workspace),
+            verification_url,
             body=ConnectionError("error"))
         tracking = responses.add(
             responses.POST,


### PR DESCRIPTION
We need a mechanism that can detect and alert any unexpected errors to us. Thus, I'l add the feature to collect telemetry data. Here is an example of JSON. We'll send the following informations to the our server.
```json
{
    "command": "verify",
    "eventName": "internalCLIError",
    "cliVersion": "1.67.2"
    "metadata": {
        "organization": "ono-max",
        "workspace": "test",
        "pythonVersion": "3.11.4"
        "stackTrace": "Traceback (most recent call last):\nFile /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable...",
    }
}

{
    "command": "build",
    "eventName": "networkError",
    "cliVersion": "1.69.2"
    "metadata": {
        "organization": "ono-max",
        "workspace": "test",
        "api": "/builds",
        "pythonVersion": "3.5.1"
        "stackTrace": "Traceback (most recent call last):\nFile /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable...",
    }
}
```

As a first step, I added this feature to verify command.