### PR TITLE
Export test path in raw profile as a structure

### DIFF
--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -161,12 +161,13 @@ def record_tests(client, test_result_files):
         default_created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         for case in doc['testCases']:
             test_path_components: TestPath = case.get('testPathComponents', None)
-            if test_path_components is None:
-                test_path: str = case.get('testPath', None)
-                if test_path:
-                    test_path_components = parse_test_path(test_path)
-                else:
-                    raise ValueError("Missing testPath or testPathComponents field in the test case.")
+            test_path: str = case.get('testPath', None)
+            if test_path_components is None and test_path is None:
+                raise ValueError("Missing testPath or testPathComponents field in the test case.")
+            if test_path_components and test_path:
+                raise ValueError("Specifying both testPath and testPathComponents fields is invalid.")
+            if test_path:
+                test_path_components = parse_test_path(test_path)
             status = case['status']
             duration_secs = case['duration'] or 0
             created_at = case['createdAt'] or default_created_at

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -160,7 +160,7 @@ def record_tests(client, test_result_files):
             doc = json.load(f)
         default_created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         for case in doc['testCases']:
-            test_path_components: TestPath | None = case.get('testPathComponents', None)
+            test_path_components: TestPath = case.get('testPathComponents', None)
             if test_path_components is None:
                 test_path: str = case.get('testPath', None)
                 if test_path:

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -90,6 +90,13 @@ def record_tests(client, test_result_files):
                 "description": "TestPath for the test",
                 "type": "string"
               },
+              "testPathComponents": {
+                "description": "TestPath for the test",
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
               "duration": {
                 "description": "Time taken to finish the test in seconds. If unspecified, assume 0 sec.",
                 "type": "number",
@@ -98,7 +105,11 @@ def record_tests(client, test_result_files):
               "status": {
                 "description": "Test result",
                 "type": "string",
-                "enum": ["TEST_PASSED", "TEST_FAILED", "TEST_SKIPPED"]
+                "enum": [
+                  "TEST_PASSED",
+                  "TEST_FAILED",
+                  "TEST_SKIPPED"
+                ]
               },
               "stdout": {
                 "description": "Standard output of the test. If unspecified, assume empty.",
@@ -115,11 +126,27 @@ def record_tests(client, test_result_files):
                 "format": "date-time"
               }
             },
-            "required": ["testPath", "status"]
+            "required": [
+              "status"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "testPath"
+                ]
+              },
+              {
+                "required": [
+                  "testPathComponents"
+                ]
+              }
+            ]
           }
         }
       },
-      "required": ["testCases"]
+      "required": [
+        "testCases"
+      ]
     }
 
     ## JUnit XML TestPath mapping

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -137,6 +137,7 @@ class RawTest(CliTestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             test_path_file = os.path.join(tempdir, 'tests.json')
             test_path_file2 = os.path.join(tempdir, 'tests_2.json')
+            test_path_file3 = os.path.join(tempdir, 'tests_3.json')
             with open(test_path_file, 'w') as f:
                 f.write('\n'.join([
                     '{',
@@ -169,10 +170,39 @@ class RawTest(CliTestCase):
                     '}',
                 ]) + '\n')
 
+            with open(test_path_file3, 'w') as f3:
+                f3.write('\n'.join([
+                    '{',
+                    '  "testCases": [',
+                    '     {',
+                    '       "testPathComponents": [',
+                    '         {',
+                    '           "type": "file",',
+                    '           "name": "login/test_a.py"',
+                    '         },',
+                    '         {',
+                    '           "type": "class",',
+                    '           "name": "class1"',
+                    '         },',
+                    '         {',
+                    '           "type": "testcase",',
+                    '           "name": "testcase#899"',
+                    '         }',
+                    '       ],',
+                    '       "duration": 34,',
+                    '       "status": "TEST_PASSED",',
+                    '       "stdout": "This is stdout",',
+                    '       "stderr": "This is stderr",',
+                    '       "createdAt": "2021-10-05T12:34:56"',
+                    '     }',
+                    '  ]',
+                    '}',
+                ]) + '\n')
+
             # emulate launchable record build
             write_build(self.build_name)
 
-            result = self.cli('record', 'tests', 'raw', test_path_file, test_path_file2, mix_stderr=False)
+            result = self.cli('record', 'tests', 'raw', test_path_file, test_path_file2, test_path_file3, mix_stderr=False)
             self.assert_success(result)
 
             # Check request body
@@ -198,6 +228,20 @@ class RawTest(CliTestCase):
                             {'type': 'class', 'name': 'classB'},
                         ],
                         'duration': 32,
+                        'status': 1,
+                        'stdout': 'This is stdout',
+                        'stderr': 'This is stderr',
+                        'created_at': '2021-10-05T12:34:56',
+                        'data': None,
+                        'type': 'case',
+                    },
+                    {
+                        'testPath': [
+                            {'type': 'file', 'name': 'login/test_a.py'},
+                            {'type': 'class', 'name': 'class1'},
+                            {'type': 'testcase', 'name': 'testcase#899'},
+                        ],
+                        'duration': 34,
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',


### PR DESCRIPTION
We're going to receive the following JSON in raw profile.

```
{
  "testCases": [
    {
      "testPathComponents": [
        {
          "type": "file",
          "name": "login/test_a.py"
        },
        {
          "type": "class",
          "name": "class1"
        },
        {
          "type": "testcase",
          "name": "testcase#899"
        }
      ],
      "duration": 42,
      "status": "TEST_PASSED",
      "stdout": "This is stdout",
      "stderr": "This is stderr",
      "createdAt": "2021-10-05T12:34:00"
    }
  ]
}
```