### PR TITLE
Ignore tagpr job temporary

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
   deploy:
     needs: tagpr
-    if: needs.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
## Background

I tried to release the new version of CLI with tagpr. Unfortunately it was not working correctly. Thus, I need to release https://github.com/launchableinc/cli/releases/tag/v1.71.0  manually.



## Struggle with releasing CLI

I enabled workflow_dispatch in release action to release CLI (https://github.com/launchableinc/cli/pull/599). However it’s failed since the version is invalid. https://github.com/launchableinc/cli/actions/runs/5793121929. From my investigation, the version of tag is updated since new change is pushed to master. Thus, we need to checkout tag v1.71.0, but it’s failed in tagpr job (https://github.com/launchableinc/cli/actions/runs/5793167123 ) when running workflow manually with v1.71.0. As a temporary fix, let me ignore tagpr job. After trying it, I’ll revert the change.