### PR TITLE
Define outputs for retrieving tagpr's output

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,12 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.run-tagpr.outputs.tag }}
     steps:
     - uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5 # v3.5.3
-    - uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8 # v1.1.2
+    - id: run-tagpr
+      uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8 # v1.1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Although we can get output between steps, it's not possible to get output directory between jobs. Thus, we need to use `jobs.<job_id>.outputs`.

Ref: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

I confirmed that this works well by releasing my extension with https://github.com/ono-max/vscode-launchable/commit/e3f27aa202cc6788912355dfef3734694463ddc5.