### PR TITLE
Support playwright's junit reporter format

### DIFF
--- a/launchable/test_runners/playwright.py
+++ b/launchable/test_runners/playwright.py
@@ -18,9 +18,9 @@ def record_tests(client, reports):
         The playwright junit report sets a file name to the name attribute in a testsuite element and the classname attribute in a testcase element. # noqa: E501
         This playwright plugin uses a testsuite attribute value.
         e.g.)
-        <testsuite name="demo-todo-app.spec.ts" ...>
-            <testcase name="New Todo › should allow me to add todo items" classname="demo-todo-app.spec.ts"></testcase>
-            <testcase name="New Todo › should clear text input field when an item is added" classname="demo-todo-app.spec.ts"></testcase>
+        <testsuite name="tests/demo-todo-app.spec.ts" ...>
+            <testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts"></testcase>
+            <testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts"></testcase>
         </testsuite>
         """
         filepath = suite.name

--- a/launchable/test_runners/playwright.py
+++ b/launchable/test_runners/playwright.py
@@ -1,0 +1,51 @@
+#
+# The the test runner to support playwright junit report format.
+# https://playwright.dev/
+#
+import click
+from junitparser import TestCase, TestSuite  # type: ignore
+
+from ..testpath import TestPath
+from . import launchable
+
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    def path_builder(case: TestCase, suite: TestSuite,
+                     report_file: str) -> TestPath:
+        """
+        The playwright junit report sets a file name to the name attribute in a testsuite element and the classname attribute in a testcase element. # noqa: E501
+        This playwright plugin uses a testsuite attribute value.
+        e.g.)
+        <testsuite name="demo-todo-app.spec.ts" ...>
+            <testcase name="New Todo › should allow me to add todo items" classname="demo-todo-app.spec.ts"></testcase>
+            <testcase name="New Todo › should clear text input field when an item is added" classname="demo-todo-app.spec.ts"></testcase>
+        </testsuite>
+        """
+        filepath = suite.name
+        if not filepath:
+            raise click.ClickException(
+                "No file name found in %s" % report_file)
+
+        test_path = [client.make_file_path_component(filepath)]
+        if case.name:
+            test_path.append({"type": "testcase", "name": case.name})
+        return test_path
+    client.path_builder = path_builder
+
+    for r in reports:
+        client.report(r)
+    client.run()
+
+
+@launchable.subset
+def subset(client):
+    # read lines as test file names
+    for t in client.stdin():
+        client.test_path(t.rstrip("\n"))
+
+    client.run()
+
+
+split_subset = launchable.CommonSplitSubsetImpls(__name__).split_subset()

--- a/tests/data/playwright/record_test_result.json
+++ b/tests/data/playwright/record_test_result.json
@@ -1,0 +1,501 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should allow me to add todo items"
+        }
+      ],
+      "duration": 0.726,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should clear text input field when an item is added"
+        }
+      ],
+      "duration": 0.71,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should append new items to the bottom of the list"
+        }
+      ],
+      "duration": 0.756,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
+        }
+      ],
+      "duration": 0.808,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
+        }
+      ],
+      "duration": 0.812,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.503,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.412,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.439,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.395,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.398,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.388,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.389,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.415,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.407,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.317,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.362,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.387,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.385,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.415,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.399,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.452,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display completed items"
+        }
+      ],
+      "duration": 0.397,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display all items"
+        }
+      ],
+      "duration": 0.466,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should highlight the currently applied filter"
+        }
+      ],
+      "duration": 0.399,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.49,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "get started link"
+        }
+      ],
+      "duration": 5.385,
+      "status": 0,
+      "stdout": "",
+      "stderr": "example.spec.ts:10:5 get started link\n\n  [chromium] \u203a example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
+      "created_at": "2024-01-31T00:23:06.919Z",
+      "data": null
+    }
+  ],
+  "testRunner": "playwright",
+  "group": "",
+  "noBuild": false
+}

--- a/tests/data/playwright/record_test_result.json
+++ b/tests/data/playwright/record_test_result.json
@@ -5,18 +5,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "New Todo \u203a should allow me to add todo items"
         }
       ],
-      "duration": 0.726,
+      "duration": 1.22,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -24,18 +24,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "New Todo \u203a should clear text input field when an item is added"
         }
       ],
-      "duration": 0.71,
+      "duration": 1.198,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -43,18 +43,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "New Todo \u203a should append new items to the bottom of the list"
         }
       ],
-      "duration": 0.756,
+      "duration": 1.24,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -62,18 +62,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Mark all as completed \u203a should allow me to mark all items as completed"
         }
       ],
-      "duration": 0.808,
+      "duration": 1.291,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -81,18 +81,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
         }
       ],
-      "duration": 0.812,
+      "duration": 1.316,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -100,18 +100,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
         }
       ],
-      "duration": 0.503,
+      "duration": 0.467,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -119,18 +119,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Item \u203a should allow me to mark items as complete"
         }
       ],
-      "duration": 0.412,
+      "duration": 0.409,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -138,18 +138,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Item \u203a should allow me to un-mark items as complete"
         }
       ],
-      "duration": 0.439,
+      "duration": 0.422,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -157,18 +157,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Item \u203a should allow me to edit an item"
         }
       ],
-      "duration": 0.395,
+      "duration": 0.392,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -176,18 +176,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Editing \u203a should hide other controls when editing"
         }
       ],
-      "duration": 0.398,
+      "duration": 0.404,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -195,18 +195,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Editing \u203a should save edits on blur"
         }
       ],
-      "duration": 0.388,
+      "duration": 0.382,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -214,18 +214,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Editing \u203a should trim entered text"
         }
       ],
-      "duration": 0.389,
+      "duration": 0.393,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -233,18 +233,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Editing \u203a should remove the item if an empty text string was entered"
         }
       ],
-      "duration": 0.415,
+      "duration": 0.392,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -252,18 +252,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Editing \u203a should cancel edits on escape"
         }
       ],
-      "duration": 0.407,
+      "duration": 0.39,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -271,18 +271,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Counter \u203a should display the current number of todo items"
         }
       ],
-      "duration": 0.317,
+      "duration": 0.318,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -290,18 +290,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Clear completed button \u203a should display the correct text"
         }
       ],
-      "duration": 0.362,
+      "duration": 0.35,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -309,7 +309,7 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
@@ -320,7 +320,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -328,18 +328,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
         }
       ],
-      "duration": 0.385,
+      "duration": 0.383,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -347,18 +347,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Persistence \u203a should persist its data"
         }
       ],
-      "duration": 0.415,
+      "duration": 0.423,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -366,18 +366,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Routing \u203a should allow me to display active items"
         }
       ],
-      "duration": 0.399,
+      "duration": 0.385,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -385,18 +385,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Routing \u203a should respect the back button"
         }
       ],
-      "duration": 0.452,
+      "duration": 0.47,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -404,18 +404,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Routing \u203a should allow me to display completed items"
         }
       ],
-      "duration": 0.397,
+      "duration": 0.396,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -423,18 +423,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Routing \u203a should allow me to display all items"
         }
       ],
-      "duration": 0.466,
+      "duration": 0.451,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -442,18 +442,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "demo-todo-app.spec.ts"
+          "name": "tests/demo-todo-app.spec.ts"
         },
         {
           "type": "testcase",
           "name": "Routing \u203a should highlight the currently applied filter"
         }
       ],
-      "duration": 0.399,
+      "duration": 0.395,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -461,18 +461,18 @@
       "testPath": [
         {
           "type": "file",
-          "name": "example.spec.ts"
+          "name": "tests/example.spec.ts"
         },
         {
           "type": "testcase",
           "name": "has title"
         }
       ],
-      "duration": 0.49,
+      "duration": 0.513,
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -480,18 +480,1006 @@
       "testPath": [
         {
           "type": "file",
-          "name": "example.spec.ts"
+          "name": "tests/example.spec.ts"
         },
         {
           "type": "testcase",
           "name": "get started link"
         }
       ],
-      "duration": 5.385,
+      "duration": 5.417,
       "status": 0,
       "stdout": "",
-      "stderr": "example.spec.ts:10:5 get started link\n\n  [chromium] \u203a example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "created_at": "2024-01-31T00:23:06.919Z",
+      "stderr": "example.spec.ts:10:5 get started link\n\n  [chromium] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should allow me to add todo items"
+        }
+      ],
+      "duration": 24.745,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should clear text input field when an item is added"
+        }
+      ],
+      "duration": 1.02,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should append new items to the bottom of the list"
+        }
+      ],
+      "duration": 1.068,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
+        }
+      ],
+      "duration": 1.211,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
+        }
+      ],
+      "duration": 0.565,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.621,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.551,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.499,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.462,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.449,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.446,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.455,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.442,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.47,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.386,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.443,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.462,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.453,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.619,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.504,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.608,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display completed items"
+        }
+      ],
+      "duration": 0.478,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display all items"
+        }
+      ],
+      "duration": 0.576,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should highlight the currently applied filter"
+        }
+      ],
+      "duration": 0.504,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.346,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "get started link"
+        }
+      ],
+      "duration": 6.048,
+      "status": 0,
+      "stdout": "",
+      "stderr": "example.spec.ts:10:5 get started link\n\n  [firefox] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should allow me to add todo items"
+        }
+      ],
+      "duration": 0.778,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should clear text input field when an item is added"
+        }
+      ],
+      "duration": 0.746,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should append new items to the bottom of the list"
+        }
+      ],
+      "duration": 0.853,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
+        }
+      ],
+      "duration": 0.576,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
+        }
+      ],
+      "duration": 0.583,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.639,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.501,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.512,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.558,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.487,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.512,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.505,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.493,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.498,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.428,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.501,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.52,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.519,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.549,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.532,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.617,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display completed items"
+        }
+      ],
+      "duration": 0.529,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display all items"
+        }
+      ],
+      "duration": 0.59,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should highlight the currently applied filter"
+        }
+      ],
+      "duration": 0.511,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.485,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "created_at": "2024-01-31T07:12:52.585Z",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "get started link"
+        }
+      ],
+      "duration": 5.586,
+      "status": 0,
+      "stdout": "",
+      "stderr": "example.spec.ts:10:5 get started link\n\n  [webkit] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
+      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     }
   ],

--- a/tests/data/playwright/report.xml
+++ b/tests/data/playwright/report.xml
@@ -1,0 +1,81 @@
+<testsuites id="" name="" tests="26" failures="1" skipped="0" errors="0" time="8.141573">
+<testsuite name="demo-todo-app.spec.ts" timestamp="2024-01-31T00:23:06.919Z" hostname="chromium" tests="24" failures="0" skipped="0" time="11.537" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="demo-todo-app.spec.ts" time="0.726">
+</testcase>
+<testcase name="New Todo › should clear text input field when an item is added" classname="demo-todo-app.spec.ts" time="0.71">
+</testcase>
+<testcase name="New Todo › should append new items to the bottom of the list" classname="demo-todo-app.spec.ts" time="0.756">
+</testcase>
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="demo-todo-app.spec.ts" time="0.808">
+</testcase>
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="demo-todo-app.spec.ts" time="0.812">
+</testcase>
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="demo-todo-app.spec.ts" time="0.503">
+</testcase>
+<testcase name="Item › should allow me to mark items as complete" classname="demo-todo-app.spec.ts" time="0.412">
+</testcase>
+<testcase name="Item › should allow me to un-mark items as complete" classname="demo-todo-app.spec.ts" time="0.439">
+</testcase>
+<testcase name="Item › should allow me to edit an item" classname="demo-todo-app.spec.ts" time="0.395">
+</testcase>
+<testcase name="Editing › should hide other controls when editing" classname="demo-todo-app.spec.ts" time="0.398">
+</testcase>
+<testcase name="Editing › should save edits on blur" classname="demo-todo-app.spec.ts" time="0.388">
+</testcase>
+<testcase name="Editing › should trim entered text" classname="demo-todo-app.spec.ts" time="0.389">
+</testcase>
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="demo-todo-app.spec.ts" time="0.415">
+</testcase>
+<testcase name="Editing › should cancel edits on escape" classname="demo-todo-app.spec.ts" time="0.407">
+</testcase>
+<testcase name="Counter › should display the current number of todo items" classname="demo-todo-app.spec.ts" time="0.317">
+</testcase>
+<testcase name="Clear completed button › should display the correct text" classname="demo-todo-app.spec.ts" time="0.362">
+</testcase>
+<testcase name="Clear completed button › should remove completed items when clicked" classname="demo-todo-app.spec.ts" time="0.387">
+</testcase>
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="demo-todo-app.spec.ts" time="0.385">
+</testcase>
+<testcase name="Persistence › should persist its data" classname="demo-todo-app.spec.ts" time="0.415">
+</testcase>
+<testcase name="Routing › should allow me to display active items" classname="demo-todo-app.spec.ts" time="0.399">
+</testcase>
+<testcase name="Routing › should respect the back button" classname="demo-todo-app.spec.ts" time="0.452">
+</testcase>
+<testcase name="Routing › should allow me to display completed items" classname="demo-todo-app.spec.ts" time="0.397">
+</testcase>
+<testcase name="Routing › should allow me to display all items" classname="demo-todo-app.spec.ts" time="0.466">
+</testcase>
+<testcase name="Routing › should highlight the currently applied filter" classname="demo-todo-app.spec.ts" time="0.399">
+</testcase>
+</testsuite>
+<testsuite name="example.spec.ts" timestamp="2024-01-31T00:23:06.919Z" hostname="chromium" tests="2" failures="1" skipped="0" time="5.875" errors="0">
+<testcase name="has title" classname="example.spec.ts" time="0.49">
+</testcase>
+<testcase name="get started link" classname="example.spec.ts" time="5.385">
+<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
+<![CDATA[  [chromium] › example.spec.ts:10:5 › get started link ─────────────────────────────────────────────
+
+    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+
+    Locator: getByRole('heading', { name: 'Installation!' })
+    Expected: visible
+    Received: hidden
+    Call log:
+      - expect.toBeVisible with timeout 5000ms
+      - waiting for getByRole('heading', { name: 'Installation!' })
+
+
+      15 |
+      16 |   // Expects page to have a heading with the name of Installation.
+    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
+         |                                                                      ^
+      18 | });
+      19 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+]]>
+</failure>
+</testcase>
+</testsuite>
+</testsuites>

--- a/tests/data/playwright/report.xml
+++ b/tests/data/playwright/report.xml
@@ -1,60 +1,220 @@
-<testsuites id="" name="" tests="26" failures="1" skipped="0" errors="0" time="8.141573">
-<testsuite name="demo-todo-app.spec.ts" timestamp="2024-01-31T00:23:06.919Z" hostname="chromium" tests="24" failures="0" skipped="0" time="11.537" errors="0">
-<testcase name="New Todo › should allow me to add todo items" classname="demo-todo-app.spec.ts" time="0.726">
+<testsuites id="" name="" tests="78" failures="3" skipped="1" errors="0" time="29.558653">
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="chromium" tests="24" failures="0" skipped="0" time="13.874" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="1.22">
 </testcase>
-<testcase name="New Todo › should clear text input field when an item is added" classname="demo-todo-app.spec.ts" time="0.71">
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="1.198">
 </testcase>
-<testcase name="New Todo › should append new items to the bottom of the list" classname="demo-todo-app.spec.ts" time="0.756">
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="1.24">
 </testcase>
-<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="demo-todo-app.spec.ts" time="0.808">
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="1.291">
 </testcase>
-<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="demo-todo-app.spec.ts" time="0.812">
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="1.316">
 </testcase>
-<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="demo-todo-app.spec.ts" time="0.503">
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.467">
 </testcase>
-<testcase name="Item › should allow me to mark items as complete" classname="demo-todo-app.spec.ts" time="0.412">
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.409">
 </testcase>
-<testcase name="Item › should allow me to un-mark items as complete" classname="demo-todo-app.spec.ts" time="0.439">
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.422">
 </testcase>
-<testcase name="Item › should allow me to edit an item" classname="demo-todo-app.spec.ts" time="0.395">
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.392">
 </testcase>
-<testcase name="Editing › should hide other controls when editing" classname="demo-todo-app.spec.ts" time="0.398">
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.404">
 </testcase>
-<testcase name="Editing › should save edits on blur" classname="demo-todo-app.spec.ts" time="0.388">
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.382">
 </testcase>
-<testcase name="Editing › should trim entered text" classname="demo-todo-app.spec.ts" time="0.389">
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.393">
 </testcase>
-<testcase name="Editing › should remove the item if an empty text string was entered" classname="demo-todo-app.spec.ts" time="0.415">
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.392">
 </testcase>
-<testcase name="Editing › should cancel edits on escape" classname="demo-todo-app.spec.ts" time="0.407">
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.39">
 </testcase>
-<testcase name="Counter › should display the current number of todo items" classname="demo-todo-app.spec.ts" time="0.317">
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.318">
 </testcase>
-<testcase name="Clear completed button › should display the correct text" classname="demo-todo-app.spec.ts" time="0.362">
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.35">
 </testcase>
-<testcase name="Clear completed button › should remove completed items when clicked" classname="demo-todo-app.spec.ts" time="0.387">
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.387">
 </testcase>
-<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="demo-todo-app.spec.ts" time="0.385">
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.383">
 </testcase>
-<testcase name="Persistence › should persist its data" classname="demo-todo-app.spec.ts" time="0.415">
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.423">
 </testcase>
-<testcase name="Routing › should allow me to display active items" classname="demo-todo-app.spec.ts" time="0.399">
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.385">
 </testcase>
-<testcase name="Routing › should respect the back button" classname="demo-todo-app.spec.ts" time="0.452">
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.47">
 </testcase>
-<testcase name="Routing › should allow me to display completed items" classname="demo-todo-app.spec.ts" time="0.397">
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.396">
 </testcase>
-<testcase name="Routing › should allow me to display all items" classname="demo-todo-app.spec.ts" time="0.466">
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.451">
 </testcase>
-<testcase name="Routing › should highlight the currently applied filter" classname="demo-todo-app.spec.ts" time="0.399">
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.395">
 </testcase>
 </testsuite>
-<testsuite name="example.spec.ts" timestamp="2024-01-31T00:23:06.919Z" hostname="chromium" tests="2" failures="1" skipped="0" time="5.875" errors="0">
-<testcase name="has title" classname="example.spec.ts" time="0.49">
+<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="chromium" tests="2" failures="1" skipped="0" time="5.93" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.513">
 </testcase>
-<testcase name="get started link" classname="example.spec.ts" time="5.385">
+<testcase name="get started link" classname="tests/example.spec.ts" time="5.417">
 <failure message="example.spec.ts:10:5 get started link" type="FAILURE">
-<![CDATA[  [chromium] › example.spec.ts:10:5 › get started link ─────────────────────────────────────────────
+<![CDATA[  [chromium] › tests/example.spec.ts:10:5 › get started link ───────────────────────────────────────
+
+    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+
+    Locator: getByRole('heading', { name: 'Installation!' })
+    Expected: visible
+    Received: hidden
+    Call log:
+      - expect.toBeVisible with timeout 5000ms
+      - waiting for getByRole('heading', { name: 'Installation!' })
+
+
+      15 |
+      16 |   // Expects page to have a heading with the name of Installation.
+    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
+         |                                                                      ^
+      18 | });
+      19 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+]]>
+</failure>
+</testcase>
+</testsuite>
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="firefox" tests="24" failures="0" skipped="1" time="38.037" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="24.745">
+<skipped>
+</skipped>
+</testcase>
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="1.02">
+</testcase>
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="1.068">
+</testcase>
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="1.211">
+</testcase>
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.565">
+</testcase>
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.621">
+</testcase>
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.551">
+</testcase>
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.499">
+</testcase>
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.462">
+</testcase>
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.449">
+</testcase>
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.446">
+</testcase>
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.455">
+</testcase>
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.442">
+</testcase>
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.47">
+</testcase>
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.386">
+</testcase>
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.443">
+</testcase>
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.462">
+</testcase>
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.453">
+</testcase>
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.619">
+</testcase>
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.504">
+</testcase>
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.608">
+</testcase>
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.478">
+</testcase>
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.576">
+</testcase>
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.504">
+</testcase>
+</testsuite>
+<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="firefox" tests="2" failures="1" skipped="0" time="6.394" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.346">
+</testcase>
+<testcase name="get started link" classname="tests/example.spec.ts" time="6.048">
+<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
+<![CDATA[  [firefox] › tests/example.spec.ts:10:5 › get started link ────────────────────────────────────────
+
+    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+
+    Locator: getByRole('heading', { name: 'Installation!' })
+    Expected: visible
+    Received: hidden
+    Call log:
+      - expect.toBeVisible with timeout 5000ms
+      - waiting for getByRole('heading', { name: 'Installation!' })
+
+
+      15 |
+      16 |   // Expects page to have a heading with the name of Installation.
+    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
+         |                                                                      ^
+      18 | });
+      19 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+]]>
+</failure>
+</testcase>
+</testsuite>
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="webkit" tests="24" failures="0" skipped="0" time="13.537" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="0.778">
+</testcase>
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="0.746">
+</testcase>
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="0.853">
+</testcase>
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="0.576">
+</testcase>
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.583">
+</testcase>
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.639">
+</testcase>
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.501">
+</testcase>
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.512">
+</testcase>
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.558">
+</testcase>
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.487">
+</testcase>
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.512">
+</testcase>
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.505">
+</testcase>
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.493">
+</testcase>
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.498">
+</testcase>
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.428">
+</testcase>
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.501">
+</testcase>
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.52">
+</testcase>
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.519">
+</testcase>
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.549">
+</testcase>
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.532">
+</testcase>
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.617">
+</testcase>
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.529">
+</testcase>
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.59">
+</testcase>
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.511">
+</testcase>
+</testsuite>
+<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="webkit" tests="2" failures="1" skipped="0" time="6.071" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.485">
+</testcase>
+<testcase name="get started link" classname="tests/example.spec.ts" time="5.586">
+<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
+<![CDATA[  [webkit] › tests/example.spec.ts:10:5 › get started link ─────────────────────────────────────────
 
     Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
 

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -1,0 +1,27 @@
+import gzip
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import responses  # type: ignore
+
+from tests.cli_test_case import CliTestCase
+
+
+class PlaywrightTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/playwright/').resolve()
+    result_file_path = test_files_dir.joinpath('record_test_result.json')
+
+    @responses.activate
+    @mock.patch.dict(os.environ,
+                     {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test_rspec(self):
+        result = self.cli('record', 'tests', '--session', self.session,
+                          'playwright', str(self.test_files_dir.joinpath("report.xml")))
+
+        self.assert_success(result)
+
+        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        expected = self.load_json_from_file(self.result_file_path)
+        self.assert_json_orderless_equal(expected, payload)


### PR DESCRIPTION
Implemented a new plugin for [playwright](https://playwright.dev/)'s junit report.

I tested this plugin at https://github.com/launchableinc/examples/pull/76

Success case: https://github.com/launchableinc/examples/actions/runs/7720959909
Fail case: https://github.com/launchableinc/examples/actions/runs/7720923648/job/21046605819#step:11:15

