### PR TITLE
Set renovate package group rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {"matchPackagePrefixes": ["com.fasterxml.jackson.core"], "groupName": "jackson update group"}
   ]
 }


### PR DESCRIPTION
Want to update these jackson's updates at the same time


https://github.com/launchableinc/cli/pull/848
https://github.com/launchableinc/cli/pull/849
https://github.com/launchableinc/cli/pull/851

So, try to set renovate config ref: https://docs.renovatebot.com/configuration-options/#matchpackageprefixes