### PR TITLE
Refactoring to deal with global configs + SSL cert check bypass

### DIFF
--- a/launchable/app.py
+++ b/launchable/app.py
@@ -1,0 +1,11 @@
+# Object representing the most global state possible, which represents a single invocation of CLI
+# Currently it's used to keep global configurations.
+#
+# From command implementations, this is available from Click 'context.obj'
+class Application(object):
+    def __init__(self, dry_run: bool = False, skip_cert_verification: bool = False):
+        # Dry run mode. This command is used by customers to inspect data we'd send to our server,
+        # but without actually doing so.
+        self.dry_run = dry_run
+        # Skip SSL certificate validation
+        self.skip_cert_verification = skip_cert_verification

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -5,6 +5,7 @@ import click
 from launchable.utils.no_build import NO_BUILD_BUILD_NAME
 from launchable.utils.tracking import TrackingClient
 
+from ..app import Application
 from ..utils.launchable_client import LaunchableClient
 from ..utils.session import read_build, read_session
 
@@ -82,7 +83,7 @@ def find_or_create_session(
     from .record.session import session as session_command
 
     if session:
-        _check_observation_mode_status(session, is_observation, tracking_client=tracking_client)
+        _check_observation_mode_status(session, is_observation, tracking_client=tracking_client, app=context.obj)
         return session
 
     if is_no_build:
@@ -114,7 +115,7 @@ def find_or_create_session(
 
     session_id = read_session(saved_build_name)
     if session_id:
-        _check_observation_mode_status(session_id, is_observation, tracking_client=tracking_client)
+        _check_observation_mode_status(session_id, is_observation, tracking_client=tracking_client, app=context.obj)
         return session_id
 
     context.invoke(
@@ -131,11 +132,12 @@ def find_or_create_session(
     return read_session(saved_build_name)
 
 
-def _check_observation_mode_status(session: str, is_observation: bool, tracking_client: TrackingClient):
+def _check_observation_mode_status(session: str, is_observation: bool,
+                                   tracking_client: TrackingClient, app: Optional[Application] = None):
     if not is_observation:
         return
 
-    client = LaunchableClient(tracking_client=tracking_client)
+    client = LaunchableClient(tracking_client=tracking_client, app=app)
     res = client.request("get", session)
 
     # only check when the status code is 200 not to stop the command

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -17,11 +17,12 @@ from ...utils.launchable_client import LaunchableClient
     help='subest id',
     required=True,
 )
-def subset(subset_id: int):
+@click.pass_context
+def subset(context: click.core.Context, subset_id: int):
     subset = []
     rest = []
     try:
-        client = LaunchableClient()
+        client = LaunchableClient(app=context.obj)
         res = client.request("get", "subset/{}".format(subset_id))
 
         if res.status_code == HTTPStatus.NOT_FOUND:

--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -16,9 +16,10 @@ from ...utils.launchable_client import LaunchableClient
     help='test session id',
     required=True
 )
-def tests(test_session_id: int):
+@click.pass_context
+def tests(context: click.core.Context, test_session_id: int):
     try:
-        client = LaunchableClient()
+        client = LaunchableClient(app=context.obj)
         res = client.request(
             "get", "/test_sessions/{}/events".format(test_session_id))
 

--- a/launchable/commands/record/attachment.py
+++ b/launchable/commands/record/attachment.py
@@ -16,14 +16,16 @@ from ..helper import require_session
     type=str,
 )
 @click.argument('attachments', nargs=-1)  # type=click.Path(exists=True)
+@click.pass_context
 def attachment(
+        context: click.core.Context,
         attachments,
         session: Optional[str] = None
 ):
     try:
         session = require_session(session)
 
-        client = LaunchableClient()
+        client = LaunchableClient(app=context.obj)
         for a in attachments:
             click.echo("Sending {}".format(a))
             with open(a, mode='rb') as f:

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -285,7 +285,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 })
             return _links
 
-        tracking_client = TrackingClient(Tracking.Command.RECORD_BUILD)
+        tracking_client = TrackingClient(Tracking.Command.RECORD_BUILD, app=ctx.obj)
         try:
             payload = {
                 "buildNumber": build_name,
@@ -297,7 +297,7 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 "links": compute_links()
             }
 
-            client = LaunchableClient(dry_run=ctx.obj.dry_run, tracking_client=tracking_client)
+            client = LaunchableClient(app=ctx.obj, tracking_client=tracking_client)
 
             res = client.request("post", "builds", payload=payload)
             res.raise_for_status()

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -55,7 +55,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
         return
 
     try:
-        exec_jar(os.path.abspath(source), max_days, ctx.obj.dry_run)
+        exec_jar(os.path.abspath(source), max_days, ctx.obj)
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -69,7 +69,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
             print(e)
 
 
-def exec_jar(source: str, max_days: int, dry_run: bool):
+def exec_jar(source: str, max_days: int, app: Application):
     java = get_java_command()
 
     if not java:
@@ -94,8 +94,10 @@ def exec_jar(source: str, max_days: int, dry_run: bool):
 
     if Logger().logger.isEnabledFor(LOG_LEVEL_AUDIT):
         command.append("-audit")
-    if dry_run:
+    if app.dry_run:
         command.append("-dry-run")
+    if app.skip_cert_verification:
+        command.append("-skip-cert-verification")
     command.append(cygpath(source))
 
     subprocess.run(

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import click
 
+from ...app import Application
 from ...utils.commit_ingester import upload_commits
 from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.git_log_parser import parse_git_log
@@ -50,7 +51,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
         sys.exit("--executable docker is no longer supported")
 
     if import_git_log_output:
-        _import_git_log(import_git_log_output, ctx.obj.dry_run)
+        _import_git_log(import_git_log_output, ctx.obj)
         return
 
     try:
@@ -104,11 +105,11 @@ def exec_jar(source: str, max_days: int, dry_run: bool):
     )
 
 
-def _import_git_log(output_file: str, dry_run: bool):
+def _import_git_log(output_file: str, app: Application):
     try:
         with click.open_file(output_file) as fp:
             commits = parse_git_log(fp)
-        upload_commits(commits, dry_run)
+        upload_commits(commits, app)
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):
             raise e

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -124,8 +124,8 @@ def session(
 
         build_name = NO_BUILD_BUILD_NAME
 
-    tracking_client = TrackingClient(Tracking.Command.RECORD_SESSION)
-    client = LaunchableClient(dry_run=ctx.obj.dry_run, tracking_client=tracking_client)
+    tracking_client = TrackingClient(Tracking.Command.RECORD_SESSION, app=ctx.obj)
+    client = LaunchableClient(app=ctx.obj, tracking_client=tracking_client)
 
     if session_name:
         sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -176,8 +176,8 @@ def tests(
 
     test_runner = context.invoked_subcommand
 
-    tracking_client = TrackingClient(Tracking.Command.RECORD_TESTS)
-    client = LaunchableClient(test_runner=test_runner, dry_run=context.obj.dry_run, tracking_client=tracking_client)
+    tracking_client = TrackingClient(Tracking.Command.RECORD_TESTS, app=context.obj)
+    client = LaunchableClient(test_runner=test_runner, app=context.obj, tracking_client=tracking_client)
 
     file_path_normalizer = FilePathNormalizer(base_path, no_base_path_inference=no_base_path_inference)
 

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -5,6 +5,7 @@ import click
 
 from launchable.testpath import TestPath
 
+from ..app import Application
 from ..utils.click import FRACTION, FractionType
 from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.launchable_client import LaunchableClient
@@ -97,11 +98,11 @@ def split_subset(
 
     TestPathWriter.base_path = base_path
 
-    client = LaunchableClient(test_runner=context.invoked_subcommand, dry_run=context.obj.dry_run)
+    client = LaunchableClient(test_runner=context.invoked_subcommand, app=context.obj)
 
     class SplitSubset(TestPathWriter):
-        def __init__(self, dry_run: bool = False):
-            super(SplitSubset, self).__init__(dry_run=dry_run)
+        def __init__(self, app: Application):
+            super(SplitSubset, self).__init__(app=app)
             self.rest = rest
             self.output_handler = self._default_output_handler
             self.exclusion_output_handler = self._default_exclusion_output_handler
@@ -338,4 +339,4 @@ def split_subset(
             else:
                 self.split_by_bin()
 
-    context.obj = SplitSubset(dry_run=context.obj.dry_run)
+    context.obj = SplitSubset(app=context.obj)

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -5,8 +5,8 @@ import click
 
 from ...utils.click import KeyValueType
 from ...utils.env_keys import REPORT_ERROR_KEY
-from ...utils.launchable_client import LaunchableClient
 from ...utils.key_value_type import normalize_key_value_types
+from ...utils.launchable_client import LaunchableClient
 
 
 @click.command()
@@ -42,7 +42,7 @@ def test_sessions(
         params.pop('flavor', None)
 
     try:
-        client = LaunchableClient(dry_run=context.obj.dry_run)
+        client = LaunchableClient(app=context.obj)
         res = client.request('get', '/stats/test-sessions', params=params)
         res.raise_for_status()
         click.echo(res.text)

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -3,17 +3,18 @@ from typing import Callable, Dict, List, Optional
 
 import click
 
+from ..app import Application
 from ..testpath import TestPath
 
 
 class TestPathWriter(object):
     base_path: Optional[str] = None
 
-    def __init__(self, dry_run=False):
+    def __init__(self, app: Application):
         self._formatter = TestPathWriter.default_formatter
         self._separator = "\n"
         self._same_bin_formatter = None
-        self.dry_run = dry_run
+        self.app = app
 
     @classmethod
     def default_formatter(cls, x: TestPath):

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -11,7 +11,7 @@ class TestPathWriter(object):
     base_path: Optional[str] = None
 
     def __init__(self, app: Application):
-        self._formatter = TestPathWriter.default_formatter  # type: Callable[[TestPath], str]
+        self._formatter: Callable[[TestPath], str] = TestPathWriter.default_formatter
         self._separator = "\n"
         self._same_bin_formatter = None  # type: Optional[Callable[[str], Dict[str, str]]]
         self.app = app

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -13,7 +13,7 @@ class TestPathWriter(object):
     def __init__(self, app: Application):
         self._formatter: Callable[[TestPath], str] = TestPathWriter.default_formatter
         self._separator = "\n"
-        self._same_bin_formatter = None  # type: Optional[Callable[[str], Dict[str, str]]]
+        self._same_bin_formatter: Optional[Callable[[str], Dict[str, str]]] = None
         self.app = app
 
     @classmethod

--- a/launchable/commands/test_path_writer.py
+++ b/launchable/commands/test_path_writer.py
@@ -11,9 +11,9 @@ class TestPathWriter(object):
     base_path: Optional[str] = None
 
     def __init__(self, app: Application):
-        self._formatter = TestPathWriter.default_formatter
+        self._formatter = TestPathWriter.default_formatter  # type: Callable[[TestPath], str]
         self._separator = "\n"
-        self._same_bin_formatter = None
+        self._same_bin_formatter = None  # type: Optional[Callable[[str], Dict[str, str]]]
         self.app = app
 
     @classmethod
@@ -55,7 +55,7 @@ class TestPathWriter(object):
                                        for t in test_paths))
 
     @property
-    def same_bin_formatter(self) -> Callable[[str], Dict[str, str]]:
+    def same_bin_formatter(self) -> Optional[Callable[[str], Dict[str, str]]]:
         return self._same_bin_formatter
 
     @same_bin_formatter.setter

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -8,12 +8,12 @@ from typing import List
 import click
 
 from launchable.utils.env_keys import REPORT_ERROR_KEY
-from launchable.utils.tracking import TrackingClient, Tracking
+from launchable.utils.tracking import Tracking, TrackingClient
 
 from ..utils.authentication import get_org_workspace
 from ..utils.click import emoji, ignorable_error
-from ..utils.launchable_client import LaunchableClient
 from ..utils.java import get_java_command
+from ..utils.launchable_client import LaunchableClient
 from ..version import __version__ as version
 
 
@@ -54,14 +54,15 @@ def check_java_version(javacmd: str) -> int:
 
 
 @click.command(name="verify")
-def verify():
+@click.pass_context
+def verify(context: click.core.Context):
     # In this command, regardless of REPORT_ERROR_KEY, always report an unexpected error with full stack trace
     # to assist troubleshooting. `click.UsageError` is handled by the invoking
     # Click gracefully.
 
     org, workspace = get_org_workspace()
-    tracking_client = TrackingClient(Tracking.Command.VERIFY)
-    client = LaunchableClient(tracking_client=tracking_client)
+    tracking_client = TrackingClient(Tracking.Command.VERIFY, app=context.obj)
+    client = LaunchableClient(tracking_client=tracking_client, app=context.obj)
     java = get_java_command()
 
     # Print the system information first so that we can get them even if there's

--- a/launchable/utils/commit_ingester.py
+++ b/launchable/utils/commit_ingester.py
@@ -2,6 +2,7 @@ import hashlib
 from datetime import tzinfo
 from typing import Dict, List, Optional
 
+from ..app import Application
 from .git_log_parser import GitCommit
 from .launchable_client import LaunchableClient
 
@@ -48,11 +49,11 @@ def _convert_git_commit(commit: GitCommit) -> Dict:
     return d
 
 
-def upload_commits(commits: List[GitCommit], dry_run: bool):
+def upload_commits(commits: List[GitCommit], app: Application):
     payload = {
         'commits': [_convert_git_commit(commit) for commit in commits]
     }
 
-    client = LaunchableClient(dry_run=dry_run)
+    client = LaunchableClient(app=app)
     res = client.request("post", "commits/collect", payload=payload)
     res.raise_for_status()

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -6,17 +6,18 @@ from requests import HTTPError, Session, Timeout
 from launchable.utils.http_client import _HttpClient, _join_paths
 from launchable.utils.tracking import Tracking, TrackingClient  # type: ignore
 
+from ..app import Application
 from .authentication import get_org_workspace
 
 
 class LaunchableClient:
     def __init__(self, tracking_client: Optional[TrackingClient] = None, base_url: str = "", session: Optional[Session] = None,
-                 test_runner: Optional[str] = "", dry_run: bool = False):
+                 test_runner: Optional[str] = "", app: Optional[Application] = None):
         self.http_client = _HttpClient(
             base_url=base_url,
             session=session,
             test_runner=test_runner,
-            dry_run=dry_run
+            app=app
         )
         self.tracking_client = tracking_client
         self.organization, self.workspace = get_org_workspace()

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -1,10 +1,11 @@
 from enum import Enum
-from typing import Dict, Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from requests import Session
+
+from launchable.app import Application
 from launchable.utils.authentication import get_org_workspace
 from launchable.utils.http_client import _HttpClient, _join_paths
-
 from launchable.version import __version__
 
 
@@ -35,12 +36,12 @@ class Tracking:
 
 class TrackingClient:
     def __init__(self, command: Tracking.Command, base_url: str = "", session: Optional[Session] = None,
-                 test_runner: Optional[str] = "", dry_run: bool = False):
+                 test_runner: Optional[str] = "", app: Optional[Application] = None):
         self.http_client = _HttpClient(
             base_url=base_url,
             session=session,
             test_runner=test_runner,
-            dry_run=dry_run
+            app=app
         )
         self.command = command
 

--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -38,6 +38,9 @@ public class CommitIngester {
   @Option(name = "-dry-run", usage = "Instead of actually sending data, print what it would do.")
   public boolean dryRun;
 
+  @Option(name = "-skip-cert-verification", usage = "Bypass SSL certification verification.")
+  public boolean skipCertVerification;
+
   /**
    * @deprecated this is an old option and this is on always.
    */
@@ -129,7 +132,10 @@ public class CommitIngester {
   }
 
   @VisibleForTesting
-  void run() throws CmdLineException, MalformedURLException, IOException {
+  void run() throws CmdLineException, IOException {
+    if (skipCertVerification) {
+      SSLBypass.install();
+    }
     parseConfiguration();
 
     URL endpoint = new URL(url, String.format("organizations/%s/workspaces/%s/commits/", org, ws));

--- a/src/main/java/com/launchableinc/ingest/commits/SSLBypass.java
+++ b/src/main/java/com/launchableinc/ingest/commits/SSLBypass.java
@@ -1,0 +1,49 @@
+package com.launchableinc.ingest.commits;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+/**
+ * Bypass HTTP server certificate verification.
+ */
+class SSLBypass {
+    static void install() {
+        try {
+            SSLContext sc = SSLContext.getInstance("TLS");
+            sc.init(null, new TrustManager[]{new UnsecureTrustManager()}, new SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+            HttpsURLConnection.setDefaultHostnameVerifier(new UnsecureHostnameVerifier());
+        } catch (GeneralSecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static class UnsecureTrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+    private static class UnsecureHostnameVerifier implements HostnameVerifier {
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/launchableinc/ingest/commits/AllTests.java
+++ b/src/test/java/com/launchableinc/ingest/commits/AllTests.java
@@ -1,0 +1,13 @@
+package com.launchableinc.ingest.commits;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    CommitGraphCollectorTest.class,
+    CommitIngesterTest.class,
+    SSLBypassTest.class
+})
+public class AllTests {}

--- a/src/test/java/com/launchableinc/ingest/commits/BUILD
+++ b/src/test/java/com/launchableinc/ingest/commits/BUILD
@@ -1,19 +1,9 @@
 java_test(
-    name = "CommitGraphCollectorTest",
-    srcs = ["CommitGraphCollectorTest.java"],
+    name = "AllTests",
+    srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/launchableinc/ingest/commits",
         "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_eclipse_jgit_org_eclipse_jgit",
-    ],
-)
-
-java_test(
-    name = "CommitIngesterTest",
-    srcs = ["CommitIngesterTest.java"],
-    deps = [
-        "//src/main/java/com/launchableinc/ingest/commits",
         "@maven//:junit_junit",
         "@maven//:org_eclipse_jgit_org_eclipse_jgit",
         "@maven//:org_mock_server_mockserver_junit_rule_no_dependencies",

--- a/src/test/java/com/launchableinc/ingest/commits/SSLBypassTest.java
+++ b/src/test/java/com/launchableinc/ingest/commits/SSLBypassTest.java
@@ -1,0 +1,13 @@
+package com.launchableinc.ingest.commits;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SSLBypassTest {
+    @Test
+    public void foo() {
+        SSLBypass.install();
+    }
+}


### PR DESCRIPTION
For unblocking a customer, added a switch to disable SSL cert check.

To deal with growing number of global options, promoted the use of the global 'Application' object (formerly called 'AppBase', but to me, that name implied there's something that extends from this base, which is not the case).