### PR TITLE
Automate creating tag in releasing process

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,11 +5,26 @@ name: Upload Python Package
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  push:
+    branches:
+    - main
 
 jobs:
+  tagpr:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5
+    - uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   deploy:
+    needs: tagpr
+    if: needs.tagpr.outputs.tag != ''
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,8 +17,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5
-    - uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8
+    - uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5 # v3.5.3
+    - uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8 # v1.1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Currently, we create a tag manually when releasing new changes. We can automate the process by using https://github.com/Songmu/tagpr.

When merging PR, the generated PR by tagpr is created, e.g. https://github.com/ono-max/vscode-launchable/pull/2. We can release new changes only by merging it in the new releasing process.