### PR TITLE
Update discord messages

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -66,4 +66,4 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI {{ EVENT_PAYLOAD.release.tag_name }} is released! {{ EVENT_PAYLOAD.release.html_url }}'
+        args: 'Launchable CLI is released!'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -66,4 +66,4 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI is released!'
+        args: 'Launchable CLI {{ needs.tagpr.outputs.tag }} is released!'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -66,4 +66,4 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI {{ needs.tagpr.outputs.tag }} is released!'
+        args: 'Launchable CLI {{ needs.tagpr.outputs.tag }} is released! https://github.com/launchableinc/cli/releases/tag/{{ needs.tagpr.outputs.tag }}'


### PR DESCRIPTION
Currently discord workflow is failed in https://github.com/launchableinc/cli/actions/runs/5793863689/job/15702394002#step:9:15 since the triggered event name for releasing is changed in https://github.com/launchableinc/cli/pull/595. Thus, we need to update the message in discord workflow.