### PR TITLE
Add validation when both option --no-build and --session are set

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -186,7 +186,7 @@ def tests(
     if is_no_build and session:
         click.echo(
             click.style(
-                "WARNING: Both options `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignore `--no-build` option".format(session),  # noqa: E501
+                "WARNING: `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignoring `--no-build` option".format(session),  # noqa: E501
                 fg='yellow'),
             err=True)
         is_no_build = False

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -183,6 +183,14 @@ def tests(
         raise click.UsageError(
             'The cli already created `.launchable` file. If you want to use `--no-build` option, please remove `.launchable` file before executing.')  # noqa: E501
 
+    if is_no_build and session:
+        click.echo(
+            click.style(
+                "WARNING: Both options `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignore `--no-build` option".format(session),  # noqa: E501
+                fg='yellow'),
+            err=True)
+        is_no_build = False
+
     try:
         if is_no_build:
             session_id = "builds/{}/test_sessions/{}".format(NO_BUILD_BUILD_NAME, NO_BUILD_TEST_SESSION_ID)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -201,7 +201,7 @@ def subset(
     if is_no_build and session:
         click.echo(
             click.style(
-                "WARNING: Both options `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignore `--no-build` option".format(session),  # noqa: E501
+                "WARNING: `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignoring `--no-build` option".format(session),  # noqa: E501
                 fg='yellow'),
             err=True)
         is_no_build = False

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -198,6 +198,14 @@ def subset(
             )
             sys.exit(1)
 
+    if is_no_build and session:
+        click.echo(
+            click.style(
+                "WARNING: Both options `--session` and `--no-build` are set.\nUsing --session option value ({}) and ignore `--no-build` option".format(session),  # noqa: E501
+                fg='yellow'),
+            err=True)
+        is_no_build = False
+
     session_id = None
     try:
         session_id = find_or_create_session(


### PR DESCRIPTION
When the user set both the `--session` option and the `--no-build` option are set, the `--no-build` option, the `--no-build` option will be prioritized now. 
However, if the user set a session value, the CLI should prioritize it, so I fixed it.