### PR TITLE
Get branch name correctly

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -135,6 +135,12 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
 
             # Github Actions
             # ref: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+            # These environment variables cannot be retrieved when a `push` event is emitted.
+            # Here is a note regarding the output of `git show-ref`:
+            # - Git tag is pushed during a `push` event
+            #   => ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/tags/tag-name
+            # - Git commit is pushed during a `push` event
+            #   => ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch/branch-name
             if os.environ.get(GITHUB_ACTIONS_KEY):
                 self.branch = os.environ.get(GITHUB_ACTIONS_GITHUB_HEAD_REF_KEY) or \
                     os.environ.get(GITHUB_ACTIONS_GITHUB_BASE_REF_KEY)
@@ -159,10 +165,12 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
                 refs = [ref for ref in show_ref.split("\n") if self.commit_hash in ref]
 
                 if len(refs) > 0:
-                    # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
-                    match = re.search('[a-f0-9]{40} refs/heads/(.*)', refs[0])
+                    # We assume the following values:
+                    # * ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch/branch-name
+                    # * ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/remotes/origin/branch-name
+                    match = re.search('[a-f0-9]{40} refs/(heads|remotes/origin)/(.*)', refs[0])
                     if match:
-                        self.branch = match.group(1)
+                        self.branch = match.group(2)
                     else:
                         self.branch = refs[0].split("/")[-1]
             except Exception:

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -160,7 +160,11 @@ def build(ctx: click.core.Context, build_name: str, source: List[str], max_days:
 
                 if len(refs) > 0:
                     # e.g) ed6de84bde58d51deebe90e01ddfa5fa78899b1c refs/heads/branch-name
-                    self.branch = refs[0].split("/")[-1]
+                    match = re.search('[a-f0-9]{40} refs/heads/(.*)', refs[0])
+                    if match:
+                        self.branch = match.group(1)
+                    else:
+                        self.branch = refs[0].split("/")[-1]
             except Exception:
                 # cannot get branch name by git command
                 pass


### PR DESCRIPTION
In the push event, GITHUB_HEAD_REF and GITHUB_BASE_REF are empty. In such cases, the git show-ref command is utilized. A complication arises when configuring a branch that contains a slash in the push event. For instance, if the branch name is test/test-branch, the expected value is "test/test-branch," but the current CLI displays "test-branch" instead. This PR resolves this discrepancy.

```
$ python                                   
Python 3.11.4 (v3.11.4:d2340ef257, Jun  6 2023, 19:15:51) [Clang 13.0.0 (clang-1300.0.29.30)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> m = re.search('[a-f0-9]{40} refs/heads/(.*)', '65fa86c19329c375cbd5c7649b601e334ba1dea3 refs/heads/foobar/foobar2')
>>> m.group(1)
'foobar/foobar2'
>>> m = re.search('[a-f0-9]{40} refs/heads/(.*)', '65fa86c19329c375cbd5c7649b601e334ba1dea3 refs/heads/foobar')
>>> m.group(1)
'foobar'
>>> 
```
