### PR TITLE
Retrieve organization and workspace within send_error_event method

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -238,12 +238,9 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         build_id = res.json().get("id", None)
 
     except Exception as e:
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
-            organization=org or "",
-            workspace=workspace or "",
         )
         if os.getenv(REPORT_ERROR_KEY):
             raise e

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 from typing import List, Optional
 
 import click
-from launchable.utils.authentication import get_org_workspace
 
 from launchable.utils.key_value_type import normalize_key_value_types
 from launchable.utils.link import LinkKind, capture_link
@@ -141,12 +140,9 @@ def session(
                     err=True)
                 sys.exit(2)
         except Exception as e:
-            org, workspace = get_org_workspace()
             tracking_client.send_error_event(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=str(e),
-                organization=org or "",
-                workspace=workspace or "",
             )
             if os.getenv(REPORT_ERROR_KEY):
                 raise e
@@ -182,12 +178,9 @@ def session(
             msg = "Build {} was not found." \
                 "Make sure to run `launchable record build --name {}` before you run this command.".format(
                     build_name, build_name)
-            org, workspace = get_org_workspace()
             tracking_client.send_error_event(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=msg,
-                organization=org or "",
-                workspace=workspace or "",
             )
             click.echo(
                 click.style(
@@ -212,12 +205,9 @@ def session(
             click.echo("{}/{}".format(sub_path, session_id), nl=False)
 
     except Exception as e:
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
-            organization=org or "",
-            workspace=workspace or "",
         )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -233,12 +223,9 @@ def session(
                 session_name=session_name,
             )
         except Exception as e:
-            org, workspace = get_org_workspace()
             tracking_client.send_error_event(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=str(e),
-                organization=org or "",
-                workspace=workspace or "",
             )
             if os.getenv(REPORT_ERROR_KEY):
                 raise e

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -13,7 +13,7 @@ from junitparser import JUnitXml, JUnitXmlError, TestCase, TestSuite  # type: ig
 from more_itertools import ichunked
 from tabulate import tabulate
 
-from launchable.utils.authentication import ensure_org_workspace, get_org_workspace
+from launchable.utils.authentication import ensure_org_workspace
 from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
@@ -184,12 +184,10 @@ def tests(
     if is_no_build and (read_build() and read_build() != ""):
         msg = 'The cli already created `.launchable` file.' \
             'If you want to use `--no-build` option, please remove `.launchable` file before executing.'
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=msg,
-            organization=org or "",
-            workspace=workspace or "",
+
         )
         raise click.UsageError(message=msg)  # noqa: E501
 
@@ -235,12 +233,9 @@ def tests(
 
         build_name, test_session_id = parse_session(session_id)
     except Exception as e:
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
-            organization=org or "",
-            workspace=workspace or "",
         )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -527,12 +522,9 @@ def tests(
                     raise Exception(exceptions)
 
             except Exception as e:
-                orgn, ws = get_org_workspace()
                 tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                     stack_trace=str(e),
-                    organization=orgn or "",
-                    workspace=ws or "",
                 )
                 if os.getenv(REPORT_ERROR_KEY):
                     raise e

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -189,12 +189,9 @@ def subset(
                 fg="red"),
             err=True,
         )
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=msg,
-            organization=org or "",
-            workspace=workspace or "",
         )
         sys.exit(1)
 
@@ -209,11 +206,8 @@ def subset(
                 fg="yellow"),
             err=True,
         )
-        org, workspace = get_org_workspace()
         tracking_client.send_event(
             event_name=Tracking.Event.WARNING,
-            organization=org or "",
-            workspace=workspace or "",
             metadata={"warningMessage": msg}
         )
 
@@ -229,12 +223,9 @@ def subset(
                     fg="red"),
                 err=True,
             )
-            org, workspace = get_org_workspace()
             tracking_client.send_error_event(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=msg,
-                organization=org or "",
-                workspace=workspace or "",
             )
             sys.exit(1)
 
@@ -261,12 +252,10 @@ def subset(
             tracking_client=tracking_client
         )
     except Exception as e:
-        org, workspace = get_org_workspace()
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
-            organization=org or "",
-            workspace=workspace or "",
+
         )
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -479,12 +468,9 @@ def subset(
                     is_observation = res.json().get("isObservation", False)
 
                 except Exception as e:
-                    org, workspace = get_org_workspace()
                     tracking_client.send_error_event(
                         event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                         stack_trace=str(e),
-                        organization=org or "",
-                        workspace=workspace or "",
                     )
 
                     if os.getenv(REPORT_ERROR_KEY):

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -99,8 +99,6 @@ def verify():
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
-            organization=org,
-            workspace=workspace,
             api="verification",
         )
         if os.getenv(REPORT_ERROR_KEY):

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -56,8 +56,6 @@ class LaunchableClient:
                 self.tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.NETWORK_ERROR,
                     stack_trace=str(e),
-                    organization=self.organization,
-                    workspace=self.workspace,
                     api=sub_path,
                 )
             raise e
@@ -66,8 +64,6 @@ class LaunchableClient:
                 self.tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.TIMEOUT_ERROR,
                     stack_trace=str(e),
-                    organization=self.organization,
-                    workspace=self.workspace,
                     api=sub_path,
                 )
             raise e
@@ -76,8 +72,6 @@ class LaunchableClient:
                 self.tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.UNEXPECTED_HTTP_STATUS_ERROR,
                     stack_trace=str(e),
-                    organization=self.organization,
-                    workspace=self.workspace,
                     api=sub_path,
                 )
             raise e
@@ -86,8 +80,6 @@ class LaunchableClient:
                 self.tracking_client.send_error_event(
                     event_name=Tracking.ErrorEvent.INTERNAL_SERVER_ERROR,
                     stack_trace=str(e),
-                    organization=self.organization,
-                    workspace=self.workspace,
                     api=sub_path,
                 )
             raise e

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Dict, Any, Optional, Union
 
 from requests import Session
+from launchable.utils.authentication import get_org_workspace
 from launchable.utils.http_client import _HttpClient, _join_paths
 
 from launchable.version import __version__
@@ -45,14 +46,13 @@ class TrackingClient:
     def send_event(
         self,
         event_name: Tracking.Event,
-        organization: str = "",
-        workspace: str = "",
         metadata: Optional[Dict[str, Any]] = None
     ):
+        org, workspace = get_org_workspace()
         if metadata is None:
             metadata = {}
-        metadata["organization"] = organization
-        metadata["workspace"] = workspace
+        metadata["organization"] = org or ""
+        metadata["workspace"] = workspace or ""
         self._post_payload(
             event_name=event_name,
             metadata=metadata,
@@ -62,16 +62,15 @@ class TrackingClient:
         self,
         event_name: Tracking.ErrorEvent,
         stack_trace: str,
-        organization: str = "",
-        workspace: str = "",
         api: str = "",
         metadata: Optional[Dict[str, Any]] = None
     ):
+        org, workspace = get_org_workspace()
         if metadata is None:
             metadata = {}
         metadata["stackTrace"] = stack_trace
-        metadata["organization"] = organization
-        metadata["workspace"] = workspace
+        metadata["organization"] = org or ""
+        metadata["workspace"] = workspace or ""
         metadata["api"] = api
         self._post_payload(
             event_name=event_name,


### PR DESCRIPTION
This PR addresses https://github.com/launchableinc/cli/pull/618#discussion_r1309583655. In this update, I've implemented a modification where `get_org_workspace()` method is invoked within `send_error_event` method, effectively preventing redundant calls.