### PR TITLE
Collect head commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ root = true
 insert_final_newline = true
 charset=utf-8
 indent_style=space
+
+[*.java]
+indent_size = 4

--- a/src/main/java/com/launchableinc/ingest/commits/ObjectRevFilter.java
+++ b/src/main/java/com/launchableinc/ingest/commits/ObjectRevFilter.java
@@ -1,0 +1,27 @@
+package com.launchableinc.ingest.commits;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+
+/**
+ * Selects one commit
+ */
+final class ObjectRevFilter extends RevFilter {
+    private final ObjectId theCommit;
+
+    ObjectRevFilter(ObjectId theCommit) {
+        this.theCommit = theCommit;
+    }
+
+    @Override
+    public boolean include(RevWalk walker, RevCommit cmit) {
+        return cmit.equals(theCommit);
+    }
+
+    @Override
+    public RevFilter clone() {
+        return this;
+    }
+}


### PR DESCRIPTION
Collect head commit, even if it's old

One way we ensure that the CI process integration is working correctly is to make sure all the commits a build refers to are in our possession. This is non-trivial to get right especially when `record build` is run without the commit collection and separate `record commit` is in use.

The intent of filtering by time is to avoid large initial ingestion, so this change is still consistent with that goal.
