### PR TITLE
Ignore $InnerClass in JUnit 5 and Gradle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: end-of-file-fixer
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 7.0.0
     hooks:
     - id: flake8
       args:

--- a/launchable/test_runners/gradle.py
+++ b/launchable/test_runners/gradle.py
@@ -118,9 +118,11 @@ def record_tests(client, reports):
         like com.launchableinc.rocket_car_gradle.AppTest$InnerClass.
         It causes a problem in subsetting bacause Launchable CLI can't detect inner classes in subsetting.
         So, we need to ignore the inner class names. The inner class name is separated by $.
+        Note: Launchable allows to use $ in test paths. But we decided ignoring it in this case
+              beause $ in the class name is not a common case.
         """
         test_path = default_path_builder(case, suite, report_file)
-        return [{**item, "name": item["name"].split("$")[0]} for item in test_path]
+        return [{**item, "name": item["name"].split("$")[0]} if item["type"] == "class" else item for item in test_path]
 
     client.path_builder = path_builder
 

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/App2Test.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/App2Test.java
@@ -4,15 +4,16 @@
 package com.launchableinc.rocket_car_gradle;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions.*;
 
 public class App2Test {
-    @Test public void testAppHasAGreeting() {
+    @Test void testAppHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }
 
-    @Test public void testAppHasAGreeting2() {
+    @Test void testAppHasAGreeting2() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/AppTest.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/AppTest.java
@@ -3,18 +3,26 @@
  */
 package com.launchableinc.rocket_car_gradle;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions.*;
 
 public class AppTest {
-    @Test public void testAppHasAGreeting() {
+    @Test void testAppHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }
 
-    @Test public void testAppHasAGreeting2() {
+    @Test void testAppHasAGreeting2() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }
 
+    @Nested
+    class Inner() {
+        @Test void testAppHasAGreeting3() {
+            App classUnderTest = new App();
+            assertNotNull("app should have a greeting", classUnderTest.getGreeting());
+        }
+    }
 }

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/AppTest.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/AppTest.java
@@ -24,5 +24,9 @@ public class AppTest {
             App classUnderTest = new App();
             assertNotNull("app should have a greeting", classUnderTest.getGreeting());
         }
+        @Test void testAppHasAGreeting4() {
+            App classUnderTest = new App();
+            assertNotNull("app should have a greeting", classUnderTest.getGreeting());
+        }
     }
 }

--- a/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/sub/App3Test.java
+++ b/tests/data/gradle/java/app/src/test/java/com/launchableinc/rocket_car_gradle/sub/App3Test.java
@@ -3,17 +3,17 @@
  */
 package com.launchableinc.rocket_car_gradle.sub;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions.*;
 import com.launchableinc.rocket_car_gradle.App;
 
 public class App3Test {
-    @Test public void testAppHasAGreeting() {
+    @Test void testAppHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }
 
-    @Test public void testAppHasAGreeting2() {
+    @Test void testAppHasAGreeting2() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }

--- a/tests/data/gradle/recursion/expected.json
+++ b/tests/data/gradle/recursion/expected.json
@@ -30,7 +30,7 @@
           "name": "testAppHasAGreeting2"
         }
       ],
-      "duration": 0.0,
+      "duration": 0.001,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -48,7 +48,25 @@
           "name": "testAppHasAGreeting3"
         }
       ],
-      "duration": 0.0,
+      "duration": 0.001,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "com.launchableinc.rocket_car_gradle.AppTest"
+        },
+        {
+          "type": "testcase",
+          "name": "testAppHasAGreeting4"
+        }
+      ],
+      "duration": 0.002,
       "status": 1,
       "stdout": "",
       "stderr": "",

--- a/tests/data/gradle/recursion/expected.json
+++ b/tests/data/gradle/recursion/expected.json
@@ -35,6 +35,24 @@
       "stdout": "",
       "stderr": "",
       "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "com.launchableinc.rocket_car_gradle.AppTest"
+        },
+        {
+          "type": "testcase",
+          "name": "testAppHasAGreeting3"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
     }
   ],
   "testRunner": "gradle",

--- a/tests/data/gradle/recursion/foo/bar/reports/1.xml
+++ b/tests/data/gradle/recursion/foo/bar/reports/1.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="com.launchableinc.rocket_car_gradle.AppTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2020-11-18T13:17:18" hostname="YoshiorinoMacBook-Pro.local" time="0.002">
+<testsuite name="com.launchableinc.rocket_car_gradle.AppTest" tests="4" skipped="0" failures="0" errors="0" timestamp="2020-11-18T13:17:18" hostname="YoshiorinoMacBook-Pro.local" time="0.002">
   <properties/>
   <testcase name="testAppHasAGreeting" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.002"/>
-  <testcase name="testAppHasAGreeting2" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.0"/>
-  <testcase name="testAppHasAGreeting3" classname="com.launchableinc.rocket_car_gradle.AppTest$InnerClass" time="0.0"/>
+  <testcase name="testAppHasAGreeting2" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.001"/>
+  <testcase name="testAppHasAGreeting3" classname="com.launchableinc.rocket_car_gradle.AppTest$InnerClass" time="0.001"/>
+  <testcase name="testAppHasAGreeting4" classname="com.launchableinc.rocket_car_gradle.AppTest$InnerClass" time="0.002"/>
   <system-out><![CDATA[]]></system-out>
   <system-err><![CDATA[]]></system-err>
 </testsuite>

--- a/tests/data/gradle/recursion/foo/bar/reports/1.xml
+++ b/tests/data/gradle/recursion/foo/bar/reports/1.xml
@@ -3,6 +3,7 @@
   <properties/>
   <testcase name="testAppHasAGreeting" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.002"/>
   <testcase name="testAppHasAGreeting2" classname="com.launchableinc.rocket_car_gradle.AppTest" time="0.0"/>
+  <testcase name="testAppHasAGreeting3" classname="com.launchableinc.rocket_car_gradle.AppTest$InnerClass" time="0.0"/>
   <system-out><![CDATA[]]></system-out>
   <system-err><![CDATA[]]></system-err>
 </testsuite>


### PR DESCRIPTION
JUnit 5 has `@Nested` annotation. With the annotation, users can write nested tests. But the nested tests are outputted as `ClassName$InnerClass` style. And Launchable CLI cannot detect the nested test cases on subsetting. So I updated the following changes:

* Update Gradle profile to ignore inner classes
* Update the Gradle demo project with Junit 5