### PR TITLE
Capture the display name of the URL.

### DIFF
--- a/launchable/utils/link.py
+++ b/launchable/utils/link.py
@@ -3,13 +3,20 @@ from typing import Dict, List, Mapping
 
 JENKINS_URL_KEY = 'JENKINS_URL'
 JENKINS_BUILD_URL_KEY = 'BUILD_URL'
+JENKINS_BUILD_DISPLAY_NAME_KEY = 'BUILD_DISPLAY_NAME'
+JENKINS_JOB_NAME_KEY = 'JOB_NAME'
 GITHUB_ACTIONS_KEY = 'GITHUB_ACTIONS'
 GITHUB_ACTIONS_SERVER_URL_KEY = 'GITHUB_SERVER_URL'
 GITHUB_ACTIONS_REPOSITORY_KEY = 'GITHUB_REPOSITORY'
 GITHUB_ACTIONS_RUN_ID_KEY = 'GITHUB_RUN_ID'
-GITHUB_PULL_REQUEST_URL_KEY = "GITHUB_PULL_REQUEST_URL"
+GITHUB_ACTIONS_RUN_NUMBER_KEY = 'GITHUB_RUN_NUMBER'
+GITHUB_ACTIONS_JOB_KEY = 'GITHUB_JOB'
+GITHUB_ACTIONS_WORKFLOW_KEY = 'GITHUB_WORKFLOW'
+GITHUB_PULL_REQUEST_URL_KEY = 'GITHUB_PULL_REQUEST_URL'
 CIRCLECI_KEY = 'CIRCLECI'
 CIRCLECI_BUILD_URL_KEY = 'CIRCLE_BUILD_URL'
+CIRCLECI_BUILD_NUM_KEY = 'CIRCLE_BUILD_NUM'
+CIRCLECI_JOB_KEY = 'CIRCLE_JOB'
 
 
 class LinkKind(Enum):
@@ -25,10 +32,13 @@ class LinkKind(Enum):
 def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
     links = []
 
+    # see https://launchableinc.atlassian.net/wiki/spaces/PRODUCT/pages/612892698/ for the list of
+    # environment variables used by various CI systems
     if env.get(JENKINS_URL_KEY):
-        links.append(
-            {"kind": LinkKind.JENKINS.name, "url": env.get(JENKINS_BUILD_URL_KEY, ""), "title": ""}
-        )
+        links.append({
+            "kind": LinkKind.JENKINS.name, "url": env.get(JENKINS_BUILD_URL_KEY, ""),
+            "title": "{} {}".format(env.get(JENKINS_JOB_NAME_KEY), env.get(JENKINS_BUILD_DISPLAY_NAME_KEY))
+        })
     if env.get(GITHUB_ACTIONS_KEY):
         links.append({
             "kind": LinkKind.GITHUB_ACTIONS.name,
@@ -37,17 +47,27 @@ def capture_link(env: Mapping[str, str]) -> List[Dict[str, str]]:
                 env.get(GITHUB_ACTIONS_REPOSITORY_KEY),
                 env.get(GITHUB_ACTIONS_RUN_ID_KEY),
             ),
-            "title": ""
+            # the nomenclature in GitHub PR comment from GHA has the optional additional part "(a,b,c)" that refers
+            # to the matrix, but that doesn't appear to be available as env var. Interestingly, run numbers are not
+            # included. Maybe it was seen as too much details and unnecessary for deciding which link to click?
+            "title": "{} / {} #{}".format(
+                env.get(GITHUB_ACTIONS_WORKFLOW_KEY),
+                env.get(GITHUB_ACTIONS_JOB_KEY),
+                env.get(GITHUB_ACTIONS_RUN_NUMBER_KEY))
         })
     if env.get(GITHUB_PULL_REQUEST_URL_KEY):
+        # TODO: where is this environment variable coming from?
         links.append({
             "kind": LinkKind.GITHUB_PULL_REQUEST.name,
             "url": env.get(GITHUB_PULL_REQUEST_URL_KEY, ""),
             "title": ""
         })
     if env.get(CIRCLECI_KEY):
-        links.append(
-            {"kind": LinkKind.CIRCLECI.name, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""), "title": ""}
-        )
+        # Their UI is organized as "project > branch > workflow > job (buildNum)" and it's not clear to me
+        # how much of that information should be present in title.
+        links.append({
+            "kind": LinkKind.CIRCLECI.name, "url": env.get(CIRCLECI_BUILD_URL_KEY, ""),
+            "title": "{} ({})".format(env.get(CIRCLECI_JOB_KEY), env.get(CIRCLECI_BUILD_NUM_KEY))
+        })
 
     return links

--- a/tests/utils/test_link.py
+++ b/tests/utils/test_link.py
@@ -5,10 +5,15 @@ from launchable.utils.link import LinkKind, capture_link
 
 class LinkTest(TestCase):
     def test_jenkins(self):
-        envs = {"JENKINS_URL": "https://jenkins.io", "BUILD_URL": "https://jenkins.launchableinc.com/build/123"}
+        envs = {
+            "JENKINS_URL": "https://jenkins.io",
+            "BUILD_URL": "https://jenkins.launchableinc.com/build/123",
+            "JOB_NAME": "foo",
+            "BUILD_DISPLAY_NAME": "#123"
+        }
         self.assertEqual(capture_link(envs), [{
             "kind": LinkKind.JENKINS.name,
-            "title": "",
+            "title": "foo #123",
             "url": "https://jenkins.launchableinc.com/build/123",
         }])
 
@@ -17,17 +22,25 @@ class LinkTest(TestCase):
             "GITHUB_ACTIONS": "true",
             "GITHUB_SERVER_URL": "https://github.com",
             "GITHUB_REPOSITORY": "launchable/cli",
-            "GITHUB_RUN_ID": 123}
+            "GITHUB_RUN_ID": 123,
+            "GITHUB_WORKFLOW": "workflow",
+            "GITHUB_JOB": "job",
+            "GITHUB_RUN_NUMBER": "234"
+        }
         self.assertEqual(capture_link(envs), [{
             "kind": LinkKind.GITHUB_ACTIONS.name,
-            "title": "",
+            "title": "workflow / job #234",
             "url": "https://github.com/launchable/cli/actions/runs/123",
         }])
 
     def test_circleci(self):
-        envs = {"CIRCLECI": "true", "CIRCLE_BUILD_URL": "https://circleci.com/build/123"}
+        envs = {
+            "CIRCLECI": "true",
+            "CIRCLE_BUILD_URL": "https://circleci.com/build/123",
+            "CIRCLE_JOB": "job",
+            "CIRCLE_BUILD_NUM": "234"}
         self.assertEqual(capture_link(envs), [{
             "kind": LinkKind.CIRCLECI.name,
-            "title": "",
+            "title": "job (234)",
             "url": "https://circleci.com/build/123",
         }])


### PR DESCRIPTION
When you have a long list of "View in Jenkins" it's not useful, but the concrete names that they are linking to would allow users to select the right one much more easily.