### PR TITLE
Improve smooth error handling

### DIFF
--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -202,8 +202,8 @@ def record_tests(client, test_result_files):
                 test_path=test_path_components,
                 duration_secs=duration_secs,
                 status=CaseEvent.STATUS_MAP[status],
-                stdout=case['stdout'],
-                stderr=case['stderr'],
+                stdout=case.get('stdout', ''),
+                stderr=case.get('stderr', ''),
                 timestamp=created_at,
                 data=metadata)
 

--- a/launchable/test_runners/raw.py
+++ b/launchable/test_runners/raw.py
@@ -179,13 +179,20 @@ def record_tests(client, test_result_files):
             if test_path:
                 test_path_components = parse_test_path(test_path)
             status = case['status']
-            duration_secs = case['duration'] or 0
-            created_at = case['createdAt'] or default_created_at
+            duration_secs = case.get('duration', 0)
+            if isinstance(duration_secs, str):
+                try:
+                    duration_secs = float(duration_secs)
+                except ValueError:
+                    raise ValueError("The duration of {} in {} isn't a valid format (was {}). Make sure set a valid duration".format(test_path_components, test_result_file, duration_secs))  # noqa
+
+            created_at = case.get('createdAt', default_created_at)
 
             if status not in CaseEvent.STATUS_MAP:
                 raise ValueError(
                     "The status of {} should be one of {} (was {})".format(test_path_components,
                                                                            list(CaseEvent.STATUS_MAP.keys()), status))
+
             if duration_secs < 0:
                 raise ValueError("The duration of {} should be positive (was {})".format(test_path_components, duration_secs))
             dateutil.parser.parse(created_at)

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -5,9 +5,8 @@ import tempfile
 from unittest import mock
 
 import dateutil.parser
-from dateutil.tz import tzlocal
-
 import responses  # type: ignore
+from dateutil.tz import tzlocal
 
 from launchable.utils.http_client import get_base_url
 from launchable.utils.session import write_build
@@ -208,7 +207,7 @@ class RawTest(CliTestCase):
                     '           "name": "testcase#899"',
                     '         }',
                     '       ],',
-                    '       "duration": 34,',
+                    '       "duration": "34",',  # set duration as string
                     '       "status": "TEST_PASSED",',
                     '       "stdout": "This is stdout",',
                     '       "stderr": "This is stderr",',


### PR DESCRIPTION
In the raw profile, we used `dict['key']` method with `or <default value>`. However if it doesn't define a target key, a default value won't used and `KeyError: '<TARGET KEY'` exception will be thrown.
So, I fixed to use `.get(<KEY>, <DEFAULT VALUE>)` instead of `dict['key'] or <DEFAULT VALUE>` style.

And, fixed when the user set duration as string type, we'll covert it to float (number)