### PR TITLE
Use a convenience method to assert exit code

### DIFF
--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -202,7 +202,10 @@ class CliTestCase(unittest.TestCase):
         return CliRunner(mix_stderr=mix_stderr).invoke(main, args, catch_exceptions=False, **kwargs)
 
     def assert_success(self, result: click.testing.Result):
-        self.assertEqual(result.exit_code, 0, result.stdout)
+        self.assert_exit_code(result, 0)
+
+    def assert_exit_code(self, result: click.testing.Result, expected: int):
+        self.assertEqual(result.exit_code, expected, result.stdout)
 
     def find_request(self, url_suffix: str, n: int = 0):
         '''Find the first (or n-th, if specified) request that matches the given suffix'''

--- a/tests/commands/record/test_attachment.py
+++ b/tests/commands/record/test_attachment.py
@@ -40,7 +40,7 @@ class AttachmentTest(CliTestCase):
 
         result = self.cli("record", "attachment", "--session", self.session, attachment.name)
 
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
         self.assertEqual(TEST_CONTENT, body)
 
         os.unlink(attachment.name)

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -136,7 +136,7 @@ class BuildTest(CliTestCase):
     def test_commit_option_and_build_option(self):
         # case only --commit option
         result = self.cli("record", "build", "--no-commit-collection", "--commit", "A=abc12", "--name", self.build_name)
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
@@ -164,7 +164,7 @@ class BuildTest(CliTestCase):
             "A=feature-xxx",
             "--name",
             self.build_name)
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
@@ -225,7 +225,7 @@ class BuildTest(CliTestCase):
             "A=feature-xxx",
             "--name",
             self.build_name)
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
@@ -249,7 +249,7 @@ class BuildTest(CliTestCase):
 
     def test_build_name_validation(self):
         result = self.cli("record", "build", "--no-commit-collection", "--name", "foo/hoge")
-        self.assertEqual(result.exit_code, 1)
+        self.assert_exit_code(result, 1)
 
         result = self.cli("record", "build", "--no-commit-collection", "--name", "foo%2Fhoge")
-        self.assertEqual(result.exit_code, 1)
+        self.assert_exit_code(result, 1)

--- a/tests/commands/record/test_commit.py
+++ b/tests/commands/record/test_commit.py
@@ -38,7 +38,7 @@ class CommitTest(CliTestCase):
 
         with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
             result = self.cli("record", "commit")
-            self.assertEqual(result.exit_code, 0, "exit normally")
+            self.assert_success(result)
 
         server.shutdown()
         thread.join()

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -24,7 +24,7 @@ class SessionTest(CliTestCase):
     }, clear=True)
     def test_run_session_without_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name)
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
@@ -41,7 +41,7 @@ class SessionTest(CliTestCase):
     def test_run_session_with_flavor(self):
         result = self.cli("record", "session", "--build", self.build_name,
                           "--flavor", "key=value", "--flavor", "k", "v", "--flavor", "k e y = v a l u e")
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal({
@@ -58,7 +58,7 @@ class SessionTest(CliTestCase):
 
         with self.assertRaises(ValueError):
             result = self.cli("record", "session", "--build", self.build_name, "--flavor", "only-key")
-            self.assertEqual(result.exit_code, 1)
+            self.assert_exit_code(result, 1)
             self.assertTrue(
                 "Expected key-value like --option kye=value or --option key value." in result.output)
 
@@ -69,7 +69,7 @@ class SessionTest(CliTestCase):
     }, clear=True)
     def test_run_session_with_observation(self):
         result = self.cli("record", "session", "--build", self.build_name, "--observation")
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
 
@@ -87,7 +87,7 @@ class SessionTest(CliTestCase):
     def test_run_session_with_session_name(self):
         # session name is already exist
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
-        self.assertEqual(result.exit_code, 2)
+        self.assert_exit_code(result, 2)
 
         responses.replace(
             responses.GET,
@@ -102,10 +102,10 @@ class SessionTest(CliTestCase):
         )
         # invalid session name
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", "invalid/name")
-        self.assertEqual(result.exit_code, 2)
+        self.assert_exit_code(result, 2)
 
         result = self.cli("record", "session", "--build", self.build_name, "--session-name", self.session_name)
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[3].request.body.decode())
         self.assert_json_orderless_equal(
@@ -122,7 +122,7 @@ class SessionTest(CliTestCase):
     def test_run_session_with_lineage(self):
         result = self.cli("record", "session", "--build", self.build_name,
                           "--lineage", "example-lineage")
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal({

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -28,9 +28,8 @@ class TestsTest(CliTestCase):
                           self.session, '--group', 'hoge', 'maven', str(
                               self.report_files_dir) + "**/reports/")
 
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
         request = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
-
         self.assertCountEqual(request.get("group", []), "hoge")
 
     @responses.activate
@@ -82,7 +81,7 @@ class TestsTest(CliTestCase):
             status=200)
 
         result = self.cli('record', 'tests', '--no-build', 'maven', str(self.report_files_dir) + "**/reports/")
-        self.assertEqual(result.exit_code, 0)
+        self.assert_success(result)
 
     def test_parse_launchable_timeformat(self):
         t1 = "2021-04-01T09:35:47.934+00:00"  # 1617269747.934

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -193,7 +193,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
 
         result = self.cli("record", "session", "--build", build)
-        self.assertEqual(result.exit_code, 1)
+        self.assert_exit_code(result, 1)
         self.assert_tracking_count(tracking=tracking, count=1)
 
         responses.replace(

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -255,7 +255,7 @@ class SubsetTest(CliTestCase):
     def test_subset_with_get_tests_from_previous_full_runs(self):
         # check error when input candidates are empty without --get-tests-from-previous-sessions option
         result = self.cli("subset", "--target", "30%", "--session", self.session, "file")
-        self.assertEqual(result.exit_code, 1)
+        self.assert_exit_code(result, 1)
         self.assertTrue("Please set subset candidates or use `--get-tests-from-previous-sessions` option" in result.stdout)
 
         responses.replace(

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -59,7 +59,7 @@ class DotnetTest(CliTestCase):
 
         # dotnet profiles requires Zero Input Subsetting
         result = self.cli('subset', '--target', '25%', '--session', self.session, 'dotnet')
-        self.assertEqual(result.exit_code, 1)
+        self.assert_exit_code(result, 1)
 
         result = self.cli(
             'subset',


### PR DESCRIPTION
Promote the use of more convenient assertion method with  richer error diagnostics