### PR TITLE
Add the option to collect commit messages

### DIFF
--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -109,9 +109,7 @@ def exec_jar(source: str, max_days: int, app: Application, commit_message: bool)
         "{}/intake/".format(base_url),
         "-max-days",
         str(max_days),
-        "-scrub-pii",
-        "-commit-message",
-        str(commit_message)
+        "-scrub-pii"
     ])
 
     if Logger().logger.isEnabledFor(LOG_LEVEL_AUDIT):
@@ -120,6 +118,8 @@ def exec_jar(source: str, max_days: int, app: Application, commit_message: bool)
         command.append("-dry-run")
     if app.skip_cert_verification:
         command.append("-skip-cert-verification")
+    if commit_message:
+        command.append("-commit-message")
     command.append(cygpath(source))
 
     subprocess.run(

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -6,6 +6,9 @@ from urllib.parse import urlparse
 
 import click
 
+from launchable.utils.launchable_client import LaunchableClient
+from launchable.utils.tracking import Tracking, TrackingClient
+
 from ...app import Application
 from ...utils.commit_ingester import upload_commits
 from ...utils.env_keys import REPORT_ERROR_KEY
@@ -54,8 +57,25 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
         _import_git_log(import_git_log_output, ctx.obj)
         return
 
+    tracking_client = TrackingClient(Tracking.Command.COMMIT, app=ctx.obj)
+    client = LaunchableClient(tracking_client=tracking_client, app=ctx.obj)
+
+    # Commit messages are not collected in the default.
+    commit_message = False
     try:
-        exec_jar(os.path.abspath(source), max_days, ctx.obj)
+        res = client.request("get", "commits/collect/options")
+        res.raise_for_status()
+        commit_message = res.json().get("commitMessage", False)
+    except Exception as e:
+        tracking_client.send_error_event(
+            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
+            stack_trace=str(e),
+            api="commits/options",
+        )
+        client.print_exception_and_recover(e)
+
+    try:
+        exec_jar(os.path.abspath(source), max_days, ctx.obj, commit_message)
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):
             raise e
@@ -69,7 +89,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
             print(e)
 
 
-def exec_jar(source: str, max_days: int, app: Application):
+def exec_jar(source: str, max_days: int, app: Application, commit_message: bool):
     java = get_java_command()
 
     if not java:
@@ -90,6 +110,8 @@ def exec_jar(source: str, max_days: int, app: Application):
         "-max-days",
         str(max_days),
         "-scrub-pii",
+        "-commit-message",
+        str(commit_message)
     ])
 
     if Logger().logger.isEnabledFor(LOG_LEVEL_AUDIT):

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -32,6 +32,7 @@ class Tracking:
         RECORD_BUILD = 'RECORD_BUILD'
         RECORD_SESSION = 'RECORD_SESSION'
         SUBSET = 'SUBSET'
+        COMMIT = 'COMMIT'
 
 
 class TrackingClient:

--- a/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
@@ -270,9 +270,9 @@ public class CommitGraphCollector {
     return response;
   }
 
-    public void skipCommitMessage(boolean skipCommitMessage) {
-        this.skipCommitMessage = skipCommitMessage;
-    }
+  public void skipCommitMessage(boolean skipCommitMessage) {
+    this.skipCommitMessage = skipCommitMessage;
+  }
 
   public void setMaxDays(int days) {
     this.maxDays = days;

--- a/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
@@ -74,6 +74,8 @@ public class CommitGraphCollector {
 
   private int commitsSent;
 
+  private boolean skipCommitMessage;
+
   private int maxDays;
 
   private boolean audit;
@@ -268,6 +270,10 @@ public class CommitGraphCollector {
     return response;
   }
 
+    public void skipCommitMessage(boolean skipCommitMessage) {
+        this.skipCommitMessage = skipCommitMessage;
+    }
+
   public void setMaxDays(int days) {
     this.maxDays = days;
   }
@@ -381,6 +387,7 @@ public class CommitGraphCollector {
     private JSCommit transform(RevCommit r) throws IOException {
       JSCommit c = new JSCommit();
       c.setCommitHash(r.name());
+      c.setMessage(skipCommitMessage ? "" : r.getFullMessage());
 
       PersonIdent author = r.getAuthorIdent();
       c.setAuthorEmailAddress(JSCommit.hashEmail(author.getEmailAddress()));

--- a/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
@@ -74,7 +74,7 @@ public class CommitGraphCollector {
 
   private int commitsSent;
 
-  private boolean skipCommitMessage;
+  private boolean collectCommitMessage;
 
   private int maxDays;
 
@@ -270,8 +270,8 @@ public class CommitGraphCollector {
     return response;
   }
 
-  public void skipCommitMessage(boolean skipCommitMessage) {
-    this.skipCommitMessage = skipCommitMessage;
+  public void collectCommitMessage(boolean commitMessage) {
+    this.collectCommitMessage = commitMessage;
   }
 
   public void setMaxDays(int days) {
@@ -387,7 +387,7 @@ public class CommitGraphCollector {
     private JSCommit transform(RevCommit r) throws IOException {
       JSCommit c = new JSCommit();
       c.setCommitHash(r.name());
-      c.setMessage(skipCommitMessage ? "" : r.getFullMessage());
+      c.setMessage(collectCommitMessage ? r.getFullMessage() : "");
 
       PersonIdent author = r.getAuthorIdent();
       c.setAuthorEmailAddress(JSCommit.hashEmail(author.getEmailAddress()));

--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -67,8 +67,6 @@ public class CommitIngester {
   public static void main(String[] args) throws Exception {
     CommitIngester ingester = new CommitIngester();
     CmdLineParser parser = new CmdLineParser(ingester);
-    System.out.println("debugg");
-    System.out.println(args);
     try {
       parser.parseArgument(args);
       ingester.run();

--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -47,10 +47,6 @@ public class CommitIngester {
   @Option(name = "-scrub-pii", usage = "Scrub emails and names", hidden = true)
   public boolean scrubPii;
 
-  /**
-   * @deprecated this is an old option and this is off always.
-   */
-  @Deprecated
   @Option(name = "-commit-message", usage = "Collect commit messages")
   public boolean commitMessage;
 
@@ -145,6 +141,7 @@ public class CommitIngester {
       cgc.setMaxDays(maxDays);
       cgc.setAudit(audit);
       cgc.setDryRun(dryRun);
+      cgc.skipCommitMessage(commitMessage);
       cgc.transfer(endpoint, authenticator);
       int numCommits = cgc.getCommitsSent();
       String suffix = "commit";

--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -67,6 +67,8 @@ public class CommitIngester {
   public static void main(String[] args) throws Exception {
     CommitIngester ingester = new CommitIngester();
     CmdLineParser parser = new CmdLineParser(ingester);
+    System.out.println("debugg");
+    System.out.println(args);
     try {
       parser.parseArgument(args);
       ingester.run();

--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -141,7 +141,7 @@ public class CommitIngester {
       cgc.setMaxDays(maxDays);
       cgc.setAudit(audit);
       cgc.setDryRun(dryRun);
-      cgc.skipCommitMessage(commitMessage);
+      cgc.collectCommitMessage(commitMessage);
       cgc.transfer(endpoint, authenticator);
       int numCommits = cgc.getCommitsSent();
       String suffix = "commit";

--- a/src/main/java/com/launchableinc/ingest/commits/JSCommit.java
+++ b/src/main/java/com/launchableinc/ingest/commits/JSCommit.java
@@ -31,8 +31,8 @@ public class JSCommit {
   /** Time zone offset in minutes. For example, JST is +9:00 so this field is 540. */
   private int committerTimezoneOffset;
 
-/** Commit message. */
-private String message;
+  /** Commit message. */
+  private String message;
 
   private Map<String, List<JSFileChange>> parentHashes = new HashMap<>();
 
@@ -100,11 +100,11 @@ private String message;
     return EMAIL_HASHER.newHasher().putString(email, StandardCharsets.UTF_8).hash().toString();
   }
 
-    public String getMessage() {
-        return message;
-    }
+  public String getMessage() {
+    return message;
+  }
 
-    public void setMessage(String message) {
-        this.message = message;
-    }
+  public void setMessage(String message) {
+    this.message = message;
+  }
 }

--- a/src/main/java/com/launchableinc/ingest/commits/JSCommit.java
+++ b/src/main/java/com/launchableinc/ingest/commits/JSCommit.java
@@ -31,6 +31,9 @@ public class JSCommit {
   /** Time zone offset in minutes. For example, JST is +9:00 so this field is 540. */
   private int committerTimezoneOffset;
 
+/** Commit message. */
+private String message;
+
   private Map<String, List<JSFileChange>> parentHashes = new HashMap<>();
 
   public String getCommitHash() {
@@ -96,4 +99,12 @@ public class JSCommit {
   public static String hashEmail(String email) {
     return EMAIL_HASHER.newHasher().putString(email, StandardCharsets.UTF_8).hash().toString();
   }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -178,6 +178,14 @@ class CliTestCase(unittest.TestCase):
                 self.workspace),
             json={'keys': ["GITHUB_ACTOR", "BRANCH_NAME"]},
             status=200)
+        responses.add(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/commits/collect/options".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={'commitMessage': True},
+            status=200)
 
     def get_test_files_dir(self):
         file_name = Path(inspect.getfile(self.__class__))  # obtain the file of the concrete type

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -111,6 +111,14 @@ class APIErrorTest(CliTestCase):
         host, port = success_server.server_address
         endpoint = "http://{}:{}".format(host, port)
         with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
+            responses.add(
+                responses.GET,
+                "{}/intake/organizations/{}/workspaces/{}/commits/collect/options".format(
+                    get_base_url(),
+                    self.organization,
+                    self.workspace),
+                json={'commitMessage': True},
+                status=200)
             responses.add(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds".format(
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
             tracking = responses.add(
@@ -137,6 +145,14 @@ class APIErrorTest(CliTestCase):
         endpoint = "http://{}:{}".format(host, port)
 
         with mock.patch.dict(os.environ, {BASE_URL_KEY: endpoint}):
+            responses.add(
+                responses.GET,
+                "{}/intake/organizations/{}/workspaces/{}/commits/collect/options".format(
+                    get_base_url(),
+                    self.organization,
+                    self.workspace),
+                json={'commitMessage': True},
+                status=200)
             responses.add(responses.POST, "{base}/intake/organizations/{org}/workspaces/{ws}/builds".format(
                 base=get_base_url(), org=self.organization, ws=self.workspace), status=500)
             tracking = responses.add(


### PR DESCRIPTION
Currently, Launchable CLI does not collect commit messages because of security concern, but we'll add the option to collect them since we plan to display commit information in the test session detail page. In the default, we don't collect commit messages.

https://app.launchableinc.com/organizations/demo/workspaces/demov2/data/test-sessions/193372?tab=commits is an example, we'll display the commit message instead of the commit hash if we have the commit message data.