### PR TITLE
Fix the notification message in Github Actions for Discord

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -65,5 +65,6 @@ jobs:
       uses: Ilshidur/action-discord@0.3.0
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        TAG_NAME: ${{ needs.tagpr.outputs.tag }}
       with:
-        args: 'Launchable CLI {{ needs.tagpr.outputs.tag }} is released! https://github.com/launchableinc/cli/releases/tag/{{ needs.tagpr.outputs.tag }}'
+        args: 'Launchable CLI {{ TAG_NAME }} is released! https://github.com/launchableinc/cli/releases/tag/{{ TAG_NAME }}'


### PR DESCRIPTION
`needs.tagpr.outputs.tag` cannot be referred from Ilshidur/action-discord (https://github.com/launchableinc/cli/actions/runs/5803613994/job/15731973019#step:9:15). Thus, we need to use enviroment variables instead.

> Environment variables can be interpolated in the message using brackets ({{ and }}) :
https://github.com/Ilshidur/action-discord#arguments
