### PR TITLE
Add metadata field in raw profile

### DIFF
--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -124,6 +124,16 @@ def record_tests(client, test_result_files):
                 that the CLI is invoked.",
                 "type": "string",
                 "format": "date-time"
+              },
+              "data": {
+                "description": "Metadata of the test, e.g. line number.",
+                "type": "object",
+                "properties": {
+                  "lineNumber": {
+                    "description": "Line number of the test (1-based).",
+                    "type": "number"
+                  }
+                }
               }
             },
             "required": [
@@ -179,6 +189,7 @@ def record_tests(client, test_result_files):
             if duration_secs < 0:
                 raise ValueError("The duration of {} should be positive (was {})".format(test_path_components, duration_secs))
             dateutil.parser.parse(created_at)
+            metadata = case.get('data', None)
 
             yield CaseEvent.create(
                 test_path=test_path_components,
@@ -186,7 +197,8 @@ def record_tests(client, test_result_files):
                 status=CaseEvent.STATUS_MAP[status],
                 stdout=case['stdout'],
                 stderr=case['stderr'],
-                timestamp=created_at)
+                timestamp=created_at,
+                data=metadata)
 
     for test_result_file in test_result_files:
         if not test_result_file.endswith('.xml'):

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -223,7 +223,10 @@ class CliTestCase(unittest.TestCase):
         """
         def tree_sorted(obj):
             if isinstance(obj, dict):
-                return sorted((k, tree_sorted(v)) for k, v in obj.items())
+                # Convert the dictionary items into a list of tuples,
+                # where each tuple contains the key and the recursively sorted value.
+                # this sort option `key=lambda item: (item[1] is None, item)`` is for when the value is None
+                return sorted([(k, tree_sorted(v)) for k, v in obj.items()], key=lambda item: (item[1] is None, item))
             if isinstance(obj, list):
                 return sorted(tree_sorted(x) for x in obj)
             else:

--- a/tests/test_cli_test_case.py
+++ b/tests/test_cli_test_case.py
@@ -1,0 +1,43 @@
+from .cli_test_case import CliTestCase
+
+
+class TestCliTestCase(CliTestCase):
+    def test_assert_json_orderless_equal(self):
+        # simple case
+        self.assert_json_orderless_equal(
+            {"a": 1, "b": 2},
+            {"b": 2, "a": 1}
+        )
+
+        # has array field
+        self.assert_json_orderless_equal(
+            {"array": [1, 2, 3], "b": 2},
+            {"b": 2, "array": [1, 2, 3]}
+        )
+
+        # has dict field
+        self.assert_json_orderless_equal(
+            {"dict": {
+                "a": 1,
+                "b": 2,
+                "c": 3
+            }, "b": 2},
+            {"b": 2, "dict": {
+                "b": 2,
+                "c": 3,
+                "a": 1
+            }}
+        )
+        # compare with array that some object have have fields that None
+        self.assert_json_orderless_equal(
+            {"array": [
+                {"name": "a", "data": {"value": 1}},
+                {"data": None, "name": "b"},
+                {"name": "c", "data": {"value": 2}}
+            ], "b": 2},
+            {"b": 2, "array": [
+                {"data": None, "name": "b"},
+                {"data": {"value": 2}, "name": "c"},
+                {"data": {"value": 1}, "name": "a"},
+            ]}
+        )

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -150,6 +150,17 @@ class RawTest(CliTestCase):
                     '       "stderr": "This is stderr",',
                     '       "createdAt": "2021-10-05T12:34:00"',
                     '     }',
+                    '     ,{',
+                    '       "testPath": "file=aa.py#class=classAA",',
+                    '       "duration": 12,',
+                    '       "status": "TEST_PASSED",',
+                    '       "stdout": "This is stdout",',
+                    '       "stderr": "This is stderr",',
+                    '       "createdAt": "2021-10-05T12:34:56",',
+                    '       "data": {',
+                    '         "lineNumber": 5',
+                    '       }',
+                    '     }',
                     '  ]',
                     '}',
                 ]) + '\n')
@@ -249,60 +260,18 @@ class RawTest(CliTestCase):
                         'data': None,
                         'type': 'case',
                     },
-                ],
-                "testRunner": "raw",
-                "group": "",
-                "noBuild": False,
-            })
-
-    @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_metadata_field(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            test_path_file = os.path.join(tempdir, 'tests.json')
-            with open(test_path_file, 'w') as f:
-                f.write('\n'.join([
-                    '{',
-                    '  "testCases": [',
-                    '     {',
-                    '       "testPath": "file=a.py#class=classA",',
-                    '       "duration": 42,',
-                    '       "status": "TEST_PASSED",',
-                    '       "stdout": "This is stdout",',
-                    '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:56",',
-                    '       "data": {',
-                    '         "lineNumber": 5',
-                    '       }',
-                    '     }',
-                    '  ]',
-                    '}',
-                ]) + '\n')
-
-            # emulate launchable record build
-            write_build(self.build_name)
-
-            result = self.cli('record', 'tests', 'raw', test_path_file, mix_stderr=False)
-            self.assert_success(result)
-
-            # Check request body
-            payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-            self.assert_json_orderless_equal(payload, {
-                'events': [
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'a.py'},
-                            {'type': 'class', 'name': 'classA'},
+                            {'type': 'file', 'name': 'aa.py'},
+                            {'type': 'class', 'name': 'classAA'},
                         ],
-                        'duration': 42,
+                        'duration': 12,
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
                         'created_at': '2021-10-05T12:34:56',
+                        'data': {"lineNumber": 5},
                         'type': 'case',
-                        'data': {
-                            'lineNumber': 5
-                        }
                     },
                 ],
                 "testRunner": "raw",


### PR DESCRIPTION
Launchable started accepting metadata field in each test case. This will provide rich feature in Launchable web console by configuring metadata field. For instance, we plan to provide the feature that users can jump into a test case from Web Console.
As a first step, we'll add metadata field in raw profile.

[58006be](https://github.com/launchableinc/cli/pull/814/commits/58006be7a967a729c4aa3e496fc876a9f2cbf410) is the core logic for adding metadata field in raw profile.