### PR TITLE
Add --test-suite option to record tests and subset commands

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -62,6 +62,7 @@ def find_or_create_session(
     links: List[str] = [],
     is_no_build: bool = False,
     lineage: Optional[str] = None,
+    test_suite: Optional[str] = None,
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -80,6 +81,7 @@ def find_or_create_session(
         links: The --link option values
         is_no_build: The --no-build option value
         lineage: lineage option value
+        test_suite: --test-suite option value
     """
     from .record.session import session as session_command
 
@@ -98,6 +100,7 @@ def find_or_create_session(
             links=links,
             is_no_build=is_no_build,
             lineage=lineage,
+            test_suite=test_suite,
         )
         saved_build_name = read_build()
         return read_session(str(saved_build_name))
@@ -129,6 +132,7 @@ def find_or_create_session(
         links=links,
         is_no_build=is_no_build,
         lineage=lineage,
+        test_suite=test_suite,
     )
     return read_session(saved_build_name)
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -150,6 +150,14 @@ def _validate_group(ctx, param, value):
     type=str,
     metavar='LINEAGE',
 )
+@click.option(
+    '--test-suite',
+    'test_suite',
+    help='Set test suite name. This option value will be passed to the record session command if a session isn\'t created yet.',  # noqa: E501
+    required=False,
+    type=str,
+    metavar='TEST_SUITE',
+)
 @click.pass_context
 def tests(
     context: click.core.Context,
@@ -167,6 +175,7 @@ def tests(
     is_no_build: bool = False,
     session_name: Optional[str] = None,
     lineage: Optional[str] = None,
+    test_suite: Optional[str] = None,
 ):
     logger = Logger()
 
@@ -225,6 +234,7 @@ def tests(
                 flavor=flavor,
                 links=links,
                 lineage=lineage,
+                test_suite=test_suite,
                 tracking_client=tracking_client))
             build_name = read_build()
             record_start_at = get_record_start_at(session_id, client)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -165,6 +165,14 @@ from .test_path_writer import TestPathWriter
     required=False,
     type=click.File('r'),
 )
+@click.option(
+    '--test-suite',
+    'test_suite',
+    help='Set test suite name. This option value will be passed to the record session command if a session isn\'t created yet.',  # noqa: E501
+    required=False,
+    type=str,
+    metavar='TEST_SUITE',
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -188,6 +196,7 @@ def subset(
     lineage: Optional[str] = None,
     prioritize_tests_failed_within_hours: Optional[int] = None,
     prioritized_tests_mapping_file: Optional[TextIO] = None,
+    test_suite: Optional[str] = None,
 ):
     app = context.obj
     tracking_client = TrackingClient(Tracking.Command.SUBSET, app=app)
@@ -260,7 +269,8 @@ def subset(
             links=links,
             is_no_build=is_no_build,
             lineage=lineage,
-            tracking_client=tracking_client
+            tracking_client=tracking_client,
+            test_suite=test_suite,
         )
     except Exception as e:
         tracking_client.send_error_event(


### PR DESCRIPTION
continue from https://github.com/launchableinc/cli/pull/861

This PR introduces `--test-suite` option to `record tests` and `subset` commands.