### PR TITLE
Exit 0 not to stop a pipeline when `record tests` command cannot get session

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -241,6 +241,8 @@ def tests(
             raise e
         else:
             traceback.print_exc()
+            # To prevent users from stopping the CI pipeline, the cli exits with a
+            # status code of 0, indicating that the program terminated successfully.
             exit(0)
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -241,7 +241,7 @@ def tests(
             raise e
         else:
             traceback.print_exc()
-            return
+            exit(0)
 
     # TODO: placed here to minimize invasion in this PR to reduce the likelihood of
     # PR merge hell. This should be moved to a top-level class

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -4,8 +4,8 @@ import sys
 import types
 
 import click
-from launchable.app import Application
 
+from launchable.app import Application
 from launchable.commands.record.tests import tests as record_tests_cmd
 from launchable.commands.split_subset import split_subset as split_subset_cmd
 from launchable.commands.subset import subset as subset_cmd
@@ -105,11 +105,6 @@ class CommonRecordTestImpls:
 
         @click.argument('source_roots', required=True, nargs=-1)
         def record_tests(client, source_roots):
-            if isinstance(client, Application):
-                # Sometimes, when an exception occurs, the RecordTests class is not initiated.
-                # At that time, the following error occurs. To prevent this error, we return here.
-                # AttributeError: 'Application' object has no attribute 'scan'
-                return
             # client type: RecordTests in def launchable.commands.record.tests.tests
             # Accept both file names and GLOB patterns
             # Simple globs like '*.xml' can be dealt with by shell, but

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,8 @@ from unittest import mock
 
 import responses  # type: ignore
 
+from launchable.utils.http_client import get_base_url
+
 from .cli_test_case import CliTestCase
 
 
@@ -11,6 +13,26 @@ class PluginTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_plugin_loading(self):
+        responses.add(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                "dummy"),
+            json={'createdAt': "2020-01-02T03:45:56.123+00:00", 'id': 123, "build": "dummy"},
+            status=200)
+
+        responses.add(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/builds/{}/test_sessions{}/events".format(
+                get_base_url(),
+                self.organization,
+                self.workspace,
+                "dummy", 123),
+            json={},
+            status=200)
+
         """
         Load plugins/foo.py as a plugin and execute its code
         """


### PR DESCRIPTION
When the Launchable API is down then the cli cannot get a session, the `launchable record tests` command fails with exit code 1. Then, the customer's pipeline will be suspended.

To prevent it, changed to exit 0 when cannot get a session.

## Before

```
$ launchable record tests file ./test-results/**/*.xml
Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/record/tests.py", line 223, in tests
    session_id = str(find_or_create_session(
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 104, in find_or_create_session
    saved_build_name = require_build()
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 43, in require_build
    raise click.UsageError(
click.exceptions.UsageError: No saved build name found.
To fix this, run `launchable record build`.
If you already ran this command on a different machine, use the --session option. See https://www.launchableinc.com/docs/sending-data-to-launchable/using-the-launchable-cli/recording-test-results-with-the-launchable-cli/managing-complex-test-session-layouts/
Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/bin/launchable", line 8, in <module>
    sys.exit(main())
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/yabuki-ryosuke/.asdf/installs/python/3.9.16/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/test_runners/file.py", line 50, in record_tests
    client.report(r)
AttributeError: 'Application' object has no attribute 'report'

$ echo $?
1
```

## After

```
$ launchable record tests file ./test-results/**/*.xml
Traceback (most recent call last):
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/record/tests.py", line 223, in tests
    session_id = str(find_or_create_session(
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 104, in find_or_create_session
    saved_build_name = require_build()
  File "/Users/yabuki-ryosuke/src/github.com/launchableinc/cli/launchable/commands/helper.py", line 43, in require_build
    raise click.UsageError(
click.exceptions.UsageError: No saved build name found.
To fix this, run `launchable record build`.
If you already ran this command on a different machine, use the --session option. See https://www.launchableinc.com/docs/sending-data-to-launchable/using-the-launchable-cli/recording-test-results-with-the-launchable-cli/managing-complex-test-session-layouts/
$ echo $?
0
```