### PR TITLE
No more close

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -438,7 +438,7 @@ def tests(
 
             # generator that creates the payload incrementally
             def payload(cases: Generator[TestCase, None, None],
-                        test_runner, group: str) -> Tuple[Dict[str, Union[str, List, bool]], List[Exception]]:
+                        test_runner, group: str) -> Tuple[Dict[str, Union[str, List, dict, bool]], List[Exception]]:
                 nonlocal count
                 cs = []
                 exs = []

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -415,7 +415,6 @@ def tests(
 
         def run(self):
             count = 0  # count number of test cases sent
-            is_observation = False
 
             def testcases(reports: List[str]) -> Generator[CaseEventType, None, None]:
                 exceptions = []

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -5,7 +5,6 @@ import types
 
 import click
 
-from launchable.app import Application
 from launchable.commands.record.tests import tests as record_tests_cmd
 from launchable.commands.split_subset import split_subset as split_subset_cmd
 from launchable.commands.subset import subset as subset_cmd

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -2,6 +2,7 @@ import os
 from typing import BinaryIO, Dict, Optional, Tuple, Union
 
 import click
+import requests
 from requests import HTTPError, Session, Timeout
 
 from launchable.utils.http_client import _HttpClient, _join_paths
@@ -39,7 +40,7 @@ class LaunchableClient:
         timeout: Tuple[int, int] = (5, 60),
         compress: bool = False,
         additional_headers: Optional[Dict] = None,
-    ):
+    ) -> requests.Response:
         path = _join_paths(
             "/intake/organizations/{}/workspaces/{}".format(self.organization, self.workspace),
             sub_path

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -76,6 +76,9 @@ class LaunchableClient:
         except Exception as e:
             track(Tracking.ErrorEvent.INTERNAL_SERVER_ERROR, e)
 
+        # should never come here, but needed to make type checker happy
+        assert False
+
     def print_exception_and_recover(self, e: Exception, warning: Optional[str] = None, warning_color='yellow'):
         """
         Print the exception raised from the request method, then recover from it

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -207,7 +207,8 @@ class CliTestCase(unittest.TestCase):
     def find_request(self, url_suffix: str, n: int = 0):
         '''Find the first (or n-th, if specified) request that matches the given suffix'''
         for call in responses.calls:
-            if call.request.url.endswith(url_suffix):
+            url = call.request.url
+            if url and url.endswith(url_suffix):
                 if n == 0:
                     return call
                 n -= 1

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -221,6 +221,19 @@ class CliTestCase(unittest.TestCase):
         expected = self.load_json_from_file(self.test_files_dir.joinpath(golden_image_filename))
         self.assert_json_orderless_equal(expected, payload)
 
+    def assert_subset_payload(self, golden_image_filename: str, payload=None):
+        '''
+        Compares the request sent by the 'launchable subset' with the given golden file image
+
+        :param payload
+            If none is given, retrieve the payload from what the mock responses captured
+        '''
+
+        if not payload:
+            payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
+        expected = self.load_json_from_file(self.test_files_dir.joinpath(golden_image_filename))
+        self.assert_json_orderless_equal(expected, payload)
+
     def load_json_from_file(self, file):
         try:
             with file.open() as json_file:

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -1,10 +1,12 @@
 import gzip
+import inspect
 import json
 import os
 import shutil
 import tempfile
 import types
 import unittest
+from pathlib import Path
 
 import click  # type: ignore
 import responses  # type: ignore
@@ -28,11 +30,17 @@ class CliTestCase(unittest.TestCase):
     subsetting_id = 456
     session = "builds/{}/test_sessions/{}".format(build_name, session_id)
 
+    # directory where test data files are placed. see get_test_files_dir()
+    test_files_dir: Path
+
     def setUp(self):
         self.dir = tempfile.mkdtemp()
         os.environ[SESSION_DIR_KEY] = self.dir
 
         self.maxDiff = None
+
+        if not hasattr(self, 'test_files_dir'):
+            self.test_files_dir = self.get_test_files_dir()
 
         responses.add(
             responses.POST,
@@ -170,6 +178,11 @@ class CliTestCase(unittest.TestCase):
             json={'keys': ["GITHUB_ACTOR", "BRANCH_NAME"]},
             status=200)
 
+    def get_test_files_dir(self):
+        file_name = Path(inspect.getfile(self.__class__))  # obtain the file of the concrete type
+        stem = file_name.stem.replace('test_', '')  # test_foo.py -> foo
+        return file_name.parent.joinpath('../data/%s/' % stem).resolve()
+
     def tearDown(self):
         clean_session_files()
         del os.environ[SESSION_DIR_KEY]
@@ -199,7 +212,7 @@ class CliTestCase(unittest.TestCase):
                     return call
                 n -= 1
 
-        self.fail("Call to % didn't happen" % url_suffix)
+        self.fail("Call to %s didn't happen" % url_suffix)
 
     def assert_record_tests_payload(self, golden_image_filename: str, payload=None):
         '''

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -29,11 +29,7 @@ class TestsTest(CliTestCase):
                               self.report_files_dir) + "**/reports/")
 
         self.assertEqual(result.exit_code, 0)
-        # get request body
-        # responses.calls[0]: GET: build information
-        # responses.calls[1]: POST: record tests
-        request = json.loads(gzip.decompress(
-            responses.calls[1].request.body).decode())
+        request = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
 
         self.assertCountEqual(request.get("group", []), "hoge")
 
@@ -59,7 +55,7 @@ class TestsTest(CliTestCase):
         self.assertIn(remove_backslash(broken_xml), remove_backslash(result.output))
 
         # normal.xml
-        self.assertIn('open_class_user_test.rb', gzip.decompress(responses.calls[2].request.body).decode())
+        self.assertIn('open_class_user_test.rb', gzip.decompress(self.find_request('/events').request.body).decode())
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/data/ant/record_test_result.json
+++ b/tests/data/ant/record_test_result.json
@@ -16,7 +16,6 @@
       "status": 0,
       "stdout": "",
       "stderr": "junit.framework.AssertionFailedError: An error message\n\tat com.launchable.HelloWorldTest.testWillAlwaysFail(Unknown Source)\n",
-      "created_at": "2021-04-28T10:36:31",
       "data": null
     },
     {
@@ -35,7 +34,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-04-28T10:36:31",
       "data": null
     },
     {
@@ -54,7 +52,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-04-28T10:36:32",
       "data": null
     }
   ],

--- a/tests/data/cypress/record_test_result.json
+++ b/tests/data/cypress/record_test_result.json
@@ -20,7 +20,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-20T08:49:02",
       "data": null
     },
     {
@@ -43,7 +42,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-20T08:49:02",
       "data": null
     },
     {
@@ -66,7 +64,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-20T08:49:02",
       "data": null
     }
   ],

--- a/tests/data/dotnet/record_test_result.json
+++ b/tests/data/dotnet/record_test_result.json
@@ -24,7 +24,6 @@
             "status": 1,
             "stdout": "",
             "stderr": "",
-            "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         },
         {
@@ -51,7 +50,6 @@
             "status": 0,
             "stdout": "",
             "stderr": "  Expected: 0.5d\n  But was:  0\n\n   at rocket_car_dotnet.ExampleTest.TestDiv() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 35\n",
-            "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         },
         {
@@ -78,7 +76,6 @@
             "status": 0,
             "stdout": "",
             "stderr": "  Expected: 10\n  But was:  25\n\n   at rocket_car_dotnet.ExampleTest.TestMul() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 28\n",
-            "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         },
         {
@@ -105,7 +102,6 @@
             "status": 0,
             "stdout": "",
             "stderr": "  Expected: 2\n  But was:  6\n\n   at rocket_car_dotnet.ExampleTest.TestSub() in /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/dotnet/ExampleTest.cs:line 21\n",
-            "created_at": "2023-05-15T 08:22:02Z",
             "data": null
         }
     ],

--- a/tests/data/googletest/fail/record_test_result.json
+++ b/tests/data/googletest/fail/record_test_result.json
@@ -16,7 +16,6 @@
       "status": 0,
       "stdout": "",
       "stderr": "github.com/launchableinc/rocket-car-googletest/test_a.cpp:21\nExpected equality of these values:\n  false\n  true",
-      "created_at": "2021-01-26T14:56:53",
       "data": null
     },
     {
@@ -35,7 +34,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-26T14:56:53",
       "data": null
     },
     {
@@ -54,7 +52,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-26T14:56:53",
       "data": null
     }
   ],

--- a/tests/data/googletest/record_test_result.json
+++ b/tests/data/googletest/record_test_result.json
@@ -16,7 +16,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     },
     {
@@ -35,7 +34,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     },
     {
@@ -54,7 +52,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     },
     {
@@ -73,7 +70,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     },
     {
@@ -92,7 +88,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     },
     {
@@ -111,7 +106,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-01-15T17:39:19",
       "data": null
     }
   ],

--- a/tests/data/gradle/recursion/expected.json
+++ b/tests/data/gradle/recursion/expected.json
@@ -16,7 +16,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-11-18T13:17:18",
       "data": null
     },
     {
@@ -35,7 +34,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-11-18T13:17:18",
       "data": null
     }
   ],

--- a/tests/data/jest/record_test_result.json
+++ b/tests/data/jest/record_test_result.json
@@ -13,7 +13,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -27,7 +26,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -43,7 +41,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -59,7 +56,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -75,7 +71,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -88,7 +83,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -104,7 +98,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -120,7 +113,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -136,7 +128,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     },
     {
@@ -153,7 +144,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-11-09T05:36:19",
       "data": null
     }
   ],

--- a/tests/data/minitest/record_test_result.json
+++ b/tests/data/minitest/record_test_result.json
@@ -13,7 +13,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -29,7 +28,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -45,7 +43,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -61,7 +58,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -77,7 +73,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -93,7 +88,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -109,7 +103,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -122,7 +115,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
       "data": null
     }
   ],

--- a/tests/data/nunit/nunit-reporter-bug-with-nested-type.json
+++ b/tests/data/nunit/nunit-reporter-bug-with-nested-type.json
@@ -10,7 +10,6 @@
         { "type": "TestSuite",   "name": "Outer+Inner" },
         { "type": "TestCase",    "name": "TheTest" }
       ],
-      "created_at": "2023-07-28T 22:32:13Z",
       "duration": 1.6e-05,
       "status": 1,
       "stdout": "",
@@ -27,7 +26,6 @@
         { "type": "TestSuite",   "name": "InlineParameterTests" },
         { "type": "TestCase",    "name": "StrTest(\"dot.in.it\")" }
       ],
-      "created_at": "2023-08-09T 22:13:42Z",
       "duration": 2.1e-05,
       "status": 1,
       "stdout": "",

--- a/tests/data/nunit/record_test_result-linux.json
+++ b/tests/data/nunit/record_test_result-linux.json
@@ -9,7 +9,6 @@
         { "type": "TestSuite", "name": "Tests2" },
         { "type": "TestCase",    "name": "Foo" }
       ],
-      "created_at": "2021-05-25T01:24:39.5030637Z",
       "duration": 0.002087,
       "status": 1,
       "stdout": "",
@@ -24,7 +23,6 @@
         { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test1" }
       ],
-      "created_at": "2021-05-25T01:24:39.5082923Z",
       "duration": 0.011325,
       "status": 1,
       "stdout": "",
@@ -39,7 +37,6 @@
         { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test2" }
       ],
-      "created_at": "2021-05-25T01:24:39.5196489Z",
       "duration": 0.009933,
       "status": 0,
       "stdout": "",
@@ -54,7 +51,6 @@
         { "type": "TestSuite", "name": "Outer+Inner" },
         { "type": "TestCase",    "name": "Test3" }
       ],
-      "created_at": "2023-07-27T17:47:58.8159407Z",
       "duration": 0.001215,
       "status": 1,
       "stdout": "",
@@ -71,7 +67,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,3)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5299429Z",
       "duration": 0.006011,
       "status": 1,
       "stdout": "",
@@ -87,7 +82,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,2)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5359698Z",
       "duration": 0.000093,
       "status": 1,
       "stdout": "",
@@ -103,7 +97,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,4)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5297832Z",
       "duration": 0.000033,
       "status": 1,
       "stdout": "",

--- a/tests/data/nunit/record_test_result-windows.json
+++ b/tests/data/nunit/record_test_result-windows.json
@@ -9,7 +9,6 @@
         { "type": "TestSuite", "name": "Tests2" },
         { "type": "TestCase",    "name": "Foo" }
       ],
-      "created_at": "2021-05-25T01:24:39.5030637Z",
       "duration": 0.002087,
       "status": 1,
       "stdout": "",
@@ -24,7 +23,6 @@
         { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test1" }
       ],
-      "created_at": "2021-05-25T01:24:39.5082923Z",
       "duration": 0.011325,
       "status": 1,
       "stdout": "",
@@ -39,7 +37,6 @@
         { "type": "TestSuite", "name": "Tests1" },
         { "type": "TestCase",    "name": "Test2" }
       ],
-      "created_at": "2021-05-25T01:24:39.5196489Z",
       "duration": 0.009933,
       "status": 0,
       "stdout": "",
@@ -54,7 +51,6 @@
         { "type": "TestSuite", "name": "Outer+Inner" },
         { "type": "TestCase",    "name": "Test3" }
       ],
-      "created_at": "2023-07-27T17:47:58.8159407Z",
       "duration": 0.001215,
       "status": 1,
       "stdout": "",
@@ -71,7 +67,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,3)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5299429Z",
       "duration": 0.006011,
       "status": 1,
       "stdout": "",
@@ -87,7 +82,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,2)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5359698Z",
       "duration": 0.000093,
       "status": 1,
       "stdout": "",
@@ -103,7 +97,6 @@
         { "type": "ParameterizedMethod", "name":  "DivideTest" },
         { "type": "TestCase",    "name": "DivideTest(12,4)" }
       ],
-      "created_at": "2021-05-25T01:24:39.5297832Z",
       "duration": 0.000033,
       "status": 1,
       "stdout": "",

--- a/tests/data/playwright/record_test_result.json
+++ b/tests/data/playwright/record_test_result.json
@@ -16,7 +16,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -35,7 +34,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -54,7 +52,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -73,7 +70,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -92,7 +88,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -111,7 +106,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -130,7 +124,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -149,7 +142,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -168,7 +160,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -187,7 +178,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -206,7 +196,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -225,7 +214,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -244,7 +232,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -263,7 +250,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -282,7 +268,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -301,7 +286,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -320,7 +304,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -339,7 +322,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -358,7 +340,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -377,7 +358,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -396,7 +376,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -415,7 +394,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -434,7 +412,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -453,7 +430,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -472,7 +448,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -491,7 +466,6 @@
       "status": 0,
       "stdout": "",
       "stderr": "\n  [chromium] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -510,7 +484,6 @@
       "status": 2,
       "stdout": "",
       "stderr": "\n",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -529,7 +502,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -548,7 +520,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -567,7 +538,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -586,7 +556,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -605,7 +574,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -624,7 +592,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -643,7 +610,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -662,7 +628,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -681,7 +646,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -700,7 +664,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -719,7 +682,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -738,7 +700,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -757,7 +718,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -776,7 +736,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -795,7 +754,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -814,7 +772,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -833,7 +790,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -852,7 +808,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -871,7 +826,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -890,7 +844,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -909,7 +862,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -928,7 +880,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -947,7 +898,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -966,7 +916,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -985,7 +934,6 @@
       "status": 0,
       "stdout": "",
       "stderr": "\n  [firefox] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1004,7 +952,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1023,7 +970,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1042,7 +988,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1061,7 +1006,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1080,7 +1024,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1099,7 +1042,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1118,7 +1060,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1137,7 +1078,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1156,7 +1096,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1175,7 +1114,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1194,7 +1132,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1213,7 +1150,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1232,7 +1168,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1251,7 +1186,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1270,7 +1204,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1289,7 +1222,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1308,7 +1240,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1327,7 +1258,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1346,7 +1276,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1365,7 +1294,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1384,7 +1312,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1403,7 +1330,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1422,7 +1348,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1441,7 +1366,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1460,7 +1384,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     },
     {
@@ -1479,7 +1402,6 @@
       "status": 0,
       "stdout": "",
       "stderr": "\n  [webkit] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "created_at": "2024-01-31T07:12:52.585Z",
       "data": null
     }
   ],

--- a/tests/data/pytest/record_test_result.json
+++ b/tests/data/pytest/record_test_result.json
@@ -20,7 +20,6 @@
        "status": 1,
        "stdout": "",
        "stderr": "",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 1 }
      },
      {
@@ -43,7 +42,6 @@
        "status": 0,
        "stdout": "",
        "stderr": "def test_func5():\n  >       assert 1 == False\n  E       assert 1 == False\n\n        tests/funcs3_test.py:6: AssertionError      ",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 5 }
      },
      {
@@ -66,7 +64,6 @@
        "status": 1,
        "stdout": "",
        "stderr": "",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 1 }
      },
      {
@@ -89,7 +86,6 @@
        "status": 0,
        "stdout": "",
        "stderr": "def test_func2():\n  >       assert 1 == False\n  E       assert 1 == False\n\n    tests/test_funcs1.py:6: AssertionError  ",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 5 }
      },
      {
@@ -112,7 +108,6 @@
        "status": 1,
        "stdout": "",
        "stderr": "",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 1 }
      },
      {
@@ -135,7 +130,6 @@
        "status": 1,
        "stdout": "",
        "stderr": "",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 5 }
      },
      {
@@ -158,7 +152,6 @@
        "status": 1,
        "stdout": "",
        "stderr": "",
-       "created_at": "2021-12-09T14:09:43.746900",
        "data": { "lineNumber": 1 }
      }
    ],

--- a/tests/data/rspec/record_test_result.json
+++ b/tests/data/rspec/record_test_result.json
@@ -20,7 +20,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -43,7 +42,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -66,7 +64,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -89,7 +86,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -112,7 +108,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -135,7 +130,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -158,7 +152,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -181,7 +174,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -204,7 +196,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -227,7 +218,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -250,7 +240,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -273,7 +262,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -296,7 +284,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -319,7 +306,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -342,7 +328,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     },
     {
@@ -365,7 +350,6 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2021-03-22T14:06:25+09:00",
       "data": null
     }
   ],

--- a/tests/test_runners/test_adb.py
+++ b/tests/test_runners/test_adb.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -62,7 +60,4 @@ INSTRUMENTATION_CODE: -1
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_subset_payload('subset_result.json')

--- a/tests/test_runners/test_adb.py
+++ b/tests/test_runners/test_adb.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -9,7 +8,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class AdbTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/adb/').resolve()
     subset_input = """INSTRUMENTATION_STATUS: class=com.launchableinc.rocketcar.ExampleInstrumentedTest2
 INSTRUMENTATION_STATUS: current=1
 INSTRUMENTATION_STATUS: id=AndroidJUnitRunner

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class AntTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/ant/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -32,15 +32,4 @@ class AntTest(CliTestCase):
                           'ant', str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
         self.assert_success(result)
 
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        def removeDate(data):
-            for e in data["events"]:
-                del e["created_at"]
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-
-        removeDate(payload)
-        removeDate(expected)
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -18,12 +16,7 @@ class AntTest(CliTestCase):
         result = self.cli('subset', '--target', '10%', '--session',
                           self.session, 'ant', str(self.test_files_dir.joinpath('src').resolve()))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -31,5 +24,4 @@ class AntTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'ant', str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
         self.assert_success(result)
-
         self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -2,7 +2,6 @@ import gzip
 import itertools
 import json
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -12,7 +11,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class BazelTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/bazel/').resolve()
     subset_input = """Starting local Bazel server and connecting to it...
 //src/test/java/com/ninjinkun:mylib_test9
 //src/test/java/com/ninjinkun:mylib_test8

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -49,16 +49,8 @@ Loading: 2 packages loaded
 
         result = self.cli('record', 'tests', 'bazel', str(self.test_files_dir) + "/")
         self.assert_success(result)
-
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-
-        for c in payload['events']:
-            del c['created_at']
-
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -69,16 +61,8 @@ Loading: 2 packages loaded
         result = self.cli('record', 'tests', 'bazel', '--build-event-json', str(
             self.test_files_dir.joinpath("build_event.json")), str(self.test_files_dir) + "/")
         self.assert_success(result)
-
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_with_build_event_json_result.json'))
-
-        for c in payload['events']:
-            del c['created_at']
-
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_record_tests_payload('record_test_with_build_event_json_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -91,17 +75,8 @@ Loading: 2 packages loaded
                           '--build-event-json', str(self.test_files_dir.joinpath("build_event_rest.json")),
                           str(self.test_files_dir) + "/")
         self.assert_success(result)
-
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath(
-            'record_test_with_multiple_build_event_json_result.json'))
-
-        for c in payload['events']:
-            del c['created_at']
-
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_record_tests_payload('record_test_with_multiple_build_event_json_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -121,7 +96,7 @@ Loading: 2 packages loaded
         result = self.cli('record', 'tests', 'bazel', str(self.test_files_dir) + "/")
         self.assert_success(result)
 
-        record_payload = json.loads(gzip.decompress(responses.calls[3].request.body).decode())
+        record_payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
 
         record_test_paths = itertools.chain.from_iterable(e['testPath'] for e in record_payload['events'])
         record_test_path_dict = {t['name']: t for t in record_test_paths}

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -34,12 +34,8 @@ Loading: 2 packages loaded
 
         result = self.cli('subset', '--target', '10%', 'bazel', input=self.subset_input)
         self.assert_success(result)
-
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -91,7 +87,7 @@ Loading: 2 packages loaded
 
         self.assert_success(result)
 
-        subset_payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        subset_payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
 
         result = self.cli('record', 'tests', 'bazel', str(self.test_files_dir) + "/")
         self.assert_success(result)

--- a/tests/test_runners/test_behave.py
+++ b/tests/test_runners/test_behave.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class BehaveTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/behave/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_behave.py
+++ b/tests/test_runners/test_behave.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -18,12 +16,7 @@ class BehaveTest(CliTestCase):
         pipe = "tutorial.feature"
         result = self.cli('subset', '--target', '10%', '--session', self.session, 'behave', input=pipe)
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_behave.py
+++ b/tests/test_runners/test_behave.py
@@ -31,12 +31,4 @@ class BehaveTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session, 'behave',
                           str(self.test_files_dir) + "/reports/report.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        for e in payload["events"]:
-            del e["created_at"]
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -101,10 +101,4 @@ class CTestTest(CliTestCase):
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-
-        for c in payload['events']:
-            del c['created_at']
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -12,8 +11,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class CTestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/ctest/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_multiple_files(self):

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 import sys
 import tempfile
@@ -86,10 +84,7 @@ class CTestTest(CliTestCase):
 
         result = self.cli('subset', '--target', '10%', 'ctest', str(self.test_files_dir.joinpath("ctest_list.json")))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -71,9 +69,7 @@ armeabi-v7a CtsAbiOverrideHostTestCases
 
         output = "--include-filter \"CtsAbiOverrideHostTestCases[instant]\"\n--include-filter \"CtsAbiOverrideHostTestCases\"\n"
         self.assertEqual(output, result.stdout)
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
         result = self.cli(
             "subset",

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses
@@ -9,9 +8,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class CtsTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/cts/').resolve()
-    subset_result_test_path = test_files_dir.joinpath('subset_result.json')
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -12,7 +12,6 @@ from tests.cli_test_case import CliTestCase
 
 class CtsTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/cts/').resolve()
-    result_file_path = test_files_dir.joinpath('record_test_result.json')
     subset_result_test_path = test_files_dir.joinpath('subset_result.json')
 
     @responses.activate
@@ -98,10 +97,4 @@ armeabi-v7a CtsAbiOverrideHostTestCases
         result = self.cli('record', 'tests', '--session', self.session,
                           'cts', str(self.test_files_dir) + "/test_result.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        for e in payload["events"]:
-            e.pop("created_at", "")
-
-        expected = self.load_json_from_file(self.result_file_path)
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_cucumber.py
+++ b/tests/test_runners/test_cucumber.py
@@ -1,6 +1,4 @@
 import glob
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -28,13 +26,7 @@ class CucumberTest(CliTestCase):
         result = self.cli('record', 'tests', '--base', str(self.test_files_dir), 'cucumber', *reports)
 
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -49,14 +41,7 @@ class CucumberTest(CliTestCase):
         result = self.cli('record', 'tests', 'cucumber', "--json", *reports)
 
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_json_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_json_result.json')
 
     def test_create_file_candidate_list(self):
         self.assertCountEqual(_create_file_candidate_list("a-b"), ["a/b", "a-b"])

--- a/tests/test_runners/test_cucumber.py
+++ b/tests/test_runners/test_cucumber.py
@@ -1,6 +1,5 @@
 import glob
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -11,8 +10,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class CucumberTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/cucumber/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test(self):

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class CypressTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/cypress/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_cypress(self):

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -20,11 +20,7 @@ class CypressTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'cypress', str(self.test_files_dir) + "/test-result.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -46,5 +42,5 @@ class CypressTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'cypress', str(self.test_files_dir) + "/empty.xml")
         self.assert_success(result)
-
-        self.assertIn("close", responses.calls[2].request.url, "No record request")
+        for call in responses.calls:
+            self.assertFalse(call.request.url.endswith('/events'), 'there should be no calls to the /events endpoint')

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -30,10 +28,7 @@ class CypressTest(CliTestCase):
         pipe = "cypress/integration/examples/window.spec.js"
         result = self.cli('subset', '--target', '10%', '--session', self.session, 'cypress', input=pipe)
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -230,7 +228,4 @@ class DotnetTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'dotnet', str(self.test_files_dir) + "/test-result.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -10,8 +9,6 @@ from tests.helper import ignore_warnings
 
 
 class DotnetTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/dotnet/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -51,17 +51,7 @@ class GoTestTest(CliTestCase):
         result = self.cli('record', 'tests', '--session',
                           self.session, 'go-test', str(self.test_files_dir.joinpath('reportv1')) + "/")
         self.assert_success(result)
-
-        self.assertIn('events', responses.calls[1].request.url, 'call events API')
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        # Remove timestamp because it depends on the machine clock
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
-
-        self.assertIn('close', responses.calls[3].request.url, 'call close API')
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -73,16 +63,7 @@ class GoTestTest(CliTestCase):
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
-
-        self.assertIn('events', responses.calls[2].request.url, 'call events API')
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
-
-        self.assertIn('close', responses.calls[4].request.url, 'call close API')
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -90,17 +71,7 @@ class GoTestTest(CliTestCase):
         result = self.cli('record', 'tests', '--session',
                           self.session, 'go-test', str(self.test_files_dir.joinpath('reportv2')) + "/")
         self.assert_success(result)
-
-        self.assertIn('events', responses.calls[1].request.url, 'call events API')
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        # Remove timestamp because it depends on the machine clock
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
-
-        self.assertIn('close', responses.calls[3].request.url, 'call close API')
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -11,8 +10,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class GoTestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/go_test/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_with_session(self):

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -22,10 +20,7 @@ class GoTestTest(CliTestCase):
                "ok      github.com/launchableinc/rocket-car-gotest      0.268s"
         result = self.cli('subset', '--target', '10%', '--session', self.session, 'go-test', input=pipe)
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -40,10 +35,7 @@ class GoTestTest(CliTestCase):
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class GoogleTestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/googletest/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -34,11 +34,7 @@ class GoogleTestTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'googletest', str(self.test_files_dir) + "/")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -47,11 +43,7 @@ class GoogleTestTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'googletest', str(self.test_files_dir) + "/fail/")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('fail/record_test_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('fail/record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -23,10 +21,7 @@ class GoogleTestTest(CliTestCase):
         """
         result = self.cli('subset', '--target', '10%', '--session', self.session, 'googletest', input=pipe)
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -1,7 +1,6 @@
 import gzip
 import os
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -13,8 +12,6 @@ from tests.helper import ignore_warnings
 
 
 class GradleTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/gradle/').resolve()
-
     @ignore_warnings
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -260,7 +260,7 @@ class GradleTest(CliTestCase):
                 0,
                 "Exit code is not 0. The output is\n" + result.output + "\n" + result.stderr)
 
-        body = gzip.decompress(responses.calls[1].request.body).decode('utf8')
+        body = gzip.decompress(self.find_request('/subset').request.body).decode('utf8')
         self.assertNotIn("java.com.launchableinc.rocket_car_gradle.App2Test", body)
 
     @responses.activate

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -1,5 +1,4 @@
 import gzip
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -15,7 +14,6 @@ from tests.helper import ignore_warnings
 
 class GradleTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/gradle/').resolve()
-    result_file_path = test_files_dir.joinpath('recursion/expected.json')
 
     @ignore_warnings
     @responses.activate
@@ -411,8 +409,4 @@ class GradleTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'gradle', str(self.test_files_dir) + "/**/reports")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        expected = self.load_json_from_file(self.result_file_path)
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('recursion/expected.json')

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -11,7 +11,6 @@ from tests.helper import ignore_warnings
 
 
 class JestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/jest/').resolve()
     # This string generate absolute paths because the CLI requires exsisting
     # directory path
     subset_input = """

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -40,12 +38,8 @@ class JestTest(CliTestCase):
 
         result = self.cli('subset', '--target', '10%', '--base',
                           os.getcwd(), 'jest', input=self.subset_input)
-        print(result.output)
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-        self.assert_json_orderless_equal(payload, expected)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -87,7 +87,4 @@ class JestTest(CliTestCase):
 
         result = self.cli('record', 'tests', 'jest', str(self.test_files_dir.joinpath("junit.xml")))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -152,15 +152,7 @@ class MavenTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'maven', str(self.test_files_dir) + "/**/reports")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        for e in payload["events"]:
-            del e["created_at"]
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result.json")
 
     def test_glob(self):
         for x in [

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -11,8 +10,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class MavenTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/maven/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -21,12 +19,7 @@ class MavenTest(CliTestCase):
         result = self.cli('subset', '--target', '10%', '--session',
                           self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -67,12 +60,7 @@ class MavenTest(CliTestCase):
                           "--test-compile-created-file",
                           str(self.test_files_dir.joinpath("createdFile_2.lst")))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_from_file_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_from_file_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -80,12 +68,7 @@ class MavenTest(CliTestCase):
         result = self.cli('subset', '--time', '1h30m', '--session',
                           self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_by_absolute_time_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_by_absolute_time_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -93,12 +76,7 @@ class MavenTest(CliTestCase):
         result = self.cli('subset', '--confidence', '90%', '--session',
                           self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_by_confidence_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_by_confidence_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -13,8 +13,6 @@ from tests.helper import ignore_warnings
 
 
 class MinitestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/minitest/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_minitest(self):

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -82,12 +80,7 @@ class NUnitTest(CliTestCase):
         result = self.cli('subset', '--target', '10%', '--session', self.session, 'nunit',
                           str(self.test_files_dir) + "/list.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
         output = 'ParameterizedTests.MyTests.DivideTest(12,3)\ncalc.Tests1.Test1'
         self.assertIn(output, result.output)

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -165,12 +165,7 @@ class NUnitTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'nunit', str(self.test_files_dir) + "/output-linux.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result-linux.json"))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result-linux.json")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -178,12 +173,7 @@ class NUnitTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'nunit', str(self.test_files_dir) + "/output-windows.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result-windows.json"))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result-windows.json")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -191,11 +181,6 @@ class NUnitTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'nunit', str(self.test_files_dir) + "/nunit-reporter-bug-with-nested-type.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
         # turns out we collapse all TestFixtures to TestSuitest so the golden file has TestSuite=Outer+Inner,
         # not TestFixture=Outer+Inner
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("nunit-reporter-bug-with-nested-type.json"))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("nunit-reporter-bug-with-nested-type.json")

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -11,8 +10,6 @@ from tests.helper import ignore_warnings
 
 
 class NUnitTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/nunit/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -11,7 +9,6 @@ from tests.cli_test_case import CliTestCase
 
 class PlaywrightTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/playwright/').resolve()
-    result_file_path = test_files_dir.joinpath('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ,
@@ -21,7 +18,4 @@ class PlaywrightTest(CliTestCase):
                           'playwright', str(self.test_files_dir.joinpath("report.xml")))
 
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.result_file_path)
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class PlaywrightTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/playwright/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ,
                      {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_prove.py
+++ b/tests/test_runners/test_prove.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import TestCase, mock
@@ -44,13 +42,4 @@ class ProveTestTest(CliTestCase):
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
-
-        self.assertIn('events', responses.calls[2].request.url, 'call events API')
-        payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
-        for c in payload['events']:
-            del c['created_at']
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('record_test_result.json'))
-        self.assert_json_orderless_equal(expected, payload)
-
-        self.assertIn('close', responses.calls[4].request.url, 'call close API')
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_prove.py
+++ b/tests/test_runners/test_prove.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import TestCase, mock
 
 import responses  # type: ignore
@@ -30,8 +29,6 @@ class remove_leading_number_and_dash_Test(TestCase):
 
 
 class ProveTestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/prove/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_tests(self):

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -33,7 +33,7 @@ tests/fooo/filenameonly_test.py
                           self.session, 'pytest', input=self.subset_input)
         self.assert_success(result)
 
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
+        payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
         expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
         for test_path in expected["testPaths"]:
             test_path[0]['name'] = os.path.normpath(test_path[0]['name'])

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -13,7 +13,6 @@ from tests.cli_test_case import CliTestCase
 class PytestTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/pytest/').resolve()
     result_file_path = test_files_dir.joinpath('record_test_result.json')
-    json_option_result_file_path = test_files_dir.joinpath('record_test_result_json.json')
     subset_input = '''tests/funcs3_test.py::test_func4
 tests/funcs3_test.py::test_func5
 tests/test_funcs1.py::test_func1
@@ -47,10 +46,7 @@ tests/fooo/filenameonly_test.py
                           'pytest', str(self.test_files_dir.joinpath("report.xml")))
 
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.result_file_path)
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
@@ -59,16 +55,7 @@ tests/fooo/filenameonly_test.py
                           'pytest', '--json', str(self.test_files_dir.joinpath("report.json")))
 
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.json_option_result_file_path)
-
-        for e in payload["events"]:
-            e.pop("created_at", "")
-        for e in expected["events"]:
-            e.pop("created_at", "")
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result_json.json')
 
     def setUp(self):
         super().setUp()

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -1,7 +1,6 @@
 import gzip
 import json
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -11,8 +10,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class PytestTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/pytest/').resolve()
-    result_file_path = test_files_dir.joinpath('record_test_result.json')
     subset_input = '''tests/funcs3_test.py::test_func4
 tests/funcs3_test.py::test_func5
 tests/test_funcs1.py::test_func1

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -217,7 +217,8 @@ class RawTest(CliTestCase):
             self.assert_success(result)
 
             # Check request body
-            payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
+            payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
+            del payload['metadata']
             self.assert_json_orderless_equal(payload, {
                 'events': [
                     {
@@ -318,7 +319,8 @@ class RawTest(CliTestCase):
                     "Exit code is not 0. The output is\n" + result.output + "\n" + result.stderr)
 
             # Check request body
-            payload = json.loads(gzip.decompress(responses.calls[2].request.body).decode())
+            payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
+            del payload['metadata']
             self.assert_json_orderless_equal(payload, {
                 'events': [
                     {

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -54,7 +54,7 @@ class RawTest(CliTestCase):
             self.assert_success(result)
 
             # Check request body
-            payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+            payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
             self.assert_json_orderless_equal(payload, {
                 'testPaths': [
                     [{'type': 'testcase', 'name': 'FooTest.Bar'}],
@@ -114,7 +114,7 @@ class RawTest(CliTestCase):
         self.assert_success(result)
 
         # Check request body
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
         self.assert_json_orderless_equal(payload, {
             'testPaths': [],
             'testRunner': 'raw',

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -33,12 +33,7 @@ class RobotTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'robot', str(self.test_files_dir) + "/output.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        for e in payload["events"]:
-            del e["created_at"]
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_result.json"))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_result.json")
 
     # for #637
     @ responses.activate
@@ -48,13 +43,4 @@ class RobotTest(CliTestCase):
         result = self.cli('record', 'tests', '--session', self.session,
                           'robot', str(self.test_files_dir) + "/single-output.xml")
         self.assert_success(result)
-
-        print(result.output)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-
-        for e in payload["events"]:
-            del e["created_at"]
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath("record_test_executed_only_one_file_result.json"))
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload("record_test_executed_only_one_file_result.json")

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,9 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class RobotTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath(
-        '../data/robot/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset(self):

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -19,12 +17,7 @@ class RobotTest(CliTestCase):
         result = self.cli('subset', '--target', '10%', '--session',
                           self.session, 'robot', str(self.test_files_dir) + "/dryrun.xml")
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[0].request.body).decode())
-
-        expected = self.load_json_from_file(self.test_files_dir.joinpath('subset_result.json'))
-
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_subset_payload('subset_result.json')
 
     @ responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})

--- a/tests/test_runners/test_rspec.py
+++ b/tests/test_runners/test_rspec.py
@@ -1,5 +1,3 @@
-import gzip
-import json
 import os
 from pathlib import Path
 from unittest import mock
@@ -11,7 +9,6 @@ from tests.cli_test_case import CliTestCase
 
 class RspecTest(CliTestCase):
     test_files_dir = Path(__file__).parent.joinpath('../data/rspec/').resolve()
-    result_file_path = test_files_dir.joinpath('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ,
@@ -19,9 +16,5 @@ class RspecTest(CliTestCase):
     def test_record_test_rspec(self):
         result = self.cli('record', 'tests', '--session', self.session,
                           'rspec', str(self.test_files_dir.joinpath("rspec.xml")))
-
         self.assert_success(result)
-
-        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
-        expected = self.load_json_from_file(self.result_file_path)
-        self.assert_json_orderless_equal(expected, payload)
+        self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_rspec.py
+++ b/tests/test_runners/test_rspec.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import mock
 
 import responses  # type: ignore
@@ -8,8 +7,6 @@ from tests.cli_test_case import CliTestCase
 
 
 class RspecTest(CliTestCase):
-    test_files_dir = Path(__file__).parent.joinpath('../data/rspec/').resolve()
-
     @responses.activate
     @mock.patch.dict(os.environ,
                      {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})


### PR DESCRIPTION
Eliminated the notion of closing a test session, which at this point was thoroughly meaningless anyway.

The one last remaining value of closing a test session is the metadata getting sent to the server. We move that data into the test data upload.

DO NOT MERGE yet. This change is coordinated with the corresponding server side change.