### PR TITLE
Improve diagnosability

### DIFF
--- a/launchable/utils/http_client.py
+++ b/launchable/utils/http_client.py
@@ -4,6 +4,7 @@ import os
 import platform
 from typing import IO, BinaryIO, Dict, Optional, Tuple, Union
 
+import click
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry  # type: ignore
@@ -120,7 +121,27 @@ class _HttpClient:
         if self.test_runner != "":
             h["User-Agent"] = h["User-Agent"] + " TestRunner/{}".format(self.test_runner)
 
+        ctx = click.get_current_context(silent=True)
+        if ctx:
+            h["User-Agent"] = h["User-Agent"] + " Command/{}".format(format_context(ctx))
+
         return {**h, **authentication_headers()}
+
+
+def format_context(ctx: click.Context) -> str:
+    """
+    So that our CSMs can better understand how the users are invoking us,
+    capture the implicit command invocations and PID. This way we can correlate
+    the server side log with what each client session is doing.
+
+    When commands like `record tests` internally invoke `record session`, so long as it goes through
+    `context.invoke()` it appears in the nested context chain
+    """
+    cmds = []
+    while ctx:
+        cmds.append(ctx.command.name)
+        ctx = ctx.parent
+    return '%s(%s)' % ('>'.join(cmds), os.getpid())
 
 
 def _file_to_generator(f: IO, chunk_size=4096):


### PR DESCRIPTION
Allow the server side to map which API requests map to which client invocation.

User-agent header can be seen & processed in Datadog. Often we struggle to understand how customers are integrating us in the CI script, and this will give us a key insight.