### PR TITLE
minitest: Fetch name attribute as a classname

### DIFF
--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -105,7 +105,6 @@ class CommonRecordTestImpls:
         @click.argument('source_roots', required=True, nargs=-1)
         def record_tests(client, source_roots):
             CommonRecordTestImpls.load_report_files(client=client, source_roots=source_roots, file_mask=file_mask)
-            client.run()
 
         return wrap(record_tests, record_tests_cmd, self.cmdname)
 
@@ -133,6 +132,8 @@ class CommonRecordTestImpls:
                 click.echo("No matches found: {}".format(root), err=True)
                 # intentionally exiting with zero
                 return
+
+        client.run()
 
 
 class CommonSplitSubsetImpls:

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -104,13 +104,13 @@ class CommonRecordTestImpls:
 
         @click.argument('source_roots', required=True, nargs=-1)
         def record_tests(client, source_roots):
-            CommonRecordTestImpls.find_files(client=client, source_roots=source_roots, file_mask=file_mask)
+            CommonRecordTestImpls.load_report_files(client=client, source_roots=source_roots, file_mask=file_mask)
             client.run()
 
         return wrap(record_tests, record_tests_cmd, self.cmdname)
 
     @classmethod
-    def find_files(cls, client, source_roots, file_mask="*.xml"):
+    def load_report_files(cls, client, source_roots, file_mask="*.xml"):
         # client type: RecordTests in def launchable.commands.record.tests.tests
         # Accept both file names and GLOB patterns
         # Simple globs like '*.xml' can be dealt with by shell, but

--- a/launchable/test_runners/launchable.py
+++ b/launchable/test_runners/launchable.py
@@ -104,32 +104,35 @@ class CommonRecordTestImpls:
 
         @click.argument('source_roots', required=True, nargs=-1)
         def record_tests(client, source_roots):
-            # client type: RecordTests in def launchable.commands.record.tests.tests
-            # Accept both file names and GLOB patterns
-            # Simple globs like '*.xml' can be dealt with by shell, but
-            # not all shells consistently deal with advanced GLOBS like '**'
-            # so it's worth supporting it here.
-            for root in source_roots:
-                match = False
-                for t in glob.iglob(root, recursive=True):
-                    match = True
-                    if os.path.isdir(t):
-                        client.scan(t, file_mask)
-                    else:
-                        client.report(t)
-
-                if not match:
-                    # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
-                    # raise it as an error. Note this can happen for reasons other than a configuration error.
-                    # For example, if a build catastrophically failed and no
-                    # tests got run.
-                    click.echo("No matches found: {}".format(root), err=True)
-                    # intentionally exiting with zero
-                    return
-
+            CommonRecordTestImpls.find_files(client=client, source_roots=source_roots, file_mask=file_mask)
             client.run()
 
         return wrap(record_tests, record_tests_cmd, self.cmdname)
+
+    @classmethod
+    def find_files(cls, client, source_roots, file_mask="*.xml"):
+        # client type: RecordTests in def launchable.commands.record.tests.tests
+        # Accept both file names and GLOB patterns
+        # Simple globs like '*.xml' can be dealt with by shell, but
+        # not all shells consistently deal with advanced GLOBS like '**'
+        # so it's worth supporting it here.
+        for root in source_roots:
+            match = False
+            for t in glob.iglob(root, recursive=True):
+                match = True
+                if os.path.isdir(t):
+                    client.scan(t, file_mask)
+                else:
+                    client.report(t)
+
+            if not match:
+                # By following the shell convention, if the file doesn't exist or GLOB doesn't match anything,
+                # raise it as an error. Note this can happen for reasons other than a configuration error.
+                # For example, if a build catastrophically failed and no
+                # tests got run.
+                click.echo("No matches found: {}".format(root), err=True)
+                # intentionally exiting with zero
+                return
 
 
 class CommonSplitSubsetImpls:

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -8,6 +8,8 @@ import click
 subset = launchable.CommonSubsetImpls(__name__).scan_files('*_test.rb')
 split_subset = launchable.CommonSplitSubsetImpls(__name__).split_subset()
 
+TEST_PATH_ORDER = {"file": 1, "class": 2, "testcase": 3}
+
 
 @click.argument('reports', required=True, nargs=-1)
 @launchable.record.tests
@@ -23,6 +25,7 @@ def record_tests(client, reports):
             classname = suite._elem.attrib.get("name")
             if classname:
                 test_path.append({"type": "class", "name": classname})
+                test_path = sorted(test_path, key=lambda x: TEST_PATH_ORDER[x["type"]])
         return test_path
 
     client.path_builder = path_builder

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -27,5 +27,5 @@ def record_tests(client, reports):
 
     client.path_builder = path_builder
 
-    launchable.CommonRecordTestImpls.find_files(client=client, source_roots=reports)
+    launchable.CommonRecordTestImpls.load_report_files(client=client, source_roots=reports)
     client.run()

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -31,4 +31,3 @@ def record_tests(client, reports):
     client.path_builder = path_builder
 
     launchable.CommonRecordTestImpls.load_report_files(client=client, source_roots=reports)
-    client.run()

--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -1,5 +1,31 @@
+import glob
+import os
 from . import launchable
+from junitparser import TestCase, TestSuite  # type: ignore
+from ..testpath import TestPath
+import click
 
 subset = launchable.CommonSubsetImpls(__name__).scan_files('*_test.rb')
 split_subset = launchable.CommonSplitSubsetImpls(__name__).split_subset()
-record_tests = launchable.CommonRecordTestImpls(__name__).report_files()
+
+
+@click.argument('reports', required=True, nargs=-1)
+@launchable.record.tests
+def record_tests(client, reports):
+    default_path_builder = client.path_builder
+
+    def path_builder(case: TestCase, suite: TestSuite, report_file: str) -> TestPath:
+        test_path = default_path_builder(case, suite, report_file)
+        if not any(item.get("type") == "class" for item in test_path):
+            # mintiest-ci sets a class name in name attribute in testsuite tag.
+            # https://github.com/CircleCI-Public/minitest-ci/blob/v3.4.0/lib/minitest/ci_plugin.rb#L86-L87
+            # https://github.com/CircleCI-Public/minitest-ci/blob/v3.4.0/lib/minitest/ci_plugin.rb#L132
+            classname = suite._elem.attrib.get("name")
+            if classname:
+                test_path.append({"type": "class", "name": classname})
+        return test_path
+
+    client.path_builder = path_builder
+
+    launchable.CommonRecordTestImpls.find_files(client=client, source_roots=reports)
+    client.run()

--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -155,7 +155,7 @@ split_subset = launchable.CommonSplitSubsetImpls(__name__, formatter=lambda x: '
 @launchable.record.tests
 def record_tests(client, report_xml):
     client.parse_func = nunit_parse_func
-    launchable.CommonRecordTestImpls.find_files(client=client, source_roots=report_xml)
+    launchable.CommonRecordTestImpls.load_report_files(client=client, source_roots=report_xml)
     client.run()
 
 

--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -156,7 +156,6 @@ split_subset = launchable.CommonSplitSubsetImpls(__name__, formatter=lambda x: '
 def record_tests(client, report_xml):
     client.parse_func = nunit_parse_func
     launchable.CommonRecordTestImpls.load_report_files(client=client, source_roots=report_xml)
-    client.run()
 
 
 """

--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -154,19 +154,8 @@ split_subset = launchable.CommonSplitSubsetImpls(__name__, formatter=lambda x: '
 @click.argument('report_xml', required=True, nargs=-1)
 @launchable.record.tests
 def record_tests(client, report_xml):
-    # TODO: copied from ctest -- promote this pattern
-    for root in report_xml:
-        match = False
-        for t in glob.iglob(root, recursive=True):
-            match = True
-            if os.path.isdir(t):
-                client.scan(t, "*.xml")
-            else:
-                client.report(t)
-        if not match:
-            click.echo("No matches found: {}".format(root), err=True)
-
     client.parse_func = nunit_parse_func
+    launchable.CommonRecordTestImpls.find_files(client=client, source_roots=report_xml)
     client.run()
 
 

--- a/tests/data/minitest/record_test_result.json
+++ b/tests/data/minitest/record_test_result.json
@@ -7,6 +7,10 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
+        },
+        {
+          "type": "class",
+          "name": "UserCopyTest"
         }
       ],
       "duration": 1.602778,
@@ -22,6 +26,10 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
+        },
+        {
+          "type": "class",
+          "name": "UserCopyTest"
         }
       ],
       "duration": 1.606243,
@@ -37,6 +45,10 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
+        },
+        {
+          "type": "class",
+          "name": "Admin::UserTest"
         }
       ],
       "duration": 1.611738,
@@ -52,6 +64,10 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
+        },
+        {
+          "type": "class",
+          "name": "Admin::UserTest"
         }
       ],
       "duration": 1.607029,
@@ -67,6 +83,10 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name_2"
+        },
+        {
+          "type": "class",
+          "name": "UserTest"
         }
       ],
       "duration": 1.614255,
@@ -82,6 +102,10 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
+        },
+        {
+          "type": "class",
+          "name": "UserControllerTest"
         }
       ],
       "duration": 1.617726,
@@ -97,7 +121,8 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
-        }
+        },
+        { "type": "class", "name": "UserControllerTest" }
       ],
       "duration": 1.611985,
       "status": 1,
@@ -109,7 +134,8 @@
       "type": "case",
       "testPath": [
         { "type": "file", "name": "test/models/admin/user_test.rb" },
-        { "type": "testcase", "name": "test_child" }
+        { "type": "testcase", "name": "test_child" },
+        { "type": "class", "name": "Admin::UserTest::ChildlenTest" }
       ],
       "duration": 1.599567,
       "status": 1,

--- a/tests/data/minitest/record_test_result_chunk1.json
+++ b/tests/data/minitest/record_test_result_chunk1.json
@@ -7,7 +7,8 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
-        }
+        },
+        { "type": "class", "name": "UserCopyTest" }
       ],
       "duration": 1.602778,
       "status": 1,
@@ -23,7 +24,8 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
-        }
+        },
+        { "type": "class", "name": "UserCopyTest" }
       ],
       "duration": 1.606243,
       "status": 1,
@@ -39,7 +41,8 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
-        }
+        },
+        { "type": "class", "name": "Admin::UserTest" }
       ],
       "duration": 1.611738,
       "status": 1,
@@ -55,7 +58,8 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
-        }
+        },
+        { "type": "class", "name": "Admin::UserTest" }
       ],
       "duration": 1.607029,
       "status": 1,
@@ -71,7 +75,8 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name_2"
-        }
+        },
+        { "type": "class", "name": "UserTest" }
       ],
       "duration": 1.614255,
       "status": 1,

--- a/tests/data/minitest/record_test_result_chunk2.json
+++ b/tests/data/minitest/record_test_result_chunk2.json
@@ -7,7 +7,8 @@
         {
           "type": "testcase",
           "name": "test_should_save_user_with_name"
-        }
+        },
+        { "type": "class", "name": "UserControllerTest" }
       ],
       "duration": 1.617726,
       "status": 1,
@@ -23,7 +24,8 @@
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
-        }
+        },
+        { "type": "class", "name": "UserControllerTest" }
       ],
       "duration": 1.611985,
       "status": 1,
@@ -36,7 +38,8 @@
       "type": "case",
       "testPath": [
         { "type": "file", "name": "test/models/admin/user_test.rb" },
-        { "type": "testcase", "name": "test_child" }
+        { "type": "testcase", "name": "test_child" },
+        { "type": "class", "name": "Admin::UserTest::ChildlenTest" }
       ],
       "duration": 1.599567,
       "status": 1,

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -43,5 +43,5 @@ class GoogleTestTest(CliTestCase):
         path = 'latest/gtest_*_results.xml'
         result = self.cli('record', 'tests', '--session', self.session,
                           'googletest', path)
-        self.assertIn("No matches found: {}".format(path), result.output.rstrip('\n'))
+        self.assertEqual(result.output.rstrip('\n'), "No matches found: {}".format(path))
         self.assert_success(result)

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -43,5 +43,5 @@ class GoogleTestTest(CliTestCase):
         path = 'latest/gtest_*_results.xml'
         result = self.cli('record', 'tests', '--session', self.session,
                           'googletest', path)
-        self.assertEqual(result.output.rstrip('\n'), "No matches found: {}".format(path))
+        self.assertIn("No matches found: {}".format(path), result.output.rstrip('\n'))
         self.assert_success(result)

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -20,6 +20,27 @@ class MinitestTest(CliTestCase):
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
+    # For testing https://github.com/launchableinc/cli/pull/846/files#r1591707246.
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test_minitest_test_path_order(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            test_path_file = os.path.join(tempdir, 'tests.xml')
+            with open(test_path_file, 'w') as f:
+                f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite time='1.614255' skipped='0' failures='0' errors='0' name="UserTest" assertions='1' tests='1' timestamp="2020-12-23T13:10:01+09:00">
+  <testcase time='1.614255' file="test/models/open_class_user_test.rb" name="test_should_not_save_user_without_name_2" assertions='1'>
+  </testcase>
+</testsuite>""")
+            result = self.cli('record', 'tests', '--session', self.session, 'minitest', test_path_file)
+            self.assert_success(result)
+            payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
+            self.assertEqual(
+                payload['events'][0]['testPath'],
+                [{'type': 'file', 'name': 'test/models/open_class_user_test.rb'},
+                 {'type': 'class', 'name': 'UserTest'},
+                 {'type': 'testcase', 'name': 'test_should_not_save_user_without_name_2'}])
+
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_minitest_chunked(self):

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -31,7 +31,7 @@ class MinitestTest(CliTestCase):
 <testsuite time='1.614255' skipped='0' failures='0' errors='0' name="UserTest" assertions='1' tests='1' timestamp="2020-12-23T13:10:01+09:00">
   <testcase time='1.614255' file="test/models/open_class_user_test.rb" name="test_should_not_save_user_without_name_2" assertions='1'>
   </testcase>
-</testsuite>""")
+</testsuite>""")  # noqa: E501
             result = self.cli('record', 'tests', '--session', self.session, 'minitest', test_path_file)
             self.assert_success(result)
             payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())


### PR DESCRIPTION
https://github.com/CircleCI-Public/minitest-ci is used for creating test report files. From the following code, it seems to be that a class name is set as a name attribute in testsuite tag.

* https://github.com/CircleCI-Public/minitest-ci/blob/v3.4.0/lib/minitest/ci_plugin.rb#L86-L87
* https://github.com/CircleCI-Public/minitest-ci/blob/v3.4.0/lib/minitest/ci_plugin.rb#L132

Here is a code snippet in minitest. 

```
require 'minitest/autorun'
require "mul"
class TestMul
  class Hoge < Minitest::Test
    def setup
      @mul = Mul.new
    end
    def test_calc_one
      assert_equal @mul.calc(1, 1), 1
    end
    def test_calc_two
      assert_equal @mul.calc(1, 2), 2
    end
    def test_calc_three
      assert_equal @mul.calc(1, 3), 3
    end
  end
end
```
After executing the above script with minitest-ci, I got the following results. As you can see, a class name is set as a name attribute in testsuite tag.

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite time='0.000020' skipped='0' failures='0' errors='0' name="TestMul::Hoge" assertions='3' tests='3' timestamp="2024-05-02T14:41:57+09:00">
  <testcase time='0.000013' file="test/test_mul.rb" name="test_calc_one" assertions='1'>
  </testcase>
  <testcase time='0.000004' file="test/test_mul.rb" name="test_calc_two" assertions='1'>
  </testcase>
  <testcase time='0.000003' file="test/test_mul.rb" name="test_calc_three" assertions='1'>
  </testcase>
</testsuite>
```