### PR TITLE
Improve a warning message for missing object errors

### DIFF
--- a/src/main/java/com/launchableinc/ingest/commits/CountingDiffFormatter.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CountingDiffFormatter.java
@@ -26,17 +26,13 @@ class CountingDiffFormatter extends DiffFormatter {
   }
 
   /** Entry point to compute a file level change. */
-  JSFileChange process(DiffEntry de) {
+  JSFileChange process(DiffEntry de) throws IOException {
     add = 0;
     del = 0;
 
     // This call internally eventually reaches to format(EditList, RawTest, RawText) that counts the
     // numbers.
-    try {
-      format(de);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    format(de);
 
     JSFileChange fc = new JSFileChange();
     fc.setLinesAdded(add);


### PR DESCRIPTION
See the linked doc site for more discussion. This solves #786 