### PR TITLE
[UX-171] error message reporting improvement

### DIFF
--- a/launchable/commands/record/attachment.py
+++ b/launchable/commands/record/attachment.py
@@ -1,9 +1,7 @@
-import os
 from typing import Optional
 
 import click
 
-from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.launchable_client import LaunchableClient
 from ..helper import require_session
 
@@ -22,10 +20,10 @@ def attachment(
         attachments,
         session: Optional[str] = None
 ):
+    client = LaunchableClient(app=context.obj)
     try:
         session = require_session(session)
 
-        client = LaunchableClient(app=context.obj)
         for a in attachments:
             click.echo("Sending {}".format(a))
             with open(a, mode='rb') as f:
@@ -34,7 +32,4 @@ def attachment(
                     additional_headers={"Content-Disposition": "attachment;filename=\"{}\"".format(a)})
                 res.raise_for_status()
     except Exception as e:
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(e)
+        client.print_exception_and_recover(e)

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -10,8 +10,7 @@ from launchable.utils.key_value_type import normalize_key_value_types
 from launchable.utils.link import LinkKind, capture_link
 from launchable.utils.tracking import Tracking, TrackingClient
 
-from ...utils.click import KeyValueType, ignorable_error
-from ...utils.env_keys import REPORT_ERROR_KEY
+from ...utils.click import KeyValueType
 from ...utils.launchable_client import LaunchableClient
 from ...utils.no_build import NO_BUILD_BUILD_NAME
 from ...utils.session import _session_file_path, read_build, write_session
@@ -148,10 +147,7 @@ def session(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=str(e),
             )
-            if os.getenv(REPORT_ERROR_KEY):
-                raise e
-            else:
-                click.echo(ignorable_error(e))
+            client.print_exception_and_recover(e)
 
     flavor_dict = {}
     for f in normalize_key_value_types(flavor):
@@ -213,10 +209,7 @@ def session(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
             stack_trace=str(e),
         )
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(e, err=True)
+        client.print_exception_and_recover(e)
 
     if session_name:
         try:
@@ -231,10 +224,7 @@ def session(
                 event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
                 stack_trace=str(e),
             )
-            if os.getenv(REPORT_ERROR_KEY):
-                raise e
-            else:
-                click.echo(e, err=True)
+            client.print_exception_and_recover(e)
 
 
 def add_session_name(

--- a/launchable/commands/split_subset.py
+++ b/launchable/commands/split_subset.py
@@ -7,7 +7,6 @@ from launchable.testpath import TestPath
 
 from ..app import Application
 from ..utils.click import FRACTION, FractionType
-from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.launchable_client import LaunchableClient
 from .test_path_writer import TestPathWriter
 
@@ -264,14 +263,9 @@ def split_subset(
                     self.output_handler(output_subset, output_rests)
 
             except Exception as e:
-                if os.getenv(REPORT_ERROR_KEY):
-                    raise e
-                else:
-                    click.echo(e, err=True)
-                    click.echo(click.style(
-                        "Warning: the service failed to split subset. Falling back to running all tests", fg='yellow'),
-                        err=True)
-                    return
+                client.print_exception_and_recover(
+                    e, "Warning: the service failed to split subset. Falling back to running all tests")
+                return
 
         def _write_split_by_groups_group_names(self, subset_group_names: List[str], rest_group_names: List[str]):
             if is_output_exclusion_rules:
@@ -319,14 +313,8 @@ def split_subset(
                     self._write_split_by_groups_group_names(subset_group_names, rest_group_names)
 
             except Exception as e:
-                if os.getenv(REPORT_ERROR_KEY):
-                    raise e
-                else:
-                    click.echo(e, err=True)
-                    click.echo(click.style(
-                        "Error: the service failed to split subset.", fg='red'),
-                        err=True)
-                    exit(1)
+                client.print_exception_and_recover(e, "Error: the service failed to split subset.", 'red')
+                exit(1)
 
         def run(self):
             if (not self._is_split_by_groups() and bin_target is None) or (self._is_split_by_groups() and bin_target):

--- a/launchable/commands/stats/test_sessions.py
+++ b/launchable/commands/stats/test_sessions.py
@@ -1,10 +1,8 @@
-import os
 from typing import Any, Dict, List
 
 import click
 
 from ...utils.click import KeyValueType
-from ...utils.env_keys import REPORT_ERROR_KEY
 from ...utils.key_value_type import normalize_key_value_types
 from ...utils.launchable_client import LaunchableClient
 
@@ -41,17 +39,11 @@ def test_sessions(
     else:
         params.pop('flavor', None)
 
+    client = LaunchableClient(app=context.obj)
     try:
-        client = LaunchableClient(app=context.obj)
         res = client.request('get', '/stats/test-sessions', params=params)
         res.raise_for_status()
         click.echo(res.text)
 
     except Exception as e:
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(e, err=True)
-        click.echo(click.style(
-            "Warning: the service failed to get stat.", fg='yellow'),
-            err=True)
+        client.print_exception_and_recover(e, "Warning: the service failed to get stat.")

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -499,14 +499,8 @@ def subset(
                         stack_trace=str(e),
                     )
 
-                    if os.getenv(REPORT_ERROR_KEY):
-                        raise e
-                    else:
-                        click.echo(e, err=True)
-
-                    click.echo(click.style(
-                        "Warning: the service failed to subset. Falling back to running all tests", fg='yellow'),
-                        err=True)
+                    client.print_exception_and_recover(
+                        e, "Warning: the service failed to subset. Falling back to running all tests")
 
             if len(original_subset) == 0:
                 click.echo(click.style("Error: no tests found matching the path.", 'yellow'), err=True)

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -7,11 +7,11 @@ from typing import List
 
 import click
 
-from launchable.utils.env_keys import REPORT_ERROR_KEY, TOKEN_KEY
+from launchable.utils.env_keys import TOKEN_KEY
 from launchable.utils.tracking import Tracking, TrackingClient
 
 from ..utils.authentication import get_org_workspace
-from ..utils.click import emoji, ignorable_error
+from ..utils.click import emoji
 from ..utils.java import get_java_command
 from ..utils.launchable_client import LaunchableClient
 from ..version import __version__ as version
@@ -112,10 +112,7 @@ def verify(context: click.core.Context):
             stack_trace=str(e),
             api="verification",
         )
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(ignorable_error(e))
+        client.print_exception_and_recover(e)
 
     if java is None:
         msg = "Java is not installed. Install Java version 8 or newer to use the Launchable CLI."


### PR DESCRIPTION
If the server reports an error, print the payload to assist the troubleshooting. When our service responds, there's JSON payload that contains a quick message. Other HTTP intermediaries may insert other failures, including intermediaries on the customer side.

@Konboi Let me know when is the best time to merge something like this. I'd imagine you might want to push this out past the scheduled maintenance.