### PR TITLE
Fix for #637

### DIFF
--- a/launchable/test_runners/robot.py
+++ b/launchable/test_runners/robot.py
@@ -56,9 +56,11 @@ def parse_func(p: str) -> ET.ElementTree:
         nested_suites = suites.findall(SUITE_TAG_NAME)
 
         if nested_suites:
+            # Run tests in a directory
             for suite in nested_suites:
                 parse_suite(suite)
         else:
+            # Run tests in a single file
             parse_suite(suites)
 
     return ET.ElementTree(testsuite)

--- a/launchable/test_runners/robot.py
+++ b/launchable/test_runners/robot.py
@@ -9,11 +9,10 @@ from . import launchable
 
 
 def parse_func(p: str) -> ET.ElementTree:
-    datetime_format = '%Y%m%d %H:%M:%S.%f'
 
-    original_tree = ET.parse(p)
-    testsuite = ET.Element("testsuite", {"name": "robot"})
-    for suite in original_tree.findall("suite/suite"):
+    def parse_suite(suite: ET.Element):
+        DATETIME_FORMAT = '%Y%m%d %H:%M:%S.%f'
+
         suite_name = suite.get('name')
         for test in suite.iter("test"):
             test_name = test.get('name')
@@ -30,8 +29,8 @@ def parse_func(p: str) -> ET.ElementTree:
                 end_time_str = status_node.get('endtime') if status_node is not None else ''
 
                 if start_time_str != '' and end_time_str != '':
-                    start_time = datetime.strptime(str(start_time_str), datetime_format)
-                    end_time = datetime.strptime(str(end_time_str), datetime_format)
+                    start_time = datetime.strptime(str(start_time_str), DATETIME_FORMAT)
+                    end_time = datetime.strptime(str(end_time_str), DATETIME_FORMAT)
 
                     duration = end_time - start_time
 
@@ -48,6 +47,19 @@ def parse_func(p: str) -> ET.ElementTree:
                     failure.text = msg.text if msg is not None else ''
                 if status == "NOT_RUN" or nested_status == 'NOT_RUN':
                     skipped = ET.SubElement(testcase, "skipped")  # noqa: F841
+
+    original_tree = ET.parse(p)
+    testsuite = ET.Element("testsuite", {"name": "robot"})
+
+    SUITE_TAG_NAME = "suite"
+    for suites in original_tree.findall(SUITE_TAG_NAME):
+        nested_suites = suites.findall(SUITE_TAG_NAME)
+
+        if nested_suites:
+            for suite in nested_suites:
+                parse_suite(suite)
+        else:
+            parse_suite(suites)
 
     return ET.ElementTree(testsuite)
 

--- a/tests/data/robot/record_test_executed_only_one_file_result.json
+++ b/tests/data/robot/record_test_executed_only_one_file_result.json
@@ -1,0 +1,61 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "Plus"
+        },
+        {
+          "type": "testcase",
+          "name": "Check method"
+        }
+      ],
+      "duration": 0.001,
+      "status": 0,
+      "stdout": "",
+      "stderr": "0 != -1",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "Plus"
+        },
+        {
+          "type": "testcase",
+          "name": "Plus method"
+        }
+      ],
+      "duration": 0.001,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "Plus"
+        },
+        {
+          "type": "testcase",
+          "name": "Plus method 2"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    }
+  ],
+  "testRunner": "robot",
+  "group": "",
+  "noBuild": false
+}

--- a/tests/data/robot/single-output.xml
+++ b/tests/data/robot/single-output.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 6.1.1 (Python 3.9.16 on darwin)" generated="20231018 14:03:28.803" rpa="false" schemaversion="4">
+<suite id="s1" name="Plus" source="/Users/yabuki-ryosuke/src/github.com/launchableinc/rocket-car-robot/plus.robot">
+<test id="s1-t1" name="Check method" line="6">
+<kw name="Result Is" library="Calculator">
+<arg>-1</arg>
+<msg timestamp="20231018 14:03:28.813" level="FAIL">0 != -1</msg>
+<status status="FAIL" starttime="20231018 14:03:28.813" endtime="20231018 14:03:28.813"/>
+</kw>
+<status status="FAIL" starttime="20231018 14:03:28.812" endtime="20231018 14:03:28.813">0 != -1</status>
+</test>
+<test id="s1-t2" name="Plus method" line="9">
+<kw name="Plus" library="Calculator">
+<arg>1</arg>
+<status status="PASS" starttime="20231018 14:03:28.813" endtime="20231018 14:03:28.813"/>
+</kw>
+<kw name="Plus" library="Calculator">
+<arg>1</arg>
+<status status="PASS" starttime="20231018 14:03:28.813" endtime="20231018 14:03:28.814"/>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arg>2</arg>
+<status status="PASS" starttime="20231018 14:03:28.814" endtime="20231018 14:03:28.814"/>
+</kw>
+<status status="PASS" starttime="20231018 14:03:28.813" endtime="20231018 14:03:28.814"/>
+</test>
+<test id="s1-t3" name="Plus method 2" line="14">
+<kw name="Plus" library="Calculator">
+<arg>10</arg>
+<status status="PASS" starttime="20231018 14:03:28.814" endtime="20231018 14:03:28.814"/>
+</kw>
+<kw name="Plus" library="Calculator">
+<arg>20</arg>
+<status status="PASS" starttime="20231018 14:03:28.814" endtime="20231018 14:03:28.814"/>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arg>30</arg>
+<status status="PASS" starttime="20231018 14:03:28.814" endtime="20231018 14:03:28.814"/>
+</kw>
+<status status="PASS" starttime="20231018 14:03:28.814" endtime="20231018 14:03:28.814"/>
+</test>
+<status status="FAIL" starttime="20231018 14:03:28.803" endtime="20231018 14:03:28.814"/>
+</suite>
+<statistics>
+<total>
+<stat pass="2" fail="1" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="2" fail="1" skip="0" id="s1" name="Plus">Plus</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -40,6 +40,7 @@ class RobotTest(CliTestCase):
         expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
         self.assert_json_orderless_equal(expected, payload)
 
+    # for #637
     @ responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_executed_only_one_file(self):

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -35,10 +35,24 @@ class RobotTest(CliTestCase):
         self.assertEqual(result.exit_code, 0)
 
         payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        for e in payload["events"]:
+            del e["created_at"]
+        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
+        self.assert_json_orderless_equal(expected, payload)
+
+    @ responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test_executed_only_one_file(self):
+
+        result = self.cli('record', 'tests', '--session', self.session,
+                          'robot', str(self.test_files_dir) + "/single-output.xml")
+        self.assertEqual(result.exit_code, 0)
+        print(result.output)
+
+        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
 
         for e in payload["events"]:
             del e["created_at"]
 
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-
+        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_executed_only_one_file_result.json"))
         self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
See: https://github.com/launchableinc/cli/issues/637

The robot plugin of the cli was designed with parse logic that assumed multiple `suite` tag. However, when specifying a file like the one below, only one `suite` tag appears, leading to parsing failure
I fixed it and supported both use cases.

Before 
```
$ robot plus.robot
==============================================================================
Plus
==============================================================================
Check method                                                          | FAIL |
0 != -1
------------------------------------------------------------------------------
Plus method                                                           | PASS |
------------------------------------------------------------------------------
Plus method 2                                                         | PASS |
------------------------------------------------------------------------------
Plus                                                                  | FAIL |
3 tests, 2 passed, 1 failed
==============================================================================
Output:  /Users/yabuki-ryosuke/src/github.com/launchableinc/rocket-car-robot/output.xml
Log:     /Users/yabuki-ryosuke/src/github.com/launchableinc/rocket-car-robot/log.html
Report:  /Users/yabuki-ryosuke/src/github.com/launchableinc/rocket-car-robot/report.html

$ launchable record tests robot output.xml
Looks like tests didn't run? If not, make sure the right files/directories were passed into `launchable record tests`
```

After 

```
$ launchable record tests output.xml
Launchable recorded tests for build robot-single (test session 134) to workspace konboi/test from 1 files:

|   Files found |   Tests found |   Tests passed |   Tests failed |   Total duration (min) |
|---------------|---------------|----------------|----------------|------------------------|
|             1 |             3 |              2 |              1 |                   0.00 |

Visit https://app.launchableinc.com/organizations/konboi/workspaces/test/test-sessions/134 to view uploaded test results (or run `launchable inspect tests --test-session-id 134`)
```