### PR TITLE
Add --prioritized-tests-mapping option

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -472,11 +472,13 @@ def subset(
 
                     # The status code 422 is returned when validation error of the test mapping file occurs.
                     if res.status_code == 422:
+                        msg = "Error: {}".format(res.json().get("reason"))
+                        tracking_client.send_error_event(
+                            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                            stack_trace=msg,
+                        )
                         click.echo(
-                            click.style(
-                                "Error: {}".format(
-                                    res.json().get("reason")),
-                                fg="yellow"),
+                            click.style(msg, fg="yellow"),
                             err=True)
 
                     res.raise_for_status()

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -474,11 +474,11 @@ def subset(
                     if res.status_code == 422:
                         msg = "Error: {}".format(res.json().get("reason"))
                         tracking_client.send_error_event(
-                            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+                            event_name=Tracking.ErrorEvent.USER_ERROR,
                             stack_trace=msg,
                         )
                         click.echo(
-                            click.style(msg, fg="yellow"),
+                            click.style(msg, fg="red"),
                             err=True)
                         sys.exit(1)
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -159,7 +159,7 @@ from .test_path_writer import TestPathWriter
 )
 @click.option(
     "--prioritized-tests-mapping",
-    "prioritized_tests_mapping",
+    "prioritized_tests_mapping_file",
     help='Prioritize tests based on test mapping file',
     required=False,
     type=click.File('r'),
@@ -186,7 +186,7 @@ def subset(
     is_no_build: bool = False,
     lineage: Optional[str] = None,
     prioritize_tests_failed_within_hours: Optional[int] = None,
-    prioritized_tests_mapping: Optional[TextIO] = None,
+    prioritized_tests_mapping_file: Optional[TextIO] = None,
 ):
     tracking_client = TrackingClient(Tracking.Command.SUBSET)
 
@@ -427,8 +427,8 @@ def subset(
             if prioritize_tests_failed_within_hours:
                 payload["hoursToPrioritizeFailedTest"] = prioritize_tests_failed_within_hours
 
-            if prioritized_tests_mapping:
-                payload['prioritizedTestsMapping'] = json.load(prioritized_tests_mapping)
+            if prioritized_tests_mapping_file:
+                payload['prioritizedTestsMapping'] = json.load(prioritized_tests_mapping_file)
 
             return payload
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -480,6 +480,7 @@ def subset(
                         click.echo(
                             click.style(msg, fg="yellow"),
                             err=True)
+                        sys.exit(1)
 
                     res.raise_for_status()
 

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -18,6 +18,7 @@ class Tracking:
         UNKNOWN_ERROR = 'UNKNOWN_ERROR'
         INTERNAL_CLI_ERROR = 'INTERNAL_CLI_ERROR'
         WARNING_ERROR = 'WARNING_ERROR'
+        USER_ERROR = 'USER_ERROR'
         # Errors related to requests package
         NETWORK_ERROR = 'NETWORK_ERROR'
         TIMEOUT_ERROR = 'TIMEOUT_ERROR'


### PR DESCRIPTION
This PR introduces the `--prioritized-tests-mapping=<string>` option. Users can prioritize tests by specifying this option when loading CLI into the test mapping file.

## Format of test mapping file

Here is the format of the file:

```json
{
  "format": "prioritized-tests-v1",
  "mappings": {
    $REPO_NAME: {
      $DIRECTORY: [$TEST_PATH, ...],
      ... // repeatable
    },
    ... // repeatable
  }
}
```

* `$REPO_NAME` refers to the repository name provided in `launchable record build --source REPO_NAME=DIR`
* `$DIRECTORY` denotes the relative path within the enclosing repository. If a file under the specified directory is modified, the specified test is prioritized.
* `$TEST_PATH` is the name of a test represented in Launchable's test path notation, such as `class=example.AddTest`.

An actual example following this format is provided below:

```json
{
    "format": "prioritized-tests-v1",
    "mappings": {
        ".": {
            "src/main/resources/schema": ["file=tests/a/b/test_d.py#testcase=yy"],
            "src/test/service": ["file=aaa.py#class=bbb#testcase=ccc"]
        },
        "cli": {
            "src/utils/foobar": [
                "file=abc.py#class=abc#testcase=abc",
                "file=def.py#class=def#testcase=def"
            ]
        }
    }
}

```

## Example Usage of `--prioritized-tests-mapping=<string>` option
As an example project, we'll use https://github.com/Konboi/launchable-java-example. When creating the subset without `--prioritized-tests-mapping=<string>` option, we obtain the following result:

```
$ /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable  subset --target 80%  maven src/test/java         
example.SubTest
example.MulTest
example.DivTest
Launchable created subset 629023 for build experiment (test session 2205299) in workspace ono-max/test

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |            3 |                    75.00 |                       0.00 |
| Remainder |            1 |                    25.00 |                       0.00 |
|           |              |                          |                            |
| Total     |            4 |                   100.00 |                       0.00 |

Run `launchable inspect subset --subset-id 629023` to view full subset details
```

Next, I defined the following test mapping file and created the subset with the `--prioritized-tests-mapping=<string>` option. This resulted in the following outcome.

#### Test Mapping file
```json
{
    "format": "prioritized-tests-v1",
    "mappings": {
        ".": {
            "src/main/java/example": ["class=example.AddTest"]
        }
    }
}
```

#### Results
```
$ /Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/bin/launchable  subset --target 80% --prioritized-tests-mapping 'sample.json' maven src/test/java            
example.AddTest
example.SubTest
example.MulTest
Launchable created subset 629022 for build experiment (test session 2205299) in workspace ono-max/test

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |            3 |                    75.00 |                       0.00 |
| Remainder |            1 |                    25.00 |                       0.00 |
|           |              |                          |                            |
| Total     |            4 |                   100.00 |                       0.00 |

Run `launchable inspect subset --subset-id 629022` to view full subset details
```
As you can see, the `example.AddTest` is included when the `--prioritized-tests-mapping=<string>` option is specified.