### PR TITLE
Support markers in pytest

### DIFF
--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -3,7 +3,7 @@ import json
 import os
 import pathlib
 import subprocess
-from typing import Dict, Generator, List
+from typing import Generator, List
 
 import click
 from junitparser import Properties, TestCase  # type: ignore
@@ -148,13 +148,8 @@ def record_tests(client, json_report, source_roots):
                     </properties>
                 ```
             """
-            markers = []
-            marker: Dict[str, str] = {}
-            for prop in props:
-                markers.append({"name": prop.name, "value": prop.value})
-            if len(marker) > 0:
-                markers.append(marker)
-            result["markers"] = markers
+            markers = [{"name": prop.name, "value": prop.value} for prop in props]
+            result["markers"] = markers if markers else []
 
         metadata = MetadataTestCase.fromelem(case)
         if metadata and metadata.line is not None:

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -3,10 +3,10 @@ import json
 import os
 import pathlib
 import subprocess
-from typing import Generator, List
+from typing import Dict, Generator, List
 
 import click
-from junitparser import Properties, TestCase
+from junitparser import Properties, TestCase  # type: ignore
 
 from launchable.commands.record.case_event import CaseEvent, CaseEventType, MetadataTestCase
 from launchable.testpath import TestPath
@@ -136,7 +136,7 @@ def record_tests(client, json_report, source_roots):
         result = {}
         if props is not None:
             markers = []
-            marker = {}
+            marker: Dict[str, str] = {}
             for prop in props:
                 if prop.name in marker:
                     """

--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -135,28 +135,23 @@ def record_tests(client, json_report, source_roots):
         props = case.child(Properties)
         result = {}
         if props is not None:
+            """
+                Here is an example of an XML file with markers.
+                ```
+                    <properties>
+                        <property name="name" value="parametrize" />
+                        <property name="args" value="('y', [2, 3])" />
+                        <property name="kwargs" value="{}" />
+                        <property name="name" value="parametrize" />
+                        <property name="args" value="('x', [0, 1])" />
+                        <property name="kwargs" value="{}" />
+                    </properties>
+                ```
+            """
             markers = []
             marker: Dict[str, str] = {}
             for prop in props:
-                if prop.name in marker:
-                    """
-                        Here is an example of an XML file.
-                        As you can see, all property tags are included within a single properties tag,
-                        so we identify each marker object by checking if a name attribute with the same value exists.
-                        ```
-                            <properties>
-                                <property name="name" value="parametrize" />
-                                <property name="args" value="('y', [2, 3])" />
-                                <property name="kwargs" value="{}" />
-                                <property name="name" value="parametrize" />
-                                <property name="args" value="('x', [0, 1])" />
-                                <property name="kwargs" value="{}" />
-                            </properties>
-                        ```
-                    """
-                    markers.append(marker.copy())
-                    marker.clear()
-                marker[prop.name] = prop.value
+                markers.append({"name": prop.name, "value": prop.value})
             if len(marker) > 0:
                 markers.append(marker)
             result["markers"] = markers

--- a/tests/data/pytest/pytest.ini
+++ b/tests/data/pytest/pytest.ini
@@ -1,8 +1,7 @@
 [pytest]
 ; xunit1 is necessary for adding line attribute.
 junit_family = xunit1
+; Regiter custom markers
 markers =
     foo
     bar
-[mypy]
-disable_error_code = import-untyped

--- a/tests/data/pytest/pytest.ini
+++ b/tests/data/pytest/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+; xunit1 is necessary for adding line attribute.
+junit_family = xunit1
+markers =
+    foo
+    bar

--- a/tests/data/pytest/pytest.ini
+++ b/tests/data/pytest/pytest.ini
@@ -4,3 +4,5 @@ junit_family = xunit1
 markers =
     foo
     bar
+[mypy]
+disable_error_code = import-untyped

--- a/tests/data/pytest/pytest.ini
+++ b/tests/data/pytest/pytest.ini
@@ -2,6 +2,7 @@
 ; xunit1 is necessary for adding line attribute.
 junit_family = xunit1
 ; Regiter custom markers
+; https://docs.pytest.org/en/stable/example/markers.html#registering-markers
 markers =
     foo
     bar

--- a/tests/data/pytest/record_test_result.json
+++ b/tests/data/pytest/record_test_result.json
@@ -64,7 +64,11 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "markers": [{ "name": "foo", "args": "()", "kwargs": "{}" }],
+        "markers": [
+          { "name": "name", "value": "foo" },
+          { "name": "args", "value": "()" },
+          { "name": "kwargs", "value": "{}" }
+        ],
         "lineNumber": 3
       }
     },
@@ -80,7 +84,11 @@
       "stdout": "",
       "stderr": "@pytest.mark.bar\n                def test_func2():\n                > assert 1 == False # noqa: E712\n                E assert 1 == False\n\n                tests/test_funcs1.py:9: AssertionError",
       "data": {
-        "markers": [{ "name": "bar", "args": "()", "kwargs": "{}" }],
+        "markers": [
+          { "name": "name", "value": "bar" },
+          { "name": "args", "value": "()" },
+          { "name": "kwargs", "value": "{}" }
+        ],
         "lineNumber": 7
       }
     },
@@ -97,8 +105,12 @@
       "stderr": "x = 0, y = 2\n\n                @pytest.mark.parametrize(\"x\", [0, 1])\n                @pytest.mark.parametrize(\"y\", [2, 3])\n                def test_foo(x, y):\n                > assert x == 1\n                E assert 0 == 1\n\n                tests/test_funcs1.py:15: AssertionError",
       "data": {
         "markers": [
-          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
-          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('y', [2, 3])" },
+          { "name": "kwargs", "value": "{}" },
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('x', [0, 1])" },
+          { "name": "kwargs", "value": "{}" }
         ],
         "lineNumber": 12
       }
@@ -116,8 +128,12 @@
       "stderr": "",
       "data": {
         "markers": [
-          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
-          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('y', [2, 3])" },
+          { "name": "kwargs", "value": "{}" },
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('x', [0, 1])" },
+          { "name": "kwargs", "value": "{}" }
         ],
         "lineNumber": 12
       }
@@ -135,8 +151,12 @@
       "stderr": "x = 0, y = 3\n\n                @pytest.mark.parametrize(\"x\", [0, 1])\n                @pytest.mark.parametrize(\"y\", [2, 3])\n                def test_foo(x, y):\n                > assert x == 1\n                E assert 0 == 1\n\n                tests/test_funcs1.py:15: AssertionError",
       "data": {
         "markers": [
-          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
-          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('y', [2, 3])" },
+          { "name": "kwargs", "value": "{}" },
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('x', [0, 1])" },
+          { "name": "kwargs", "value": "{}" }
         ],
         "lineNumber": 12
       }
@@ -154,8 +174,12 @@
       "stderr": "",
       "data": {
         "markers": [
-          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
-          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('y', [2, 3])" },
+          { "name": "kwargs", "value": "{}" },
+          { "name": "name", "value": "parametrize" },
+          { "name": "args", "value": "('x', [0, 1])" },
+          { "name": "kwargs", "value": "{}" }
         ],
         "lineNumber": 12
       }
@@ -172,7 +196,11 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "markers": [{ "name": "foo", "args": "()", "kwargs": "{}" }],
+        "markers": [
+          { "name": "name", "value": "foo" },
+          { "name": "args", "value": "()" },
+          { "name": "kwargs", "value": "{}" }
+        ],
         "lineNumber": 3
       }
     },
@@ -188,7 +216,11 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "markers": [{ "name": "bar", "args": "()", "kwargs": "{}" }],
+        "markers": [
+          { "name": "name", "value": "bar" },
+          { "name": "args", "value": "()" },
+          { "name": "kwargs", "value": "{}" }
+        ],
         "lineNumber": 8
       }
     }

--- a/tests/data/pytest/record_test_result.json
+++ b/tests/data/pytest/record_test_result.json
@@ -1,161 +1,199 @@
 {
-   "events": [
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/funcs3_test.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.funcs3_test"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func4"
-         }
-       ],
-       "duration": 0.001,
-       "status": 1,
-       "stdout": "",
-       "stderr": "",
-       "data": { "lineNumber": 1 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/funcs3_test.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.funcs3_test"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func5"
-         }
-       ],
-       "duration": 0.001,
-       "status": 0,
-       "stdout": "",
-       "stderr": "def test_func5():\n  >       assert 1 == False\n  E       assert 1 == False\n\n        tests/funcs3_test.py:6: AssertionError      ",
-       "data": { "lineNumber": 5 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/test_funcs1.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.test_funcs1"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func1"
-         }
-       ],
-       "duration": 0.001,
-       "status": 1,
-       "stdout": "",
-       "stderr": "",
-       "data": { "lineNumber": 1 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/test_funcs1.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.test_funcs1"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func2"
-         }
-       ],
-       "duration": 0.001,
-       "status": 0,
-       "stdout": "",
-       "stderr": "def test_func2():\n  >       assert 1 == False\n  E       assert 1 == False\n\n    tests/test_funcs1.py:6: AssertionError  ",
-       "data": { "lineNumber": 5 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/test_funcs2.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.test_funcs2"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func3"
-         }
-       ],
-       "duration": 0.001,
-       "status": 1,
-       "stdout": "",
-       "stderr": "",
-       "data": { "lineNumber": 1 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/test_funcs2.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.test_funcs2"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func4"
-         }
-       ],
-       "duration": 0.001,
-       "status": 1,
-       "stdout": "",
-       "stderr": "",
-       "data": { "lineNumber": 5 }
-     },
-     {
-       "type": "case",
-       "testPath": [
-         {
-           "type": "file",
-           "name": "tests/data/pytest/tests/fooo/func4_test.py"
-         },
-         {
-           "type": "class",
-           "name": "tests.data.pytest.tests.fooo.func4_test"
-         },
-         {
-           "type": "testcase",
-           "name": "test_func6"
-         }
-       ],
-       "duration": 0.001,
-       "status": 1,
-       "stdout": "",
-       "stderr": "",
-       "data": { "lineNumber": 1 }
-     }
-   ],
-   "testRunner": "pytest",
-   "group": "",
-   "noBuild": false
- }
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/fooo/filenameonly_test.py" },
+        { "type": "class", "name": "tests.fooo.filenameonly_test" },
+        { "type": "testcase", "name": "test_x" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": { "lineNumber": 1 }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/fooo/func4_test.py" },
+        { "type": "class", "name": "tests.fooo.func4_test" },
+        { "type": "testcase", "name": "test_func6" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": { "lineNumber": 1 }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/funcs3_test.py" },
+        { "type": "class", "name": "tests.funcs3_test" },
+        { "type": "testcase", "name": "test_func4" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": { "lineNumber": 1 }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/funcs3_test.py" },
+        { "type": "class", "name": "tests.funcs3_test" },
+        { "type": "testcase", "name": "test_func5" }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "def test_func5():\n                > assert 1 == False # noqa: E712\n                E assert 1 == False\n\n                tests/funcs3_test.py:6: AssertionError",
+      "data": { "lineNumber": 5 }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_func1" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "markers": [{ "name": "foo", "args": "()", "kwargs": "{}" }],
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_func2" }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "@pytest.mark.bar\n                def test_func2():\n                > assert 1 == False # noqa: E712\n                E assert 1 == False\n\n                tests/test_funcs1.py:9: AssertionError",
+      "data": {
+        "markers": [{ "name": "bar", "args": "()", "kwargs": "{}" }],
+        "lineNumber": 7
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_foo[2-0]" }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "x = 0, y = 2\n\n                @pytest.mark.parametrize(\"x\", [0, 1])\n                @pytest.mark.parametrize(\"y\", [2, 3])\n                def test_foo(x, y):\n                > assert x == 1\n                E assert 0 == 1\n\n                tests/test_funcs1.py:15: AssertionError",
+      "data": {
+        "markers": [
+          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
+          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+        ],
+        "lineNumber": 12
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_foo[2-1]" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "markers": [
+          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
+          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+        ],
+        "lineNumber": 12
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_foo[3-0]" }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "x = 0, y = 3\n\n                @pytest.mark.parametrize(\"x\", [0, 1])\n                @pytest.mark.parametrize(\"y\", [2, 3])\n                def test_foo(x, y):\n                > assert x == 1\n                E assert 0 == 1\n\n                tests/test_funcs1.py:15: AssertionError",
+      "data": {
+        "markers": [
+          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
+          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+        ],
+        "lineNumber": 12
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs1.py" },
+        { "type": "class", "name": "tests.test_funcs1" },
+        { "type": "testcase", "name": "test_foo[3-1]" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "markers": [
+          { "name": "parametrize", "args": "('y', [2, 3])", "kwargs": "{}" },
+          { "name": "parametrize", "args": "('x', [0, 1])", "kwargs": "{}" }
+        ],
+        "lineNumber": 12
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs2.py" },
+        { "type": "class", "name": "tests.test_funcs2" },
+        { "type": "testcase", "name": "test_func3" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "markers": [{ "name": "foo", "args": "()", "kwargs": "{}" }],
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        { "type": "file", "name": "tests/test_funcs2.py" },
+        { "type": "class", "name": "tests.test_funcs2" },
+        { "type": "testcase", "name": "test_func4" }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "markers": [{ "name": "bar", "args": "()", "kwargs": "{}" }],
+        "lineNumber": 8
+      }
+    }
+  ],
+  "testRunner": "pytest",
+  "group": "",
+  "noBuild": false
+}

--- a/tests/data/pytest/report.xml
+++ b/tests/data/pytest/report.xml
@@ -1,24 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite name="pytest" errors="0" failures="2" skipped="0" tests="7" time="0.076" timestamp="2021-12-09T14:09:43.746900" hostname="Yoshioris-MacBook-Pro.local">
-    <testcase classname="tests.data.pytest.tests.funcs3_test" name="test_func4" file="tests/data/pytest/tests/funcs3_test.py" line="0" time="0.001" />
-    <testcase classname="tests.data.pytest.tests.funcs3_test" name="test_func5" file="tests/data/pytest/tests/funcs3_test.py" line="4" time="0.001">
-      <failure message="assert 1 == False">def test_func5():
-  &gt;       assert 1 == False
-  E       assert 1 == False
+    <testsuite name="pytest" errors="0" failures="4" skipped="0" tests="12" time="0.035"
+        timestamp="2024-06-13T12:33:48.703447" hostname="ip-192-168-0-28.us-west-2.compute.internal">
+        <testcase classname="tests.fooo.filenameonly_test" name="test_x"
+            file="tests/fooo/filenameonly_test.py" line="0" time="0.000" />
+        <testcase classname="tests.fooo.func4_test" name="test_func6"
+            file="tests/fooo/func4_test.py" line="0" time="0.000" />
+        <testcase classname="tests.funcs3_test" name="test_func4" file="tests/funcs3_test.py"
+            line="0" time="0.000" />
+        <testcase classname="tests.funcs3_test" name="test_func5" file="tests/funcs3_test.py"
+            line="4" time="0.000">
+            <failure message="assert 1 == False">def test_func5():
+                &gt; assert 1 == False # noqa: E712
+                E assert 1 == False
 
-        tests/funcs3_test.py:6: AssertionError      </failure>
-    </testcase>
-    <testcase classname="tests.data.pytest.tests.test_funcs1" name="test_func1" file="tests/data/pytest/tests/test_funcs1.py" line="0" time="0.001" />
-    <testcase classname="tests.data.pytest.tests.test_funcs1" name="test_func2" file="tests/data/pytest/tests/test_funcs1.py" line="4" time="0.001">
-      <failure message="assert 1 == False">def test_func2():
-  &gt;       assert 1 == False
-  E       assert 1 == False
+                tests/funcs3_test.py:6: AssertionError</failure>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_func1" file="tests/test_funcs1.py"
+            line="2" time="0.000">
+            <properties>
+                <property name="name" value="foo" />
+                <property name="args" value="()" />
+                <property name="kwargs" value="{}" />
+            </properties>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_func2" file="tests/test_funcs1.py"
+            line="6" time="0.000">
+            <properties>
+                <property name="name" value="bar" />
+                <property name="args" value="()" />
+                <property name="kwargs" value="{}" />
+            </properties>
+            <failure message="assert 1 == False">@pytest.mark.bar
+                def test_func2():
+                &gt; assert 1 == False # noqa: E712
+                E assert 1 == False
 
-    tests/test_funcs1.py:6: AssertionError  </failure>
-  </testcase>
-  <testcase classname="tests.data.pytest.tests.test_funcs2" name="test_func3" file="tests/data/pytest/tests/test_funcs2.py" line="0" time="0.001" />
-  <testcase classname="tests.data.pytest.tests.test_funcs2" name="test_func4" file="tests/data/pytest/tests/test_funcs2.py" line="4" time="0.001" />
-  <testcase classname="tests.data.pytest.tests.fooo.func4_test" name="test_func6" file="tests/data/pytest/tests/fooo/func4_test.py" line="0" time="0.001" />
-  </testsuite>
+                tests/test_funcs1.py:9: AssertionError</failure>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_foo[2-0]" file="tests/test_funcs1.py"
+            line="11" time="0.000">
+            <properties>
+                <property name="name" value="parametrize" />
+                <property name="args" value="('y', [2, 3])" />
+                <property name="kwargs" value="{}" />
+                <property name="name" value="parametrize" />
+                <property name="args" value="('x', [0, 1])" />
+                <property name="kwargs" value="{}" />
+            </properties>
+            <failure message="assert 0 == 1">x = 0, y = 2
+
+                @pytest.mark.parametrize("x", [0, 1])
+                @pytest.mark.parametrize("y", [2, 3])
+                def test_foo(x, y):
+                &gt; assert x == 1
+                E assert 0 == 1
+
+                tests/test_funcs1.py:15: AssertionError</failure>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_foo[2-1]" file="tests/test_funcs1.py"
+            line="11" time="0.000">
+            <properties>
+                <property name="name" value="parametrize" />
+                <property name="args" value="('y', [2, 3])" />
+                <property name="kwargs" value="{}" />
+                <property name="name" value="parametrize" />
+                <property name="args" value="('x', [0, 1])" />
+                <property name="kwargs" value="{}" />
+            </properties>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_foo[3-0]" file="tests/test_funcs1.py"
+            line="11" time="0.000">
+            <properties>
+                <property name="name" value="parametrize" />
+                <property name="args" value="('y', [2, 3])" />
+                <property name="kwargs" value="{}" />
+                <property name="name" value="parametrize" />
+                <property name="args" value="('x', [0, 1])" />
+                <property name="kwargs" value="{}" />
+            </properties>
+            <failure message="assert 0 == 1">x = 0, y = 3
+
+                @pytest.mark.parametrize("x", [0, 1])
+                @pytest.mark.parametrize("y", [2, 3])
+                def test_foo(x, y):
+                &gt; assert x == 1
+                E assert 0 == 1
+
+                tests/test_funcs1.py:15: AssertionError</failure>
+        </testcase>
+        <testcase classname="tests.test_funcs1" name="test_foo[3-1]" file="tests/test_funcs1.py"
+            line="11" time="0.000">
+            <properties>
+                <property name="name" value="parametrize" />
+                <property name="args" value="('y', [2, 3])" />
+                <property name="kwargs" value="{}" />
+                <property name="name" value="parametrize" />
+                <property name="args" value="('x', [0, 1])" />
+                <property name="kwargs" value="{}" />
+            </properties>
+        </testcase>
+        <testcase classname="tests.test_funcs2" name="test_func3" file="tests/test_funcs2.py"
+            line="2" time="0.000">
+            <properties>
+                <property name="name" value="foo" />
+                <property name="args" value="()" />
+                <property name="kwargs" value="{}" />
+            </properties>
+        </testcase>
+        <testcase classname="tests.test_funcs2" name="test_func4" file="tests/test_funcs2.py"
+            line="7" time="0.000">
+            <properties>
+                <property name="name" value="bar" />
+                <property name="args" value="()" />
+                <property name="kwargs" value="{}" />
+            </properties>
+        </testcase>
+    </testsuite>
 </testsuites>

--- a/tests/data/pytest/tests/conftest.py
+++ b/tests/data/pytest/tests/conftest.py
@@ -1,0 +1,6 @@
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        for marker in item.iter_markers():
+            item.user_properties.append(("name", marker.name))
+            item.user_properties.append(("args", marker.args))
+            item.user_properties.append(("kwargs", marker.kwargs))

--- a/tests/data/pytest/tests/test_funcs1.py
+++ b/tests/data/pytest/tests/test_funcs1.py
@@ -1,6 +1,19 @@
+import pytest
+
+
+@pytest.mark.foo
 def test_func1():
     assert 1 == True  # noqa: E712
 
 
+@pytest.mark.bar
 def test_func2():
     assert 1 == False  # noqa: E712
+
+# Borrowed from https://docs.pytest.org/en/stable/how-to/parametrize.html#parametrizemark.
+
+
+@pytest.mark.parametrize("x", [0, 1])
+@pytest.mark.parametrize("y", [2, 3])
+def test_foo(x, y):
+    assert x == 1

--- a/tests/data/pytest/tests/test_funcs1.py
+++ b/tests/data/pytest/tests/test_funcs1.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore
 
 
 @pytest.mark.foo
@@ -9,6 +9,7 @@ def test_func1():
 @pytest.mark.bar
 def test_func2():
     assert 1 == False  # noqa: E712
+
 
 # Borrowed from https://docs.pytest.org/en/stable/how-to/parametrize.html#parametrizemark.
 

--- a/tests/data/pytest/tests/test_funcs2.py
+++ b/tests/data/pytest/tests/test_funcs2.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore
 
 
 @pytest.mark.foo

--- a/tests/data/pytest/tests/test_funcs2.py
+++ b/tests/data/pytest/tests/test_funcs2.py
@@ -1,6 +1,11 @@
+import pytest
+
+
+@pytest.mark.foo
 def test_func3():
     assert True == True  # noqa: E712
 
 
+@pytest.mark.bar
 def test_func4():
     assert False == False  # noqa: E712


### PR DESCRIPTION
This PR supports https://docs.pytest.org/en/stable/how-to/mark.html in Launchable CLI. Here is an example of an XML file when using marker object.

```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="pytest" errors="0" failures="4" skipped="0" tests="12" time="0.035"
        timestamp="2024-06-13T12:33:48.703447" hostname="ip-192-168-0-28.us-west-2.compute.internal">
        <testcase classname="tests.fooo.filenameonly_test" name="test_x"
            file="tests/fooo/filenameonly_test.py" line="0" time="0.000" />
        <testcase classname="tests.test_funcs1" name="test_func1" file="tests/test_funcs1.py"
            line="2" time="0.000">
            <properties>
                <property name="name" value="foo" />
                <property name="args" value="()" />
                <property name="kwargs" value="{}" />
            </properties>
        </testcase>
...
```