### PR TITLE
Fixed a truncation bug in the NUnit profile

### DIFF
--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -44,7 +44,8 @@ def build_path(e: Element):
         # work around a bug in NUnitXML.Logger.
         # see nunit-reporter-bug-with-nested-type.xml test case
         methodname = e.attrs['methodname']
-        idx = methodname.rfind(".")
+        bra = methodname.find("(")
+        idx = methodname.rfind(".",0,bra)
         if idx >= 0:
             # when things are going well, method name cannot contain '.' since it's not a valid character in a symbol.
             # but when NUnitXML.Logger messes up, it ends up putting the class name and the method name, like

--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -45,7 +45,7 @@ def build_path(e: Element):
         # see nunit-reporter-bug-with-nested-type.xml test case
         methodname = e.attrs['methodname']
         bra = methodname.find("(")
-        idx = methodname.rfind(".",0,bra)
+        idx = methodname.rfind(".", 0, bra)
         if idx >= 0:
             # when things are going well, method name cannot contain '.' since it's not a valid character in a symbol.
             # but when NUnitXML.Logger messes up, it ends up putting the class name and the method name, like

--- a/tests/data/nunit/nunit-reporter-bug-with-nested-type.json
+++ b/tests/data/nunit/nunit-reporter-bug-with-nested-type.json
@@ -16,7 +16,25 @@
       "stdout": "",
       "stderr": "",
       "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "Launchable.NUnit.Test.dll" },
+        { "type": "TestSuite",   "name": "Launchable" },
+        { "type": "TestSuite",   "name": "NUnit" },
+        { "type": "TestSuite",   "name": "Test" },
+        { "type": "TestSuite",   "name": "InlineParameterTests" },
+        { "type": "TestCase",    "name": "StrTest(\"dot.in.it\")" }
+      ],
+      "created_at": "2023-08-09T 22:13:42Z",
+      "duration": 2.1e-05,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
     }
+
   ],
   "testRunner": "nunit",
   "group": "",

--- a/tests/data/nunit/nunit-reporter-bug-with-nested-type.xml
+++ b/tests/data/nunit/nunit-reporter-bug-with-nested-type.xml
@@ -14,6 +14,9 @@
       <test-suite type="TestSuite" name="NUnit" fullname="Launchable.NUnit" total="1" passed="1" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2023-07-28T 22:32:13Z" end-time="2023-07-28T 22:32:13Z" duration="1.6E-05">
         <test-suite type="TestFixture" name="Test" fullname="Launchable.NUnit.Test" classname="Launchable.NUnit.Test" total="1" passed="1" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2023-07-28T 22:32:13Z" end-time="2023-07-28T 22:32:13Z" duration="1.6E-05">
           <test-case name="TheTest" fullname="Launchable.NUnit.Test.Outer+Inner.TheTest" methodname="Outer+Inner.TheTest" classname="Test" result="Passed" start-time="2023-07-28T 22:32:13Z" end-time="2023-07-28T 22:32:13Z" duration="1.6E-05" asserts="0" seed="427950853" />
+          <test-suite type="TestFixture" name="InlineParameterTests" fullname="Launchable.NUnit.Test.InlineParameterTests" classname="Launchable.NUnit.Test.InlineParameterTests" total="1" passed="1" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2023-08-09T 22:13:42Z" end-time="2023-08-09T 22:13:42Z" duration="2.1E-05">
+            <test-case name="StrTest(&quot;dot.in.it&quot;)" fullname="Launchable.NUnit.Test.InlineParameterTests.StrTest(&quot;dot.in.it&quot;)" methodname="StrTest(&quot;dot.in.it&quot;)" classname="InlineParameterTests" result="Passed" start-time="2023-08-09T 22:13:42Z" end-time="2023-08-09T 22:13:42Z" duration="2.1E-05" asserts="0" seed="1434720057" />
+          </test-suite>
         </test-suite>
       </test-suite>
     </test-suite>


### PR DESCRIPTION
Turns out there's another odd behaviour with NUnitXML.Logger that we run into with a customer, which involves the use of TestCase annotation with parameter.

Improved the logic, and added a test case.