### PR TITLE
Add telemetry for other CLI commands

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -13,12 +13,12 @@ def find_or_create_session(
     context: click.core.Context,
     session: Optional[str],
     build_name: Optional[str],
+    tracking_client: TrackingClient,
     flavor=[],
     is_observation: bool = False,
     links: List[str] = [],
     is_no_build: bool = False,
     lineage: Optional[str] = None,
-    tracking_client: Optional[TrackingClient] = None,
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -97,7 +97,7 @@ def find_or_create_session(
             return read_session(saved_build_name)
 
 
-def _check_observation_mode_status(session: str, is_observation: bool, tracking_client: Optional[TrackingClient] = None,):
+def _check_observation_mode_status(session: str, is_observation: bool, tracking_client: TrackingClient):
     if not is_observation:
         return
 

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import click
 
 from launchable.utils.no_build import NO_BUILD_BUILD_NAME
+from launchable.utils.tracking import TrackingClient
 
 from ..utils.launchable_client import LaunchableClient
 from ..utils.session import read_build, read_session
@@ -17,6 +18,7 @@ def find_or_create_session(
     links: List[str] = [],
     is_no_build: bool = False,
     lineage: Optional[str] = None,
+    tracking_client: Optional[TrackingClient] = None,
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -38,7 +40,7 @@ def find_or_create_session(
     from .record.session import session as session_command
 
     if session:
-        _check_observation_mode_status(session, is_observation)
+        _check_observation_mode_status(session, is_observation, tracking_client=tracking_client)
         return session
 
     if is_no_build:
@@ -78,7 +80,7 @@ def find_or_create_session(
 
         session_id = read_session(saved_build_name)
         if session_id:
-            _check_observation_mode_status(session_id, is_observation)
+            _check_observation_mode_status(session_id, is_observation, tracking_client=tracking_client)
             return session_id
         else:
             context.invoke(
@@ -95,11 +97,11 @@ def find_or_create_session(
             return read_session(saved_build_name)
 
 
-def _check_observation_mode_status(session: str, is_observation: bool):
+def _check_observation_mode_status(session: str, is_observation: bool, tracking_client: Optional[TrackingClient] = None,):
     if not is_observation:
         return
 
-    client = LaunchableClient()
+    client = LaunchableClient(tracking_client=tracking_client)
     res = client.request("get", session)
 
     # only check when the status code is 200 not to stop the command

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -5,9 +5,11 @@ from http import HTTPStatus
 from typing import List, Optional
 
 import click
+from launchable.utils.authentication import get_org_workspace
 
 from launchable.utils.key_value_type import normalize_key_value_types
 from launchable.utils.link import LinkKind, capture_link
+from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...utils.click import KeyValueType, ignorable_error
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -123,7 +125,8 @@ def session(
 
         build_name = NO_BUILD_BUILD_NAME
 
-    client = LaunchableClient(dry_run=ctx.obj.dry_run)
+    tracking_client = TrackingClient(Tracking.Command.RECORD_SESSION)
+    client = LaunchableClient(dry_run=ctx.obj.dry_run, tracking_client=tracking_client)
 
     if session_name:
         sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
@@ -138,6 +141,13 @@ def session(
                     err=True)
                 sys.exit(2)
         except Exception as e:
+            org, workspace = get_org_workspace()
+            tracking_client.send_error_event(
+                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                stack_trace=str(e),
+                organization=org or "",
+                workspace=workspace or "",
+            )
             if os.getenv(REPORT_ERROR_KEY):
                 raise e
             else:
@@ -169,12 +179,18 @@ def session(
         res = client.request("post", sub_path, payload=payload)
 
         if res.status_code == HTTPStatus.NOT_FOUND:
+            msg = "Build {} was not found. Make sure to run `launchable record build --name {}` before you run this command.".format(
+                build_name, build_name)
+            org, workspace = get_org_workspace()
+            tracking_client.send_error_event(
+                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                stack_trace=msg,
+                organization=org or "",
+                workspace=workspace or "",
+            )
             click.echo(
                 click.style(
-                    "Build {} was not found. "
-                    "Make sure to run `launchable record build --name {}` before you run this command.".format(
-                        build_name,
-                        build_name),
+                    msg,
                     'yellow'),
                 err=True,
             )
@@ -195,6 +211,13 @@ def session(
             click.echo("{}/{}".format(sub_path, session_id), nl=False)
 
     except Exception as e:
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=str(e),
+            organization=org or "",
+            workspace=workspace or "",
+        )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
@@ -209,6 +232,13 @@ def session(
                 session_name=session_name,
             )
         except Exception as e:
+            org, workspace = get_org_workspace()
+            tracking_client.send_error_event(
+                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                stack_trace=str(e),
+                organization=org or "",
+                workspace=workspace or "",
+            )
             if os.getenv(REPORT_ERROR_KEY):
                 raise e
             else:

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -179,8 +179,9 @@ def session(
         res = client.request("post", sub_path, payload=payload)
 
         if res.status_code == HTTPStatus.NOT_FOUND:
-            msg = "Build {} was not found. Make sure to run `launchable record build --name {}` before you run this command.".format(
-                build_name, build_name)
+            msg = "Build {} was not found." \
+                "Make sure to run `launchable record build --name {}` before you run this command.".format(
+                    build_name, build_name)
             org, workspace = get_org_workspace()
             tracking_client.send_error_event(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -220,7 +220,8 @@ def tests(
                 build_name=build_name,
                 flavor=flavor,
                 links=links,
-                lineage=lineage))
+                lineage=lineage,
+                tracking_client=tracking_client))
             build_name = read_build()
             record_start_at = get_record_start_at(session_id, client)
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -182,7 +182,8 @@ def tests(
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 
     if is_no_build and (read_build() and read_build() != ""):
-        msg = 'The cli already created `.launchable` file. If you want to use `--no-build` option, please remove `.launchable` file before executing.'
+        msg = 'The cli already created `.launchable` file.' \
+            'If you want to use `--no-build` option, please remove `.launchable` file before executing.'
         org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -13,7 +13,8 @@ from junitparser import JUnitXml, JUnitXmlError, TestCase, TestSuite  # type: ig
 from more_itertools import ichunked
 from tabulate import tabulate
 
-from launchable.utils.authentication import ensure_org_workspace
+from launchable.utils.authentication import ensure_org_workspace, get_org_workspace
+from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
 from ...utils.click import KeyValueType
@@ -175,13 +176,21 @@ def tests(
 
     test_runner = context.invoked_subcommand
 
-    client = LaunchableClient(test_runner=test_runner, dry_run=context.obj.dry_run)
+    tracking_client = TrackingClient(Tracking.Command.RECORD_TESTS)
+    client = LaunchableClient(test_runner=test_runner, dry_run=context.obj.dry_run, tracking_client=tracking_client)
 
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 
     if is_no_build and (read_build() and read_build() != ""):
-        raise click.UsageError(
-            'The cli already created `.launchable` file. If you want to use `--no-build` option, please remove `.launchable` file before executing.')  # noqa: E501
+        msg = 'The cli already created `.launchable` file. If you want to use `--no-build` option, please remove `.launchable` file before executing.'
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=msg,
+            organization=org or "",
+            workspace=workspace or "",
+        )
+        raise click.UsageError(message=msg)  # noqa: E501
 
     try:
         if is_no_build:
@@ -216,6 +225,13 @@ def tests(
 
         build_name, test_session_id = parse_session(session_id)
     except Exception as e:
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=str(e),
+            organization=org or "",
+            workspace=workspace or "",
+        )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
@@ -501,6 +517,13 @@ def tests(
                     raise Exception(exceptions)
 
             except Exception as e:
+                org, workspace = get_org_workspace()
+                tracking_client.send_error_event(
+                    event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                    stack_trace=str(e),
+                    organization=org or "",
+                    workspace=workspace or "",
+                )
                 if os.getenv(REPORT_ERROR_KEY):
                     raise e
                 else:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -518,12 +518,12 @@ def tests(
                     raise Exception(exceptions)
 
             except Exception as e:
-                org, workspace = get_org_workspace()
+                orgn, ws = get_org_workspace()
                 tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                     stack_trace=str(e),
-                    organization=org or "",
-                    workspace=workspace or "",
+                    organization=orgn or "",
+                    workspace=ws or "",
                 )
                 if os.getenv(REPORT_ERROR_KEY):
                     raise e

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -200,9 +200,8 @@ def subset(
             sys.exit(1)
 
     session_id = None
-    tracking_client = None
+    tracking_client = TrackingClient(Tracking.Command.SUBSET)
     try:
-        tracking_client = TrackingClient(Tracking.Command.SUBSET)
         session_id = find_or_create_session(
             context=context,
             session=session,
@@ -215,14 +214,13 @@ def subset(
             tracking_client=tracking_client
         )
     except Exception as e:
-        if tracking_client:
-            org, workspace = get_org_workspace()
-            tracking_client.send_error_event(
-                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
-                stack_trace=str(e),
-                organization=org or "",
-                workspace=workspace or "",
-            )
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=str(e),
+            organization=org or "",
+            workspace=workspace or "",
+        )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
@@ -434,14 +432,13 @@ def subset(
                     is_observation = res.json().get("isObservation", False)
 
                 except Exception as e:
-                    if tracking_client:
-                        org, workspace = get_org_workspace()
-                        tracking_client.send_error_event(
-                            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
-                            stack_trace=str(e),
-                            organization=org or "",
-                            workspace=workspace or "",
-                        )
+                    org, workspace = get_org_workspace()
+                    tracking_client.send_error_event(
+                        event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                        stack_trace=str(e),
+                        organization=org or "",
+                        workspace=workspace or "",
+                    )
 
                     if os.getenv(REPORT_ERROR_KEY):
                         raise e

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -10,6 +10,7 @@ from tabulate import tabulate
 
 from launchable.utils.authentication import get_org_workspace
 from launchable.utils.session import parse_session
+from launchable.utils.tracking import Tracking, TrackingClient
 
 from ..testpath import FilePathNormalizer, TestPath
 from ..utils.click import DURATION, PERCENTAGE, DurationType, KeyValueType, PercentageType, ignorable_error
@@ -199,7 +200,9 @@ def subset(
             sys.exit(1)
 
     session_id = None
+    tracking_client = None
     try:
+        tracking_client = TrackingClient(Tracking.Command.SUBSET)
         session_id = find_or_create_session(
             context=context,
             session=session,
@@ -208,9 +211,18 @@ def subset(
             is_observation=is_observation,
             links=links,
             is_no_build=is_no_build,
-            lineage=lineage
+            lineage=lineage,
+            tracking_client=tracking_client
         )
     except Exception as e:
+        if tracking_client:
+            org, workspace = get_org_workspace()
+            tracking_client.send_error_event(
+                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                stack_trace=str(e),
+                organization=org or "",
+                workspace=workspace or "",
+            )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
@@ -399,7 +411,10 @@ def subset(
             else:
                 try:
                     test_runner = context.invoked_subcommand
-                    client = LaunchableClient(test_runner=test_runner, dry_run=context.obj.dry_run)
+                    client = LaunchableClient(
+                        test_runner=test_runner,
+                        dry_run=context.obj.dry_run,
+                        tracking_client=tracking_client)
 
                     # temporarily extend the timeout because subset API response has become slow
                     # TODO: remove this line when API response return respose
@@ -419,6 +434,15 @@ def subset(
                     is_observation = res.json().get("isObservation", False)
 
                 except Exception as e:
+                    if tracking_client:
+                        org, workspace = get_org_workspace()
+                        tracking_client.send_error_event(
+                            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                            stack_trace=str(e),
+                            organization=org or "",
+                            workspace=workspace or "",
+                        )
+
                     if os.getenv(REPORT_ERROR_KEY):
                         raise e
                     else:

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -76,9 +76,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
-        # Prior to 3.6, `Response` object can't be obtained.
-        if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
-            assert tracking.call_count == 2
+        self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -111,10 +109,17 @@ class APIErrorTest(CliTestCase):
         with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
             responses.add(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds".format(
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
+            tracking = responses.add(
+                responses.POST,
+                "{base}/intake/cli_tracking".format(
+                    base=get_base_url()),
+                body=ReadTimeout("error"))
 
             result = self.cli("record", "build", "--name", "example")
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.exception, None)
+            # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
+            self.assert_tracking_count(tracking=tracking, count=1)
 
         success_server.shutdown()
         thread.join()
@@ -130,10 +135,17 @@ class APIErrorTest(CliTestCase):
         with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
             responses.add(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds".format(
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
+            tracking = responses.add(
+                responses.POST,
+                "{base}/intake/cli_tracking".format(
+                    base=get_base_url()),
+                body=ReadTimeout("error"))
 
             result = self.cli("record", "build", "--name", "example")
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.exception, None)
+            # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
+            self.assert_tracking_count(tracking=tracking, count=1)
 
         error_server.shutdown()
         thread.join()
@@ -150,9 +162,16 @@ class APIErrorTest(CliTestCase):
                 ws=self.workspace,
                 build=build),
             status=500)
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         result = self.cli("record", "session", "--build", build)
         self.assertEqual(result.exit_code, 0)
+        # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
+        self.assert_tracking_count(tracking=tracking, count=1)
 
         build = "not_found"
         responses.add(
@@ -163,9 +182,15 @@ class APIErrorTest(CliTestCase):
                 ws=self.workspace,
                 build=build),
             status=404)
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         result = self.cli("record", "session", "--build", build)
         self.assertEqual(result.exit_code, 1)
+        self.assert_tracking_count(tracking=tracking, count=1)
 
         responses.replace(
             responses.GET,
@@ -178,9 +203,15 @@ class APIErrorTest(CliTestCase):
             ),
             body=ReadTimeout("error")
         )
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
         self.assertEqual(result.exit_code, 0)
+        self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -192,6 +223,11 @@ class APIErrorTest(CliTestCase):
                 org=self.organization,
                 ws=self.workspace),
             status=500)
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         subset_file = "example_test.rb"
 
@@ -212,6 +248,8 @@ class APIErrorTest(CliTestCase):
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
             self.assertTrue(subset_file in result.stdout)
             self.assertEqual(Path(rest_file.name).read_text(), "")
+            # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
+            self.assert_tracking_count(tracking=tracking, count=1)
 
         responses.replace(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
             base=get_base_url(), org=self.organization, ws=self.workspace), status=404)
@@ -234,6 +272,11 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             body=ReadTimeout("error"))
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             result = self.cli("subset",
                               "--target",
@@ -246,6 +289,7 @@ class APIErrorTest(CliTestCase):
                               "minitest",
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
+            self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -259,9 +303,16 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             json=[], status=500)
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
+        # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
+        self.assert_tracking_count(tracking=tracking, count=1)
 
         responses.replace(
             responses.POST,
@@ -272,9 +323,16 @@ class APIErrorTest(CliTestCase):
                 build=self.build_name,
                 session_id=self.session_id),
             json=[], status=404)
+        tracking = responses.add(
+            responses.POST,
+            "{base}/intake/cli_tracking".format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
 
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
+
+        self.assert_tracking_count(tracking=tracking, count=1)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -302,13 +360,6 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         # setup subset
         responses.replace(
-            responses.POST,
-            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
-                base=get_base_url(),
-                org=self.organization,
-                ws=self.workspace),
-            body=ReadTimeout("error"))
-        responses.replace(
             responses.GET,
             "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}/test_sessions/{session_id}".format(
                 base=get_base_url(),
@@ -331,12 +382,12 @@ class APIErrorTest(CliTestCase):
         # test commands
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
-        # Prior to 3.6, `Response` object can't be obtained.
-        if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
-            assert tracking.call_count == 2
+        self.assert_tracking_count(tracking=tracking, count=2)
 
         result = self.cli("record", "build", "--name", "example")
         self.assertEqual(result.exit_code, 0)
+
+        self.assert_tracking_count(tracking=tracking, count=4)
 
         # set delete=False to solve the error `PermissionError: [Errno 13] Permission denied:` on Windows.
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
@@ -352,5 +403,13 @@ class APIErrorTest(CliTestCase):
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
 
+        self.assert_tracking_count(tracking=tracking, count=6)
+
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
+        self.assert_tracking_count(tracking=tracking, count=8)
+
+    def assert_tracking_count(self, tracking, count: int):
+        # Prior to 3.6, `Response` object can't be obtained.
+        if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
+            assert tracking.call_count == count

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -79,6 +79,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
@@ -214,6 +215,7 @@ class APIErrorTest(CliTestCase):
 
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
         self.assertEqual(result.exit_code, 0)
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
@@ -292,6 +294,7 @@ class APIErrorTest(CliTestCase):
                               "minitest",
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
+            # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
             self.assert_tracking_count(tracking=tracking, count=2)
 
     @responses.activate
@@ -385,11 +388,13 @@ class APIErrorTest(CliTestCase):
         # test commands
         result = self.cli("verify")
         self.assertEqual(result.exit_code, 0)
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=2)
 
         result = self.cli("record", "build", "--name", "example")
         self.assertEqual(result.exit_code, 0)
 
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=4)
 
         # set delete=False to solve the error `PermissionError: [Errno 13] Permission denied:` on Windows.
@@ -406,10 +411,12 @@ class APIErrorTest(CliTestCase):
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assertEqual(result.exit_code, 0)
 
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=6)
 
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assertEqual(result.exit_code, 0)
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=8)
 
     def assert_tracking_count(self, tracking, count: int):

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -48,6 +48,9 @@ class ErrorCommitHandlerMock(SimpleHTTPRequestHandler):
         self.wfile.write(json.dumps(body).encode("utf-8"))
 
 
+CLI_TRACKING_URL = "{base}/intake/cli_tracking"
+
+
 class APIErrorTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/minitest/').resolve()
 
@@ -71,7 +74,7 @@ class APIErrorTest(CliTestCase):
             body=ConnectionError("error"))
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
         result = self.cli("verify")
@@ -111,7 +114,7 @@ class APIErrorTest(CliTestCase):
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
             tracking = responses.add(
                 responses.POST,
-                "{base}/intake/cli_tracking".format(
+                CLI_TRACKING_URL.format(
                     base=get_base_url()),
                 body=ReadTimeout("error"))
 
@@ -137,7 +140,7 @@ class APIErrorTest(CliTestCase):
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
             tracking = responses.add(
                 responses.POST,
-                "{base}/intake/cli_tracking".format(
+                CLI_TRACKING_URL.format(
                     base=get_base_url()),
                 body=ReadTimeout("error"))
 
@@ -164,7 +167,7 @@ class APIErrorTest(CliTestCase):
             status=500)
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -184,7 +187,7 @@ class APIErrorTest(CliTestCase):
             status=404)
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -205,7 +208,7 @@ class APIErrorTest(CliTestCase):
         )
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -225,7 +228,7 @@ class APIErrorTest(CliTestCase):
             status=500)
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -274,7 +277,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
@@ -305,7 +308,7 @@ class APIErrorTest(CliTestCase):
             json=[], status=500)
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -325,7 +328,7 @@ class APIErrorTest(CliTestCase):
             json=[], status=404)
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
@@ -347,7 +350,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         tracking = responses.add(
             responses.POST,
-            "{base}/intake/cli_tracking".format(
+            CLI_TRACKING_URL.format(
                 base=get_base_url()),
             body=ReadTimeout("error"))
         # setup build

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -43,7 +43,7 @@ class HelperTest(CliTestCase):
                     "isObservation": False
                 }, status=200)
 
-            _check_observation_mode_status(test_session, True)
+            _check_observation_mode_status(test_session, True, tracking_client=tracking_client)
             self.assertIn("WARNING:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
@@ -54,7 +54,7 @@ class HelperTest(CliTestCase):
                     "isObservation": True
                 }, status=200)
 
-            _check_observation_mode_status(test_session, True)
+            _check_observation_mode_status(test_session, True, tracking_client=tracking_client)
             self.assertNotIn("WARNING:", stderr.getvalue())
 
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
@@ -65,7 +65,7 @@ class HelperTest(CliTestCase):
                     "isObservation": True
                 }, status=404)
 
-            _check_observation_mode_status(test_session, False)
+            _check_observation_mode_status(test_session, False, tracking_client=tracking_client)
 
             # not check when status isn't 200
             self.assertNotIn("WARNING:", stderr.getvalue())

--- a/tests/commands/test_helper.py
+++ b/tests/commands/test_helper.py
@@ -7,6 +7,7 @@ import responses  # type: ignore
 
 from launchable.commands.helper import _check_observation_mode_status
 from launchable.utils.http_client import get_base_url
+from launchable.utils.tracking import Tracking, TrackingClient
 from tests.cli_test_case import CliTestCase
 
 
@@ -20,8 +21,10 @@ class HelperTest(CliTestCase):
             self.session_id,
         )
 
+        tracking_client = TrackingClient(Tracking.Command.RECORD_TESTS)
+
         with mock.patch('sys.stderr', new=StringIO()) as stderr:
-            _check_observation_mode_status(test_session, False)
+            _check_observation_mode_status(test_session, False, tracking_client=tracking_client)
             print(stderr.getvalue())
             self.assertNotIn("WARNING:", stderr.getvalue())
 


### PR DESCRIPTION
This is a follow-up PR for https://github.com/launchableinc/cli/pull/594. Since it seems working now, we can collect telemetry data in other commands, too.