### PR TITLE
Make sure tests are triggered with updated dependencies

### DIFF
--- a/.github/workflows/update_maven_install_json.yml
+++ b/.github/workflows/update_maven_install_json.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          # Bot token is needed to ensure that git-push triggers relevant workflows
+          # See https://github.com/orgs/community/discussions/27146
+          token: ${{ secrets.LAUNCHABLEINC_CI_GITHUB_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The key motivation of this workflow is to make sure tests are run with the updated dependencies, but I noticed that wasn't happening.

I tracked it down to the URL referenced in the comment. Also see https://github.com/EndBug/add-and-commit?tab=readme-ov-file#the-commit-from-the-action-is-not-triggering-ci The issue described there is not specific to that workflow action, it equally applies to our inline definition of git-push.

This should do the trick.