### PR TITLE
`record build` refactoring

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -197,7 +197,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
         if no_submodules:
             return workspaces
 
-        r = [] + workspaces
+        r = workspaces.copy()
         for w in workspaces:
             submodule_pattern = re.compile(r"^[\+\-U ](?P<hash>[a-f0-9]{40}) (?P<name>\S+)")
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -111,25 +111,20 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
     # not what they want to do
 
     if no_commit_collection:
-        collect_commits = False
         if len(commits) == 0:
             detect_sources = True
             detect_submodules = not no_submodules
         else:
             detect_sources = False
             detect_submodules = False
-    else:
-        collect_commits = True
-        detect_sources = True
-        detect_submodules = not no_submodules
-
-    if collect_commits:
-        for (name, repo_dist) in repos:
-            ctx.invoke(commit, source=repo_dist, max_days=max_days, scrub_pii=scrub_pii)
-    else:
         click.echo(click.style(
             "Warning: Commit collection is turned off. The commit data must be collected separately.",
             fg='yellow'), err=True)
+    else:
+        detect_sources = True
+        detect_submodules = not no_submodules
+        for (name, repo_dist) in repos:
+            ctx.invoke(commit, source=repo_dist, max_days=max_days, scrub_pii=scrub_pii)
 
     sources = []
     branch_name_map = {}

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -187,6 +187,9 @@ class CliTestCase(unittest.TestCase):
         """
         return CliRunner(mix_stderr=mix_stderr).invoke(main, args, catch_exceptions=False, **kwargs)
 
+    def assert_success(self, result: click.testing.Result):
+        self.assertEqual(result.exit_code, 0, result.stdout)
+
     def load_json_from_file(self, file):
         try:
             with file.open() as json_file:

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -6,14 +6,14 @@ import threading
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from unittest import mock
-from requests.exceptions import ReadTimeout
 
 import responses  # type: ignore
+from requests.exceptions import ReadTimeout
 
+from launchable.commands.verify import compare_version
 from launchable.utils.env_keys import BASE_URL_KEY
 from launchable.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
-from launchable.commands.verify import compare_version
 
 
 # dummy server for exe.jar
@@ -392,7 +392,7 @@ class APIErrorTest(CliTestCase):
         self.assert_tracking_count(tracking=tracking, count=2)
 
         result = self.cli("record", "build", "--name", "example")
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=4)


### PR DESCRIPTION
I was trying to add a new capability here but felt the logic was too complex at this point. A single big function that has tons of local variables, controlling flow of executions in a non-trivial way.

The main idea of this refactoring is:
- Use a single typed `Workspace` object with properties that we are trying to compute, whereas previously this was done by multiple maps keyed by repository names
- Use well-defined sub-functions to split the work into smaller bite-sized chunks, leaving the main logic (L346-356) higher altitude.

In retrospect, this was probably too big to take on without some prior consensus building. So it's OK if we decided not to do this.

If we do choose to move forward, please advise me how best to roll this out a bit slowly & carefully. There appears to be a good number of test cases to cover this, but this is a pretty critical functionality. If I break this, it could be a major outage.
