### PR TITLE
Fix add metadata

### DIFF
--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -223,7 +223,10 @@ class CliTestCase(unittest.TestCase):
         """
         def tree_sorted(obj):
             if isinstance(obj, dict):
-                return sorted((k, tree_sorted(v)) for k, v in obj.items())
+                # Convert the dictionary items into a list of tuples,
+                # where each tuple contains the key and the recursively sorted value.
+                # this sort option `key=lambda item: (item[1] is None, item)`` is for when the value is None
+                return sorted(list((k, tree_sorted(v)) for k, v in obj.items()), key=lambda item: (item[1] is None, item))
             if isinstance(obj, list):
                 return sorted(tree_sorted(x) for x in obj)
             else:

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -226,7 +226,7 @@ class CliTestCase(unittest.TestCase):
                 # Convert the dictionary items into a list of tuples,
                 # where each tuple contains the key and the recursively sorted value.
                 # this sort option `key=lambda item: (item[1] is None, item)`` is for when the value is None
-                return sorted(list((k, tree_sorted(v)) for k, v in obj.items()), key=lambda item: (item[1] is None, item))
+                return sorted([(k, tree_sorted(v)) for k, v in obj.items()], key=lambda item: (item[1] is None, item))
             if isinstance(obj, list):
                 return sorted(tree_sorted(x) for x in obj)
             else:

--- a/tests/test_cli_test_case.py
+++ b/tests/test_cli_test_case.py
@@ -1,0 +1,43 @@
+from .cli_test_case import CliTestCase
+
+
+class TestCliTestCase(CliTestCase):
+    def test_assert_json_orderless_equal(self):
+        # simple case
+        self.assert_json_orderless_equal(
+            {"a": 1, "b": 2},
+            {"b": 2, "a": 1}
+        )
+
+        # has array field
+        self.assert_json_orderless_equal(
+            {"array": [1, 2, 3], "b": 2},
+            {"b": 2, "array": [1, 2, 3]}
+        )
+
+        # has dict field
+        self.assert_json_orderless_equal(
+            {"dict": {
+                "a": 1,
+                "b": 2,
+                "c": 3
+            }, "b": 2},
+            {"b": 2, "dict": {
+                "b": 2,
+                "c": 3,
+                "a": 1
+            }}
+        )
+        # compare with array that some object have have fields that None
+        self.assert_json_orderless_equal(
+            {"array": [
+                {"name": "a", "data": {"value": 1}},
+                {"data": None, "name": "b"},
+                {"name": "c", "data": {"value": 2}}
+            ], "b": 2},
+            {"b": 2, "array": [
+                {"data": None, "name": "b"},
+                {"data": {"value": 2}, "name": "c"},
+                {"data": {"value": 1}, "name": "a"},
+            ]}
+        )

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -150,7 +150,7 @@ class RawTest(CliTestCase):
                     '       "stderr": "This is stderr",',
                     '       "createdAt": "2021-10-05T12:34:00"',
                     '     }',
-                    '     {',
+                    '     ,{',
                     '       "testPath": "file=aa.py#class=classAA",',
                     '       "duration": 12,',
                     '       "status": "TEST_PASSED",',
@@ -235,19 +235,6 @@ class RawTest(CliTestCase):
                     },
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'aa.py'},
-                            {'type': 'class', 'name': 'classAA'},
-                        ],
-                        'duration': 12,
-                        'status': 1,
-                        'stdout': 'This is stdout',
-                        'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:56',
-                        'data': {"lineNumber": 5},
-                        'type': 'case',
-                    },
-                    {
-                        'testPath': [
                             {'type': 'file', 'name': 'b.py'},
                             {'type': 'class', 'name': 'classB'},
                         ],
@@ -271,6 +258,19 @@ class RawTest(CliTestCase):
                         'stderr': 'This is stderr',
                         'created_at': '2021-10-05T12:34:56',
                         'data': None,
+                        'type': 'case',
+                    },
+                    {
+                        'testPath': [
+                            {'type': 'file', 'name': 'aa.py'},
+                            {'type': 'class', 'name': 'classAA'},
+                        ],
+                        'duration': 12,
+                        'status': 1,
+                        'stdout': 'This is stdout',
+                        'stderr': 'This is stderr',
+                        'created_at': '2021-10-05T12:34:56',
+                        'data': {"lineNumber": 5},
                         'type': 'case',
                     },
                 ],

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -150,6 +150,17 @@ class RawTest(CliTestCase):
                     '       "stderr": "This is stderr",',
                     '       "createdAt": "2021-10-05T12:34:00"',
                     '     }',
+                    '     {',
+                    '       "testPath": "file=aa.py#class=classAA",',
+                    '       "duration": 12,',
+                    '       "status": "TEST_PASSED",',
+                    '       "stdout": "This is stdout",',
+                    '       "stderr": "This is stderr",',
+                    '       "createdAt": "2021-10-05T12:34:56",',
+                    '       "data": {',
+                    '         "lineNumber": 5',
+                    '       }',
+                    '     }',
                     '  ]',
                     '}',
                 ]) + '\n')
@@ -224,6 +235,19 @@ class RawTest(CliTestCase):
                     },
                     {
                         'testPath': [
+                            {'type': 'file', 'name': 'aa.py'},
+                            {'type': 'class', 'name': 'classAA'},
+                        ],
+                        'duration': 12,
+                        'status': 1,
+                        'stdout': 'This is stdout',
+                        'stderr': 'This is stderr',
+                        'created_at': '2021-10-05T12:34:56',
+                        'data': {"lineNumber": 5},
+                        'type': 'case',
+                    },
+                    {
+                        'testPath': [
                             {'type': 'file', 'name': 'b.py'},
                             {'type': 'class', 'name': 'classB'},
                         ],
@@ -248,61 +272,6 @@ class RawTest(CliTestCase):
                         'created_at': '2021-10-05T12:34:56',
                         'data': None,
                         'type': 'case',
-                    },
-                ],
-                "testRunner": "raw",
-                "group": "",
-                "noBuild": False,
-            })
-
-    @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_metadata_field(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            test_path_file = os.path.join(tempdir, 'tests.json')
-            with open(test_path_file, 'w') as f:
-                f.write('\n'.join([
-                    '{',
-                    '  "testCases": [',
-                    '     {',
-                    '       "testPath": "file=a.py#class=classA",',
-                    '       "duration": 42,',
-                    '       "status": "TEST_PASSED",',
-                    '       "stdout": "This is stdout",',
-                    '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:56",',
-                    '       "data": {',
-                    '         "lineNumber": 5',
-                    '       }',
-                    '     }',
-                    '  ]',
-                    '}',
-                ]) + '\n')
-
-            # emulate launchable record build
-            write_build(self.build_name)
-
-            result = self.cli('record', 'tests', 'raw', test_path_file, mix_stderr=False)
-            self.assert_success(result)
-
-            # Check request body
-            payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-            self.assert_json_orderless_equal(payload, {
-                'events': [
-                    {
-                        'testPath': [
-                            {'type': 'file', 'name': 'a.py'},
-                            {'type': 'class', 'name': 'classA'},
-                        ],
-                        'duration': 42,
-                        'status': 1,
-                        'stdout': 'This is stdout',
-                        'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:56',
-                        'type': 'case',
-                        'data': {
-                            'lineNumber': 5
-                        }
                     },
                 ],
                 "testRunner": "raw",


### PR DESCRIPTION
When comparing a NoneType object and another type, we encountered an error e.g.) `TypeError: '<' not supported between instances of 'NoneType' and 'list'`  and we couldn't use the `assert_json_orderless_equal(self, a, b)` method

So, I fixed it

https://github.com/launchableinc/cli/actions/runs/8390491593?pr=817