### PR TITLE
Error check improvement

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -7,7 +7,7 @@ from launchable.utils.tracking import TrackingClient
 
 from ..app import Application
 from ..utils.launchable_client import LaunchableClient
-from ..utils.session import read_build, read_session
+from ..utils.session import parse_session, read_build, read_session
 
 
 def require_session(
@@ -20,6 +20,7 @@ def require_session(
        See https://github.com/launchableinc/cli/pull/342
     """
     if session:
+        parse_session(session)  # make sure session is in the right format
         return session
 
     session = read_session(require_build())


### PR DESCRIPTION
An experienced customer experiemented with the CLI locally to try out a new command. Upon seeing the --session option, they assumed they just need to pass a test session ID, so they ended up invoking something like `launchable foo bar --session 12345`

That is a good assumption on their part, but it's actually incorrect, as the ID format we take is more complicated. However, there's no error check, so the CLI resulted in 404, which misled them.

By adding parse_session, we can make sure the ID given from the command line is in the correct format, and fail gracefully if not.