### PR TITLE
Define Warning as an error instead of normal event

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -206,9 +206,9 @@ def subset(
                 fg="yellow"),
             err=True,
         )
-        tracking_client.send_event(
-            event_name=Tracking.Event.WARNING,
-            metadata={"warningMessage": msg}
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.WARNING_ERROR,
+            stack_trace=msg
         )
 
     if prioritize_tests_failed_within_hours is not None and prioritize_tests_failed_within_hours > 0:

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -11,13 +11,13 @@ from launchable.version import __version__
 class Tracking:
     # General events
     class Event(Enum):
-        WARNING = 'WARNING'
         SHALLOW_CLONE = 'shallow_clone'  # this event is an example
 
     # Error events
     class ErrorEvent(Enum):
         UNKNOWN_ERROR = 'UNKNOWN_ERROR'
         INTERNAL_CLI_ERROR = 'INTERNAL_CLI_ERROR'
+        WARNING_ERROR = 'WARNING_ERROR'
         # Errors related to requests package
         NETWORK_ERROR = 'NETWORK_ERROR'
         TIMEOUT_ERROR = 'TIMEOUT_ERROR'


### PR DESCRIPTION
We have made the decision to classify WARNING event as an error event instead of normal event. Consequently, I have made necessary modifications accordingly.