### PR TITLE
Fix to use total_seconds() method

### DIFF
--- a/launchable/test_runners/robot.py
+++ b/launchable/test_runners/robot.py
@@ -37,7 +37,7 @@ def parse_func(p: str) -> ET.ElementTree:
                 testcase = ET.SubElement(testsuite, "testcase", {
                     "name": str(test_name),
                     "classname": str(suite_name),
-                    "time": str(duration.microseconds / 1000 / 1000) if duration is not None else '0',
+                    "time": str(duration.total_seconds()) if duration is not None else '0',
                 })
 
                 if status == "FAIL":


### PR DESCRIPTION
The `duration` is [datetime.timedelta](https://docs.python.org/3/library/datetime.html#timedelta-objects) object. Then `microseconds` accessor returns just microseconds of the value. In the below case, `microseconds` returns 10.
But we need the total duration of the time. So we changed to use `total_seconds()` method. https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds
```
from datetime import timedelta
delta = timedelta(
    days=50,
    seconds=27,
    microseconds=10,
    milliseconds=29000,
    minutes=5,
    hours=8,
    weeks=2
)
# Only days, seconds, and microseconds remain
delta
datetime.timedelta(days=64, seconds=29156, microseconds=10)
```
