### PR TITLE
Add --test-suite option to record session

### DIFF
--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -90,6 +90,14 @@ def _validate_session_name(ctx, param, value):
     type=str,
     metavar='LINEAGE',
 )
+@click.option(
+    '--test-suite',
+    'test_suite',
+    help='Set test suite name. A test suite is a collection of test sessions. Setting a test suite allows you to manage data over test sessions and lineages.',  # noqa: E501
+    required=False,
+    type=str,
+    metavar='TEST_SUITE',
+)
 @click.pass_context
 def session(
     ctx: click.core.Context,
@@ -102,6 +110,7 @@ def session(
     is_no_build: bool = False,
     session_name: Optional[str] = None,
     lineage: Optional[str] = None,
+    test_suite: Optional[str] = None,
 ):
     """
     print_session is for backward compatibility.
@@ -158,6 +167,7 @@ def session(
         "isObservation": is_observation,
         "noBuild": is_no_build,
         "lineage": lineage,
+        "testSuite": test_suite,
     }
 
     _links = capture_link(os.environ)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -27,11 +27,14 @@ class SessionTest(CliTestCase):
         self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
-        self.assert_json_orderless_equal(
-            {"flavors": {},
-             "isObservation": False, "links": [],
-             "noBuild": False, "lineage": None},
-            payload)
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": False,
+            "links": [],
+            "noBuild": False,
+            "lineage": None,
+            "testSuite": None,
+        }, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -54,6 +57,7 @@ class SessionTest(CliTestCase):
             "links": [],
             "noBuild": False,
             "lineage": None,
+            "testSuite": None,
         }, payload)
 
         with self.assertRaises(ValueError):
@@ -73,11 +77,14 @@ class SessionTest(CliTestCase):
 
         payload = json.loads(responses.calls[0].request.body.decode())
 
-        self.assert_json_orderless_equal(
-            {"flavors": {},
-             "isObservation": True, "links": [],
-             "noBuild": False, "lineage": None},
-            payload)
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": True,
+            "links": [],
+            "noBuild": False,
+            "lineage": None,
+            "testSuite": None,
+        }, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -108,11 +115,14 @@ class SessionTest(CliTestCase):
         self.assert_success(result)
 
         payload = json.loads(responses.calls[3].request.body.decode())
-        self.assert_json_orderless_equal(
-            {"flavors": {},
-             "isObservation": False, "links": [],
-             "noBuild": False, "lineage": None},
-            payload)
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": False,
+            "links": [],
+            "noBuild": False,
+            "lineage": None,
+            "testSuite": None,
+        }, payload)
 
     @responses.activate
     @mock.patch.dict(os.environ, {
@@ -131,4 +141,25 @@ class SessionTest(CliTestCase):
             "links": [],
             "noBuild": False,
             "lineage": "example-lineage",
+            "testSuite": None,
+        }, payload)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
+    }, clear=True)
+    def test_run_session_with_test_suite(self):
+        result = self.cli("record", "session", "--build", self.build_name,
+                          "--test-suite", "example-test-suite")
+        self.assert_success(result)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": False,
+            "links": [],
+            "noBuild": False,
+            "lineage": None,
+            "testSuite": "example-test-suite",
         }, payload)


### PR DESCRIPTION
# Background

When we introduced a workspace, we expect that customers use a workspace per test suite. However, we  noticed that some customers use a single workspace with multiple test suites. Mixing test suites in a workspace make many features less valuable. For example, trends, test issue triages, test session list, and unhealthy tests are affected. It’s natural to promote “test suites” as a first class data model on Launchable so our customers can sort, filter, and analyze data based on test suites in a workspace.

# Change

- Add a new option `--test-suite` to specify a name of test suite executed in a test session.