### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:8
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM circleci/openjdk:8
+FROM eclipse-temurin:21
 
 USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   python3-setuptools \
-  python3-pip \
+  pipx \
   && apt-get -y clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir wheel
-RUN pip3 install --no-cache-dir launchable
+ENV PATH="$PATH:/root/.local/bin"
+
+RUN pipx install wheel
+RUN pipx install launchable


### PR DESCRIPTION
* `circleci/openjdk` is deprecated now, so I'm going to update the docker image.
  * https://github.com/CircleCI-Archived/circleci-dockerfiles
* pipx3 installation failed and here is the log, so I substitute `pipx` instead.

```
> [3/4] RUN pip3 install --no-cache-dir wheel:
0.250 error: externally-managed-environment
0.250 
0.250 × This environment is externally managed
0.250 ╰─> To install Python packages system-wide, try apt install
0.250     python3-xyz, where xyz is the package you are trying to
0.250     install.
0.250     
0.250     If you wish to install a non-Debian-packaged Python package,
0.250     create a virtual environment using python3 -m venv path/to/venv.
0.250     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.250     sure you have python3-full installed.
0.250     
0.250     If you wish to install a non-Debian packaged Python application,
0.250     it may be easiest to use pipx install xyz, which will manage a
0.250     virtual environment for you. Make sure you have pipx installed.
0.250     
0.250     See /usr/share/doc/python3.12/README.venv for more information.
0.250 
0.250 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.250 hint: See PEP 668 for the detailed specification.
```