### PR TITLE
Handle build/{buildId} correctly

### DIFF
--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -301,6 +301,25 @@ class APIErrorTest(CliTestCase):
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_tests(self):
         responses.replace(
+            responses.GET,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}".format(
+                base=get_base_url(),
+                org=self.organization,
+                ws=self.workspace,
+                build=self.build_name),
+            body=ReadTimeout("error"))
+        tracking = responses.add(
+            responses.POST,
+            CLI_TRACKING_URL.format(
+                base=get_base_url()),
+            body=ReadTimeout("error"))
+
+        result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
+        self.assert_success(result)
+        # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
+        self.assert_tracking_count(tracking=tracking, count=2)
+
+        responses.replace(
             responses.POST,
             "{base}/intake/organizations/{org}/workspaces/{ws}/builds/{build}/test_sessions/{session_id}/events".format(
                 base=get_base_url(),
@@ -318,7 +337,7 @@ class APIErrorTest(CliTestCase):
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
-        self.assert_tracking_count(tracking=tracking, count=1)
+        self.assert_tracking_count(tracking=tracking, count=3)
 
         responses.replace(
             responses.POST,
@@ -338,7 +357,7 @@ class APIErrorTest(CliTestCase):
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assert_success(result)
 
-        self.assert_tracking_count(tracking=tracking, count=1)
+        self.assert_tracking_count(tracking=tracking, count=3)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})


### PR DESCRIPTION
When [adding the mock response which throws timeout error](https://github.com/launchableinc/cli/pull/761/files#diff-d1c38c43b1cef30c3db605e17c4ade6a177835334931b8d03aa0f9783bec0c34R303) in `builds/{build}`, I got the following error. This might stop client's pipeline. Thus, this PR addresses the problem.

```
ERROR: test_record_tests (tests.commands.test_api_error.APIErrorTest.test_record_tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/responses/__init__.py", line 229, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/unittest/mock.py", line 1828, in _inner
    return f(*args, **kw)
           ^^^^^^^^^^^^^^
  File "/Users/ono-max/workspace/cli/tests/commands/test_api_error.py", line 326, in test_record_tests
    result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/workspace/cli/tests/cli_test_case.py", line 189, in cli
    return CliRunner(mix_stderr=mix_stderr).invoke(main, args, catch_exceptions=False, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/testing.py", line 408, in invoke
    return_value = cli.main(args=args or (), prog_name=prog_name, **extra)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/.local/share/virtualenvs/cli-o7XEfK99/lib/python3.11/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ono-max/workspace/cli/launchable/test_runners/launchable.py", line 117, in record_tests
    client.scan(t, file_mask)
    ^^^^^^^^^^^
AttributeError: 'Application' object has no attribute 'scan'

````