### PR TITLE
Add validation for scenarios when both --observation and --output-exclusion-rules options are used

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -200,8 +200,8 @@ def subset(
 
     if is_observation and is_output_exclusion_rules:
         msg = (
-            "WARNING: Both options --observation and --output-exclusion-rules are set. "
-            "No output will be generated in this case."
+            "WARNING: --observation and --output-exclusion-rules are set. "
+            "No output will be generated."
         )
         click.echo(
             click.style(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -210,11 +210,11 @@ def subset(
             err=True,
         )
         org, workspace = get_org_workspace()
-        tracking_client.send_error_event(
+        tracking_client.send_event(
             event_name=Tracking.Event.WARNING,
-            stack_trace=msg,
             organization=org or "",
             workspace=workspace or "",
+            metadata={"warningMessage": msg}
         )
 
     if prioritize_tests_failed_within_hours is not None and prioritize_tests_failed_within_hours > 0:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -187,6 +187,15 @@ def subset(
         )
         sys.exit(1)
 
+    if is_observation and is_output_exclusion_rules:
+        click.echo(
+            click.style(
+                "WARNING: Both options --observation and --output-exclusion-rules are set. "
+                "No output will be generated in this case.",
+                fg="yellow"),
+            err=True,
+        )
+
     if prioritize_tests_failed_within_hours is not None and prioritize_tests_failed_within_hours > 0:
         if ignore_new_tests or (ignore_flaky_tests_above is not None and ignore_flaky_tests_above > 0):
             click.echo(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -10,6 +10,7 @@ from tabulate import tabulate
 
 from launchable.utils.authentication import get_org_workspace
 from launchable.utils.session import parse_session
+from launchable.utils.tracking import Tracking, TrackingClient
 
 from ..testpath import FilePathNormalizer, TestPath
 from ..utils.click import DURATION, PERCENTAGE, DurationType, KeyValueType, PercentageType, ignorable_error
@@ -178,32 +179,62 @@ def subset(
     lineage: Optional[str] = None,
     prioritize_tests_failed_within_hours: Optional[int] = None,
 ):
+    tracking_client = TrackingClient(Tracking.Command.SUBSET)
+
     if is_observation and is_get_tests_from_previous_sessions:
+        msg = "Cannot use --observation and --get-tests-from-previous-sessions options at the same time"
         click.echo(
             click.style(
-                "Cannot use --observation and --get-tests-from-previous-sessions options at the same time",
+                msg,
                 fg="red"),
             err=True,
+        )
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=msg,
+            organization=org or "",
+            workspace=workspace or "",
         )
         sys.exit(1)
 
     if is_observation and is_output_exclusion_rules:
+        msg = (
+            "WARNING: Both options --observation and --output-exclusion-rules are set. "
+            "No output will be generated in this case."
+        )
         click.echo(
             click.style(
-                "WARNING: Both options --observation and --output-exclusion-rules are set. "
-                "No output will be generated in this case.",
+                msg,
                 fg="yellow"),
             err=True,
+        )
+        org, workspace = get_org_workspace()
+        tracking_client.send_error_event(
+            event_name=Tracking.Event.WARNING,
+            stack_trace=msg,
+            organization=org or "",
+            workspace=workspace or "",
         )
 
     if prioritize_tests_failed_within_hours is not None and prioritize_tests_failed_within_hours > 0:
         if ignore_new_tests or (ignore_flaky_tests_above is not None and ignore_flaky_tests_above > 0):
+            msg = (
+                "Cannot use --ignore-new-tests or --ignore-flaky-tests-above options "
+                "with --prioritize-tests-failed-within-hours"
+            )
             click.echo(
                 click.style(
-                    "Cannot use --ignore-new-tests or --ignore-flaky-tests-above options "
-                    "with --prioritize-tests-failed-within-hours",
+                    msg,
                     fg="red"),
                 err=True,
+            )
+            org, workspace = get_org_workspace()
+            tracking_client.send_error_event(
+                event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                stack_trace=msg,
+                organization=org or "",
+                workspace=workspace or "",
             )
             sys.exit(1)
 

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -44,7 +44,7 @@ class TrackingClient:
 
     def send_event(
         self,
-        event_name: Union[Tracking.Event, Tracking.ErrorEvent],
+        event_name: Tracking.Event,
         organization: str = "",
         workspace: str = "",
         metadata: Optional[Dict[str, Any]] = None
@@ -60,7 +60,7 @@ class TrackingClient:
 
     def send_error_event(
         self,
-        event_name: Union[Tracking.Event, Tracking.ErrorEvent],
+        event_name: Tracking.ErrorEvent,
         stack_trace: str,
         organization: str = "",
         workspace: str = "",

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -10,6 +10,7 @@ from launchable.version import __version__
 class Tracking:
     # General events
     class Event(Enum):
+        WARNING = 'WARNING'
         SHALLOW_CLONE = 'shallow_clone'  # this event is an example
 
     # Error events

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -466,6 +466,7 @@ class SubsetTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "")
+        self.assertIn("WARNING: Both options --observation and --output-exclusion-rules are set.", result.stderr)
 
         self.assertEqual(rest.read().decode(), os.linesep.join(
             ["test_aaa.py", "test_bbb.py", "test_ccc.py", "test_111.py", "test_222.py", "test_333.py"]))

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -466,7 +466,7 @@ class SubsetTest(CliTestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "")
-        self.assertIn("WARNING: Both options --observation and --output-exclusion-rules are set.", result.stderr)
+        self.assertIn("WARNING: --observation and --output-exclusion-rules are set.", result.stderr)
 
         self.assertEqual(rest.read().decode(), os.linesep.join(
             ["test_aaa.py", "test_bbb.py", "test_ccc.py", "test_111.py", "test_222.py", "test_333.py"]))


### PR DESCRIPTION
When using both --observation and --output-exclusion-rules options, no output is generated in the standard error. It would be beneficial to inform users about this behaviour.

## Example
```shell
$ /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable subset --output-exclusion-rules --observation maven src/test/java
WARNING: Both options --observation and --output-exclusion-rules are set. No output will be generated in this case.
Your model is currently in training
Launchable created subset 52 for build sample (test session 46) in workspace launchableinc/mothership
(This test session is under observation mode)

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |            4 |                   100.00 |                       0.00 |
| Remainder |            0 |                     0.00 |                       0.00 |
|           |              |                          |                            |
| Total     |            4 |                   100.00 |                       0.00 |

Run `launchable inspect subset --subset-id 52` to view full subset details
```