### PR TITLE
Send stderr when recording tests in nunit plugin

### DIFF
--- a/tests/data/dotnet/record_test_result.json
+++ b/tests/data/dotnet/record_test_result.json
@@ -50,7 +50,7 @@
             "duration": 0.016795,
             "status": 0,
             "stdout": "",
-            "stderr": "",
+            "stderr": "  Expected: 0.5d\n  But was:  0\n\n   at rocket_car_dotnet.ExampleTest.TestDiv() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 35\n",
             "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         },
@@ -77,7 +77,7 @@
             "duration": 0.0003959,
             "status": 0,
             "stdout": "",
-            "stderr": "",
+            "stderr": "  Expected: 10\n  But was:  25\n\n   at rocket_car_dotnet.ExampleTest.TestMul() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 28\n",
             "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         },
@@ -104,7 +104,7 @@
             "duration": 0.000308,
             "status": 0,
             "stdout": "",
-            "stderr": "",
+            "stderr": "  Expected: 2\n  But was:  6\n\n   at rocket_car_dotnet.ExampleTest.TestSub() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 21\n",
             "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         }

--- a/tests/data/nunit/output-linux.xml
+++ b/tests/data/nunit/output-linux.xml
@@ -38,12 +38,13 @@
         <test-case id="1-1006" name="Test1" fullname="calc.Tests1.Test1" methodname="Test1" classname="calc.Tests1" runstate="Runnable" seed="691785611" result="Passed" start-time="2021-05-25T01:24:39.5082923Z" end-time="2021-05-25T01:24:39.5196169Z" duration="0.011325" asserts="0" />
         <test-case id="1-1007" name="Test2" fullname="calc.Tests1.Test2" methodname="Test2" classname="calc.Tests1" runstate="Runnable" seed="1977602105" result="Failed" start-time="2021-05-25T01:24:39.5196489Z" end-time="2021-05-25T01:24:39.5295813Z" duration="0.009933" asserts="0">
           <failure>
+            <message><![CDATA[test 2 failed]]></message>
             <stack-trace><![CDATA[   at calc.Tests1.Test2() in /home/kohsuke/ws/launchable/cli/tests/data/nunit/src/Test.cs:line 17
 ]]></stack-trace>
           </failure>
           <assertions>
             <assertion result="Failed">
-              <message><![CDATA[]]></message>
+              <message><![CDATA[test 2 failed]]></message>
               <stack-trace><![CDATA[   at calc.Tests1.Test2() in /home/kohsuke/ws/launchable/cli/tests/data/nunit/src/Test.cs:line 17
 ]]></stack-trace>
             </assertion>

--- a/tests/data/nunit/output-windows.xml
+++ b/tests/data/nunit/output-windows.xml
@@ -38,12 +38,13 @@
         <test-case id="1-1006" name="Test1" fullname="calc.Tests1.Test1" methodname="Test1" classname="calc.Tests1" runstate="Runnable" seed="691785611" result="Passed" start-time="2021-05-25T01:24:39.5082923Z" end-time="2021-05-25T01:24:39.5196169Z" duration="0.011325" asserts="0" />
         <test-case id="1-1007" name="Test2" fullname="calc.Tests1.Test2" methodname="Test2" classname="calc.Tests1" runstate="Runnable" seed="1977602105" result="Failed" start-time="2021-05-25T01:24:39.5196489Z" end-time="2021-05-25T01:24:39.5295813Z" duration="0.009933" asserts="0">
           <failure>
+            <message><![CDATA[test 2 failed]]></message>
             <stack-trace><![CDATA[   at calc.Tests1.Test2() in C:\home\kohsuke\ws\launchable\cli\tests\data\nunit\src\Test.cs:line 17
 ]]></stack-trace>
           </failure>
           <assertions>
             <assertion result="Failed">
-              <message><![CDATA[]]></message>
+              <message><![CDATA[test 2 failed]]></message>
               <stack-trace><![CDATA[   at calc.Tests1.Test2() in C:\home\kohsuke\ws\launchable\cli\tests\data\nunit\src\Test.cs:line 17
 ]]></stack-trace>
             </assertion>

--- a/tests/data/nunit/record_test_result-linux.json
+++ b/tests/data/nunit/record_test_result-linux.json
@@ -1,0 +1,117 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "calc" },
+        { "type": "TestSuite",   "name": "sub" },
+        { "type": "TestSuite", "name": "Tests2" },
+        { "type": "TestCase",    "name": "Foo" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5030637Z",
+      "duration": 0.002087,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "calc" },
+        { "type": "TestSuite", "name": "Tests1" },
+        { "type": "TestCase",    "name": "Test1" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5082923Z",
+      "duration": 0.011325,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "calc" },
+        { "type": "TestSuite", "name": "Tests1" },
+        { "type": "TestCase",    "name": "Test2" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5196489Z",
+      "duration": 0.009933,
+      "status": 0,
+      "stdout": "",
+      "stderr": "test 2 failed\n   at calc.Tests1.Test2() in /home/kohsuke/ws/launchable/cli/tests/data/nunit/src/Test.cs:line 17\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "calc" },
+        { "type": "TestSuite", "name": "Outer+Inner" },
+        { "type": "TestCase",    "name": "Test3" }
+      ],
+      "created_at": "2023-07-27T17:47:58.8159407Z",
+      "duration": 0.001215,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "ParameterizedTests" },
+        { "type": "TestSuite", "name": "MyTests" },
+        { "type": "ParameterizedMethod", "name":  "DivideTest" },
+        { "type": "TestCase",    "name": "DivideTest(12,3)" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5299429Z",
+      "duration": 0.006011,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "ParameterizedTests" },
+        { "type": "TestSuite", "name": "MyTests" },
+        { "type": "ParameterizedMethod", "name":  "DivideTest" },
+        { "type": "TestCase",    "name": "DivideTest(12,2)" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5359698Z",
+      "duration": 0.000093,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "Assembly",    "name": "calc.dll" },
+        { "type": "TestSuite",   "name": "ParameterizedTests" },
+        { "type": "TestSuite", "name": "MyTests" },
+        { "type": "ParameterizedMethod", "name":  "DivideTest" },
+        { "type": "TestCase",    "name": "DivideTest(12,4)" }
+      ],
+      "created_at": "2021-05-25T01:24:39.5297832Z",
+      "duration": 0.000033,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    }
+  ],
+  "testRunner": "nunit",
+  "group": "",
+  "noBuild": false
+}

--- a/tests/data/nunit/record_test_result-windows.json
+++ b/tests/data/nunit/record_test_result-windows.json
@@ -43,7 +43,7 @@
       "duration": 0.009933,
       "status": 0,
       "stdout": "",
-      "stderr": "",
+      "stderr": "test 2 failed\n   at calc.Tests1.Test2() in C:\\home\\kohsuke\\ws\\launchable\\cli\\tests\\data\\nunit\\src\\Test.cs:line 17\n",
       "data": null
     },
     {

--- a/tests/data/nunit/src/Test.cs
+++ b/tests/data/nunit/src/Test.cs
@@ -14,7 +14,7 @@ namespace calc
         [Test]
         public void Test2()
         {
-            Assert.Fail();
+            Assert.Fail("test 2 failed");
         }
     }
 

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -168,7 +168,7 @@ class NUnitTest(CliTestCase):
 
         payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
 
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
+        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result-linux.json"))
 
         self.assert_json_orderless_equal(expected, payload)
 
@@ -181,7 +181,7 @@ class NUnitTest(CliTestCase):
 
         payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
 
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
+        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result-windows.json"))
 
         self.assert_json_orderless_equal(expected, payload)
 


### PR DESCRIPTION
Currently, our CLI's nunit plugin does not send stderr. This PR fixes that.