### PR TITLE
Pass to output values as string

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -66,4 +66,4 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI {{ needs.tagpr.outputs.tag }} is released! https://github.com/launchableinc/cli/releases/tag/{{ needs.tagpr.outputs.tag }}'
+        args: 'Launchable CLI ${{ needs.tagpr.outputs.tag }} is released! https://github.com/launchableinc/cli/releases/tag/${{ needs.tagpr.outputs.tag }}'


### PR DESCRIPTION
To fix https://github.com/launchableinc/cli/actions/runs/5803613994/job/15731973019#step:9:15

We pass these output values as an object(or a function) now. (Sorry, I don't know how should I say)
But we need to pass these output values as strings. So I fixed it.

> When you use expressions in an if conditional, you may omit the ${{ }} expression syntax because GitHub Actions automatically evaluates the if conditional as an expression. Using the ${{ }} expression syntax turns the contents into a string, and strings are truth.

https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions