### PR TITLE
[IB-395] capture the mechanism in which a workspace information was obtained

### DIFF
--- a/launchable/test_runners/minitest.py
+++ b/launchable/test_runners/minitest.py
@@ -1,9 +1,8 @@
-import glob
-import os
-from . import launchable
-from junitparser import TestCase, TestSuite  # type: ignore
-from ..testpath import TestPath
 import click
+from junitparser import TestCase, TestSuite  # type: ignore
+
+from ..testpath import TestPath
+from . import launchable
 
 subset = launchable.CommonSubsetImpls(__name__).scan_files('*_test.rb')
 split_subset = launchable.CommonSplitSubsetImpls(__name__).split_subset()

--- a/launchable/test_runners/nunit.py
+++ b/launchable/test_runners/nunit.py
@@ -1,12 +1,10 @@
-import glob
-import os
 from typing import Callable, Dict, List
 from xml.etree import ElementTree as ET
 
 import click
 
 from launchable.commands.record.case_event import CaseEvent
-from launchable.testpath import TestPath, unparse_test_path, parse_test_path
+from launchable.testpath import TestPath, parse_test_path, unparse_test_path
 
 from . import launchable
 

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -45,17 +45,20 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": ".",
                         "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
-                        "branchName": "main"
+                        "branchName": "main",
+                        "mode": "source"
                     },
                     {
                         "repositoryName": "./foo",
                         "commitHash": "491e03096e2234dab9a9533da714fb6eff5dcaa7",
-                        "branchName": ""
+                        "branchName": "",
+                        "mode": "source"
                     },
                     {
                         "repositoryName": "./bar-zot",
                         "commitHash": "8bccab48338219e73c3118ad71c8c98fbd32a4be",
-                        "branchName": ""
+                        "branchName": "",
+                        "mode": "source"
                     },
                 ],
                 "links": []
@@ -88,7 +91,8 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": ".",
                         "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
-                        "branchName": ""
+                        "branchName": "",
+                        "mode": "source"
                     },
                 ],
                 "links": []
@@ -119,6 +123,7 @@ class BuildTest(CliTestCase):
                             "repositoryName": ".",
                             "commitHash": "c50f5de0f06fe16afa4fd1dd615e4903e40b42a2",
                             "branchName": "",
+                            "mode": "commit"
                         },
                     ],
                     "links": []
@@ -146,7 +151,8 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": "A",
                         "commitHash": "abc12",
-                        "branchName": ""
+                        "branchName": "",
+                        "mode": "commit"
                     },
                 ],
                 "links": []
@@ -174,7 +180,8 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": "A",
                         "commitHash": "abc12",
-                        "branchName": "feature-xxx"
+                        "branchName": "feature-xxx",
+                        "mode": "commit"
                     },
                 ],
                 "links": []
@@ -202,7 +209,8 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": "A",
                         "commitHash": "abc12",
-                        "branchName": ""
+                        "branchName": "",
+                        "mode": "commit"
                     },
                 ],
                 "links": []
@@ -235,12 +243,14 @@ class BuildTest(CliTestCase):
                     {
                         "repositoryName": "A",
                         "commitHash": "abc12",
-                        "branchName": "feature-xxx"
+                        "branchName": "feature-xxx",
+                        "mode": "commit"
                     },
                     {
                         "repositoryName": "B",
                         "commitHash": "56cde",
-                        "branchName": "feature-yyy"
+                        "branchName": "feature-yyy",
+                        "mode": "commit"
                     },
                 ],
                 "links": []


### PR DESCRIPTION
This would allow us to guide the server side behaviour later.

@ono-max can you double check your pre-commit config on this workspace? I had to create 6e5997792783c00a3ba8c720c57494013e36a01f  because my local flake8 run detected unused import statements, which I assume was caused by your recent edits to those files. I expected that when you committed those changes, your pre-commit would have run flake8 that should have fixed them automatically for you.