### PR TITLE
Add assertion to check if the order of test paths is correct

### DIFF
--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -237,6 +237,7 @@ class CliTestCase(unittest.TestCase):
 
         expected = self.load_json_from_file(self.test_files_dir.joinpath(golden_image_filename))
         self.assert_json_orderless_equal(expected, payload)
+        self.assert_test_path_orderly_equal(expected, payload)
 
     def assert_subset_payload(self, golden_image_filename: str, payload=None):
         '''
@@ -294,3 +295,15 @@ class CliTestCase(unittest.TestCase):
                 return obj
 
         self.assertEqual(tree_sorted(a), tree_sorted(b))
+
+    def assert_test_path_orderly_equal(self, a, b):
+        def extract_all_test_paths(obj):
+            paths_list = []
+            for event in obj['events']:
+                paths_list.append(event['testPath'])
+            return paths_list
+
+        a_test_paths = extract_all_test_paths(a)
+        b_test_paths = extract_all_test_paths(b)
+        for test_path in a_test_paths:
+            self.assertIn(test_path, b_test_paths, "Expected to include {}".format(test_path))

--- a/tests/data/cucumber/record_test_json_result.json
+++ b/tests/data/cucumber/record_test_json_result.json
@@ -399,15 +399,15 @@
         },
         {
           "type": "Given",
+          "name": "the current UTC is 01:00 AM"
+        },
+        {
+          "type": "Given",
           "name": "the current EST is 08:00 PM"
         },
         {
           "type": "Given",
           "name": "the current JST is 10:00 AM"
-        },
-        {
-          "type": "Given",
-          "name": "the current UTC is 01:00 AM"
         },
         {
           "type": "When",

--- a/tests/data/minitest/record_test_result.json
+++ b/tests/data/minitest/record_test_result.json
@@ -5,12 +5,12 @@
       "testPath": [
         { "type": "file", "name": "test/models/user_copy_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_save_user_with_name"
-        },
-        {
           "type": "class",
           "name": "UserCopyTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_save_user_with_name"
         }
       ],
       "duration": 1.602778,
@@ -24,12 +24,12 @@
       "testPath": [
         { "type": "file", "name": "test/models/user_copy_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_not_save_user_without_name"
-        },
-        {
           "type": "class",
           "name": "UserCopyTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_not_save_user_without_name"
         }
       ],
       "duration": 1.606243,
@@ -43,12 +43,12 @@
       "testPath": [
         { "type": "file", "name": "test/models/admin/user_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_not_save_user_without_name"
-        },
-        {
           "type": "class",
           "name": "Admin::UserTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_not_save_user_without_name"
         }
       ],
       "duration": 1.611738,
@@ -62,12 +62,12 @@
       "testPath": [
         { "type": "file", "name": "test/models/admin/user_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_save_user_with_name"
-        },
-        {
           "type": "class",
           "name": "Admin::UserTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_save_user_with_name"
         }
       ],
       "duration": 1.607029,
@@ -81,12 +81,12 @@
       "testPath": [
         { "type": "file", "name": "test/models/open_class_user_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_not_save_user_without_name_2"
-        },
-        {
           "type": "class",
           "name": "UserTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_not_save_user_without_name_2"
         }
       ],
       "duration": 1.614255,
@@ -100,12 +100,12 @@
       "testPath": [
         { "type": "file", "name": "test/controllers/user_test.rb" },
         {
-          "type": "testcase",
-          "name": "test_should_save_user_with_name"
-        },
-        {
           "type": "class",
           "name": "UserControllerTest"
+        },
+        {
+          "type": "testcase",
+          "name": "test_should_save_user_with_name"
         }
       ],
       "duration": 1.617726,
@@ -118,11 +118,11 @@
       "type": "case",
       "testPath": [
         { "type": "file", "name": "test/controllers/user_test.rb" },
+        { "type": "class", "name": "UserControllerTest" },
         {
           "type": "testcase",
           "name": "test_should_not_save_user_without_name"
-        },
-        { "type": "class", "name": "UserControllerTest" }
+        }
       ],
       "duration": 1.611985,
       "status": 1,
@@ -134,8 +134,8 @@
       "type": "case",
       "testPath": [
         { "type": "file", "name": "test/models/admin/user_test.rb" },
-        { "type": "testcase", "name": "test_child" },
-        { "type": "class", "name": "Admin::UserTest::ChildlenTest" }
+        { "type": "class", "name": "Admin::UserTest::ChildlenTest" },
+        { "type": "testcase", "name": "test_child" }
       ],
       "duration": 1.599567,
       "status": 1,

--- a/tests/test_cli_test_case.py
+++ b/tests/test_cli_test_case.py
@@ -4,40 +4,240 @@ from .cli_test_case import CliTestCase
 class TestCliTestCase(CliTestCase):
     def test_assert_json_orderless_equal(self):
         # simple case
-        self.assert_json_orderless_equal(
-            {"a": 1, "b": 2},
-            {"b": 2, "a": 1}
-        )
+        self.assert_json_orderless_equal({"a": 1, "b": 2}, {"b": 2, "a": 1})
 
         # has array field
         self.assert_json_orderless_equal(
-            {"array": [1, 2, 3], "b": 2},
-            {"b": 2, "array": [1, 2, 3]}
+            {"array": [1, 2, 3], "b": 2}, {"b": 2, "array": [1, 2, 3]}
         )
 
         # has dict field
         self.assert_json_orderless_equal(
-            {"dict": {
-                "a": 1,
-                "b": 2,
-                "c": 3
-            }, "b": 2},
-            {"b": 2, "dict": {
-                "b": 2,
-                "c": 3,
-                "a": 1
-            }}
+            {"dict": {"a": 1, "b": 2, "c": 3}, "b": 2},
+            {"b": 2, "dict": {"b": 2, "c": 3, "a": 1}},
         )
         # compare with array that some object have have fields that None
         self.assert_json_orderless_equal(
-            {"array": [
-                {"name": "a", "data": {"value": 1}},
-                {"data": None, "name": "b"},
-                {"name": "c", "data": {"value": 2}}
-            ], "b": 2},
-            {"b": 2, "array": [
-                {"data": None, "name": "b"},
-                {"data": {"value": 2}, "name": "c"},
-                {"data": {"value": 1}, "name": "a"},
-            ]}
+            {
+                "array": [
+                    {"name": "a", "data": {"value": 1}},
+                    {"data": None, "name": "b"},
+                    {"name": "c", "data": {"value": 2}},
+                ],
+                "b": 2,
+            },
+            {
+                "b": 2,
+                "array": [
+                    {"data": None, "name": "b"},
+                    {"data": {"value": 2}, "name": "c"},
+                    {"data": {"value": 1}, "name": "a"},
+                ],
+            },
+        )
+
+    def test_extract_all_test_paths_do_not_throw_exception_when_correct_input(self):
+        self.assert_test_path_orderly_equal(
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    }
+                ],
+            },
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    }
+                ]
+            },
+        )
+
+        self.assert_test_path_orderly_equal(
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    },
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test2"},
+                        ],
+                    },
+                ],
+            },
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    },
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {"type": "class", "name": "com.launchable.HelloWorldTest"},
+                            {"type": "testcase", "name": "test2"},
+                        ],
+                    },
+                ]
+            },
+        )
+
+    def test_extract_all_test_paths_throw_exception_when_element_size_does_not_match(
+        self,
+    ):
+        with self.assertRaises(AssertionError):
+            self.assert_test_path_orderly_equal(
+                {
+                    "events": [
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test1"},
+                            ],
+                        },
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test2"},
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "events": [
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test1"},
+                            ],
+                        }
+                    ]
+                },
+            )
+
+        with self.assertRaises(AssertionError):
+            self.assert_test_path_orderly_equal(
+                {
+                    "events": [
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test1"},
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "events": [
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test1"},
+                            ],
+                        },
+                        {
+                            "type": "case",
+                            "testPath": [
+                                {
+                                    "type": "class",
+                                    "name": "com.launchable.HelloWorldTest",
+                                },
+                                {"type": "testcase", "name": "test2"},
+                            ],
+                        },
+                    ]
+                },
+            )
+
+    def test_extract_all_test_paths_throw_exception_when_the_events_order_does_not_match(
+        self,
+    ):
+        self.assert_test_path_orderly_equal(
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {
+                                "type": "class",
+                                "name": "com.launchable.HelloWorldTest",
+                            },
+                            {"type": "testcase", "name": "test2"},
+                        ],
+                    },
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {
+                                "type": "class",
+                                "name": "com.launchable.HelloWorldTest",
+                            },
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    },
+                ],
+            },
+            {
+                "events": [
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {
+                                "type": "class",
+                                "name": "com.launchable.HelloWorldTest",
+                            },
+                            {"type": "testcase", "name": "test1"},
+                        ],
+                    },
+                    {
+                        "type": "case",
+                        "testPath": [
+                            {
+                                "type": "class",
+                                "name": "com.launchable.HelloWorldTest",
+                            },
+                            {"type": "testcase", "name": "test2"},
+                        ],
+                    },
+                ]
+            },
         )

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -20,27 +20,6 @@ class MinitestTest(CliTestCase):
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
-    # For testing https://github.com/launchableinc/cli/pull/846/files#r1591707246.
-    @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_record_test_minitest_test_path_order(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            test_path_file = os.path.join(tempdir, 'tests.xml')
-            with open(test_path_file, 'w') as f:
-                f.write("""<?xml version="1.0" encoding="UTF-8"?>
-<testsuite time='1.614255' skipped='0' failures='0' errors='0' name="UserTest" assertions='1' tests='1' timestamp="2020-12-23T13:10:01+09:00">
-  <testcase time='1.614255' file="test/models/open_class_user_test.rb" name="test_should_not_save_user_without_name_2" assertions='1'>
-  </testcase>
-</testsuite>""")  # noqa: E501
-            result = self.cli('record', 'tests', '--session', self.session, 'minitest', test_path_file)
-            self.assert_success(result)
-            payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
-            self.assertEqual(
-                payload['events'][0]['testPath'],
-                [{'type': 'file', 'name': 'test/models/open_class_user_test.rb'},
-                 {'type': 'class', 'name': 'UserTest'},
-                 {'type': 'testcase', 'name': 'test_should_not_save_user_without_name_2'}])
-
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_record_test_minitest_chunked(self):


### PR DESCRIPTION
Currently, we do not verify the order of JSON at https://github.com/launchableinc/cli/blob/main/tests/cli_test_case.py#L221 because we evaluate JSON in an order-agnostic manner. However, we aim to ensure the order of test paths is accurate. `assert_json_orderless_equal` disregards the order of items intentionally. Consequently, I have introduced the `assert_test_path_orderly_equal` method to address this requirement, instead of modifying `assert_json_orderless_equal`.

@kohsuke 

I think you designed these methods in https://github.com/launchableinc/cli/pull/91. Can you take a look at this PR?