### PR TITLE
Send createdAt as a camel case

### DIFF
--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -231,7 +231,7 @@ class CliTestCase(unittest.TestCase):
 
         # Remove timestamp because it depends on the machine clock
         for c in payload['events']:
-            del c['created_at']
+            del c['createdAt']
         # metadata includes server dependent data
         del payload['metadata']
 

--- a/tests/data/minitest/record_test_result_chunk1.json
+++ b/tests/data/minitest/record_test_result_chunk1.json
@@ -13,7 +13,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -29,7 +29,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -45,7 +45,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -61,7 +61,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -77,7 +77,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     }
   ],

--- a/tests/data/minitest/record_test_result_chunk2.json
+++ b/tests/data/minitest/record_test_result_chunk2.json
@@ -13,7 +13,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -29,7 +29,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     },
     {
@@ -42,7 +42,7 @@
       "status": 1,
       "stdout": "",
       "stderr": "",
-      "created_at": "2020-12-23T13:10:01+09:00",
+      "createdAt": "2020-12-23T13:10:01+09:00",
       "data": null
     }
   ],

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -4,6 +4,9 @@ import os
 import tempfile
 from unittest import mock
 
+import dateutil.parser
+from dateutil.tz import tzlocal
+
 import responses  # type: ignore
 
 from launchable.utils.http_client import get_base_url
@@ -138,6 +141,10 @@ class RawTest(CliTestCase):
             test_path_file = os.path.join(tempdir, 'tests.json')
             test_path_file2 = os.path.join(tempdir, 'tests_2.json')
             test_path_file3 = os.path.join(tempdir, 'tests_3.json')
+            a_timestamp = dateutil.parser.parse("2021-10-05T12:34:00")
+            aa_timestamp = dateutil.parser.parse("2021-10-05T12:34:56")
+            b_timestamp = dateutil.parser.parse("2021-10-05T12:35:30")
+            test_a_timestamp = dateutil.parser.parse("2021-10-05T12:36:10")
             with open(test_path_file, 'w') as f:
                 f.write('\n'.join([
                     '{',
@@ -148,7 +155,7 @@ class RawTest(CliTestCase):
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:00"',
+                    f'       "createdAt": "{a_timestamp}"',
                     '     }',
                     '     ,{',
                     '       "testPath": "file=aa.py#class=classAA",',
@@ -156,7 +163,7 @@ class RawTest(CliTestCase):
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:56",',
+                    f'       "createdAt": "{aa_timestamp}",',
                     '       "data": {',
                     '         "lineNumber": 5',
                     '       }',
@@ -175,7 +182,7 @@ class RawTest(CliTestCase):
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:56"',
+                    f'       "createdAt": "{b_timestamp}"',
                     '     }',
                     '  ]',
                     '}',
@@ -204,7 +211,7 @@ class RawTest(CliTestCase):
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    '       "createdAt": "2021-10-05T12:34:56"',
+                    f'       "createdAt": "{test_a_timestamp}"',
                     '     }',
                     '  ]',
                     '}',
@@ -230,7 +237,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:00',
+                        'createdAt': a_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
@@ -243,7 +250,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:56',
+                        'createdAt': b_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
@@ -257,7 +264,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:56',
+                        'createdAt': test_a_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
@@ -270,7 +277,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'created_at': '2021-10-05T12:34:56',
+                        'createdAt': aa_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': {"lineNumber": 5},
                         'type': 'case',
                     },
@@ -286,22 +293,24 @@ class RawTest(CliTestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             test_path_file = os.path.join(tempdir, 'tests.xml')
             test_path_file2 = os.path.join(tempdir, 'tests_2.xml')
+            timestamp1 = dateutil.parser.parse("2021-10-05T12:34:00")
             with open(test_path_file, 'w') as f:
                 f.write('\n'.join([
                     '<?xml version="1.0" encoding="UTF-8"?>',
                     '<testsuites name="test_suite_name1" tests="1" failures="0" errors="0" time="10.123">',
-                    '  <testsuite name="test_suite_name2" errors="0" failures="0" skipped="0" timestamp="2021-10-05T12:34:00" time="10.123" tests="1">',   # noqa: E501
+                    f'  <testsuite name="test_suite_name2" errors="0" failures="0" skipped="0" timestamp="{timestamp1}" time="10.123" tests="1">',   # noqa: E501
                     '    <testcase classname="test_class_name" name="test_case_name" time="10.123">',
                     '    </testcase>',
                     '  </testsuite>',
                     '</testsuites>',
                 ]) + '\n')
 
+            timestamp2 = dateutil.parser.parse("2021-10-05T12:34:56")
             with open(test_path_file2, 'w') as f2:
                 f2.write('\n'.join([
                     '<?xml version="1.0" encoding="UTF-8"?>',
                     '<testsuites name="test_suite_name3" tests="1" failures="0" errors="0" time="12.345">',
-                    '  <testsuite name="test_suite_name4" errors="0" failures="0" skipped="0" timestamp="2021-10-05T12:34:56" time="12.345" tests="1">',   # noqa: E501
+                    f'  <testsuite name="test_suite_name4" errors="0" failures="0" skipped="0" timestamp="{timestamp2}" time="12.345" tests="1">',   # noqa: E501
                     '    <testcase classname="test_class_name2" name="test_case_name2" time="12.345">',
                     '    </testcase>',
                     '  </testsuite>',
@@ -332,7 +341,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': '',
                         'stderr': '',
-                        'created_at': '2021-10-05T12:34:00',
+                        'createdAt': timestamp1.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
@@ -345,7 +354,7 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': '',
                         'stderr': '',
-                        'created_at': '2021-10-05T12:34:56',
+                        'createdAt': timestamp2.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -141,29 +141,30 @@ class RawTest(CliTestCase):
             test_path_file = os.path.join(tempdir, 'tests.json')
             test_path_file2 = os.path.join(tempdir, 'tests_2.json')
             test_path_file3 = os.path.join(tempdir, 'tests_3.json')
-            a_timestamp = dateutil.parser.parse("2021-10-05T12:34:00")
-            aa_timestamp = dateutil.parser.parse("2021-10-05T12:34:56")
-            b_timestamp = dateutil.parser.parse("2021-10-05T12:35:30")
-            test_a_timestamp = dateutil.parser.parse("2021-10-05T12:36:10")
+            # These timestamp variables are defined for testing timezone.
+            test_ruby_timestamp = dateutil.parser.parse("2021-10-05T12:34:00")
+            test_python_timestamp = dateutil.parser.parse("2021-10-05T12:34:56")
+            test_go_timestamp = dateutil.parser.parse("2021-10-05T12:35:30")
+            test_java_timestamp = dateutil.parser.parse("2021-10-05T12:36:10")
             with open(test_path_file, 'w') as f:
                 f.write('\n'.join([
                     '{',
                     '  "testCases": [',
                     '     {',
-                    '       "testPath": "file=a.py#class=classA",',
+                    '       "testPath": "file=test_ruby.py#class=classA",',
                     '       "duration": 42,',
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    f'       "createdAt": "{a_timestamp}"',
+                    f'       "createdAt": "{test_ruby_timestamp}"',
                     '     }',
                     '     ,{',
-                    '       "testPath": "file=aa.py#class=classAA",',
+                    '       "testPath": "file=test_python.py#class=classAA",',
                     '       "duration": 12,',
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    f'       "createdAt": "{aa_timestamp}",',
+                    f'       "createdAt": "{test_python_timestamp}",',
                     '       "data": {',
                     '         "lineNumber": 5',
                     '       }',
@@ -177,12 +178,12 @@ class RawTest(CliTestCase):
                     '{',
                     '  "testCases": [',
                     '     {',
-                    '       "testPath": "file=b.py#class=classB",',
+                    '       "testPath": "file=test_go.py#class=classB",',
                     '       "duration": 32,',
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    f'       "createdAt": "{b_timestamp}"',
+                    f'       "createdAt": "{test_go_timestamp}"',
                     '     }',
                     '  ]',
                     '}',
@@ -196,7 +197,7 @@ class RawTest(CliTestCase):
                     '       "testPathComponents": [',
                     '         {',
                     '           "type": "file",',
-                    '           "name": "login/test_a.py"',
+                    '           "name": "test_java.py"',
                     '         },',
                     '         {',
                     '           "type": "class",',
@@ -211,7 +212,7 @@ class RawTest(CliTestCase):
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',
-                    f'       "createdAt": "{test_a_timestamp}"',
+                    f'       "createdAt": "{test_java_timestamp}"',
                     '     }',
                     '  ]',
                     '}',
@@ -230,33 +231,33 @@ class RawTest(CliTestCase):
                 'events': [
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'a.py'},
+                            {'type': 'file', 'name': 'test_ruby.py'},
                             {'type': 'class', 'name': 'classA'},
                         ],
                         'duration': 42,
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'createdAt': a_timestamp.replace(tzinfo=tzlocal()).isoformat(),
+                        'createdAt': test_ruby_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'b.py'},
+                            {'type': 'file', 'name': 'test_go.py'},
                             {'type': 'class', 'name': 'classB'},
                         ],
                         'duration': 32,
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'createdAt': b_timestamp.replace(tzinfo=tzlocal()).isoformat(),
+                        'createdAt': test_go_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'login/test_a.py'},
+                            {'type': 'file', 'name': 'test_java.py'},
                             {'type': 'class', 'name': 'class1'},
                             {'type': 'testcase', 'name': 'testcase#899'},
                         ],
@@ -264,20 +265,20 @@ class RawTest(CliTestCase):
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'createdAt': test_a_timestamp.replace(tzinfo=tzlocal()).isoformat(),
+                        'createdAt': test_java_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': None,
                         'type': 'case',
                     },
                     {
                         'testPath': [
-                            {'type': 'file', 'name': 'aa.py'},
+                            {'type': 'file', 'name': 'test_python.py'},
                             {'type': 'class', 'name': 'classAA'},
                         ],
                         'duration': 12,
                         'status': 1,
                         'stdout': 'This is stdout',
                         'stderr': 'This is stderr',
-                        'createdAt': aa_timestamp.replace(tzinfo=tzlocal()).isoformat(),
+                        'createdAt': test_python_timestamp.replace(tzinfo=tzlocal()).isoformat(),
                         'data': {"lineNumber": 5},
                         'type': 'case',
                     },

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -294,7 +294,9 @@ class RawTest(CliTestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             test_path_file = os.path.join(tempdir, 'tests.xml')
             test_path_file2 = os.path.join(tempdir, 'tests_2.xml')
+            # These timestamp variables are defined for testing timezone.
             timestamp1 = dateutil.parser.parse("2021-10-05T12:34:00")
+            timestamp2 = dateutil.parser.parse("2021-10-05T12:34:56")
             with open(test_path_file, 'w') as f:
                 f.write('\n'.join([
                     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -306,7 +308,6 @@ class RawTest(CliTestCase):
                     '</testsuites>',
                 ]) + '\n')
 
-            timestamp2 = dateutil.parser.parse("2021-10-05T12:34:56")
             with open(test_path_file2, 'w') as f2:
                 f2.write('\n'.join([
                     '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
Launchable accepts response as a camel case, not snake case, but CLI sends createdAt as a snake case. This PR addresses the problem.