### PR TITLE
add timedOut test case

### DIFF
--- a/launchable/test_runners/playwright.py
+++ b/launchable/test_runners/playwright.py
@@ -222,9 +222,10 @@ class JSONReportParser:
         return events
 
     def _case_event_status_from_str(self, status_str: str) -> int:
+        # see: https://playwright.dev/docs/api/class-testresult#test-result-status
         if status_str == "passed":
             return CaseEvent.TEST_PASSED
-        elif status_str == "failed":
+        elif status_str == "failed" or status_str == "timedOut" or status_str == "interrupted":
             return CaseEvent.TEST_FAILED
         elif status_str == "skipped":
             return CaseEvent.TEST_SKIPPED

--- a/tests/data/playwright/record_test_result.json
+++ b/tests/data/playwright/record_test_result.json
@@ -12,7 +12,7 @@
           "name": "New Todo \u203a should allow me to add todo items"
         }
       ],
-      "duration": 1.22,
+      "duration": 0.715,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -30,7 +30,7 @@
           "name": "New Todo \u203a should clear text input field when an item is added"
         }
       ],
-      "duration": 1.198,
+      "duration": 0.692,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -48,7 +48,7 @@
           "name": "New Todo \u203a should append new items to the bottom of the list"
         }
       ],
-      "duration": 1.24,
+      "duration": 0.742,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -66,7 +66,7 @@
           "name": "Mark all as completed \u203a should allow me to mark all items as completed"
         }
       ],
-      "duration": 1.291,
+      "duration": 0.799,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -84,7 +84,7 @@
           "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
         }
       ],
-      "duration": 1.316,
+      "duration": 0.844,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -102,7 +102,7 @@
           "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
         }
       ],
-      "duration": 0.467,
+      "duration": 0.648,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -120,7 +120,7 @@
           "name": "Item \u203a should allow me to mark items as complete"
         }
       ],
-      "duration": 0.409,
+      "duration": 0.579,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -138,7 +138,7 @@
           "name": "Item \u203a should allow me to un-mark items as complete"
         }
       ],
-      "duration": 0.422,
+      "duration": 0.622,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -156,7 +156,7 @@
           "name": "Item \u203a should allow me to edit an item"
         }
       ],
-      "duration": 0.392,
+      "duration": 0.578,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -172,1122 +172,6 @@
         {
           "type": "testcase",
           "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.404,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.382,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.393,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.392,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.39,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.318,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.35,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
-        }
-      ],
-      "duration": 0.387,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
-        }
-      ],
-      "duration": 0.383,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
-        }
-      ],
-      "duration": 0.423,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
-        }
-      ],
-      "duration": 0.385,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should respect the back button"
-        }
-      ],
-      "duration": 0.47,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display completed items"
-        }
-      ],
-      "duration": 0.396,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display all items"
-        }
-      ],
-      "duration": 0.451,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should highlight the currently applied filter"
-        }
-      ],
-      "duration": 0.395,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/example.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "has title"
-        }
-      ],
-      "duration": 0.513,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/example.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "get started link"
-        }
-      ],
-      "duration": 5.417,
-      "status": 0,
-      "stdout": "",
-      "stderr": "\n  [chromium] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should allow me to add todo items"
-        }
-      ],
-      "duration": 24.745,
-      "status": 2,
-      "stdout": "",
-      "stderr": "\n",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should clear text input field when an item is added"
-        }
-      ],
-      "duration": 1.02,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should append new items to the bottom of the list"
-        }
-      ],
-      "duration": 1.068,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
-        }
-      ],
-      "duration": 1.211,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
-        }
-      ],
-      "duration": 0.565,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
-        }
-      ],
-      "duration": 0.621,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to mark items as complete"
-        }
-      ],
-      "duration": 0.551,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to un-mark items as complete"
-        }
-      ],
-      "duration": 0.499,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to edit an item"
-        }
-      ],
-      "duration": 0.462,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.449,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.446,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.455,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.442,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.47,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.386,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.443,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
-        }
-      ],
-      "duration": 0.462,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
-        }
-      ],
-      "duration": 0.453,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
-        }
-      ],
-      "duration": 0.619,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
-        }
-      ],
-      "duration": 0.504,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should respect the back button"
-        }
-      ],
-      "duration": 0.608,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display completed items"
-        }
-      ],
-      "duration": 0.478,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display all items"
-        }
-      ],
-      "duration": 0.576,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should highlight the currently applied filter"
-        }
-      ],
-      "duration": 0.504,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/example.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "has title"
-        }
-      ],
-      "duration": 0.346,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/example.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "get started link"
-        }
-      ],
-      "duration": 6.048,
-      "status": 0,
-      "stdout": "",
-      "stderr": "\n  [firefox] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should allow me to add todo items"
-        }
-      ],
-      "duration": 0.778,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should clear text input field when an item is added"
-        }
-      ],
-      "duration": 0.746,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should append new items to the bottom of the list"
-        }
-      ],
-      "duration": 0.853,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
-        }
-      ],
-      "duration": 0.576,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
-        }
-      ],
-      "duration": 0.583,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
-        }
-      ],
-      "duration": 0.639,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to mark items as complete"
-        }
-      ],
-      "duration": 0.501,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to un-mark items as complete"
-        }
-      ],
-      "duration": 0.512,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to edit an item"
-        }
-      ],
-      "duration": 0.558,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.487,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.512,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.505,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.493,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.498,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.428,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.501,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
-        }
-      ],
-      "duration": 0.52,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
-        }
-      ],
-      "duration": 0.519,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
-        }
-      ],
-      "duration": 0.549,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": null
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
         }
       ],
       "duration": 0.532,
@@ -1305,10 +189,190 @@
         },
         {
           "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.394,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.423,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.429,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.418,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.348,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.38,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.424,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.418,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.441,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
           "name": "Routing \u203a should respect the back button"
         }
       ],
-      "duration": 0.617,
+      "duration": 0.471,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1326,7 +390,7 @@
           "name": "Routing \u203a should allow me to display completed items"
         }
       ],
-      "duration": 0.529,
+      "duration": 0.418,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1344,7 +408,7 @@
           "name": "Routing \u203a should allow me to display all items"
         }
       ],
-      "duration": 0.59,
+      "duration": 0.466,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1362,7 +426,7 @@
           "name": "Routing \u203a should highlight the currently applied filter"
         }
       ],
-      "duration": 0.511,
+      "duration": 0.414,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1380,7 +444,7 @@
           "name": "has title"
         }
       ],
-      "duration": 0.485,
+      "duration": 0.526,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1398,10 +462,1216 @@
           "name": "get started link"
         }
       ],
-      "duration": 5.586,
-      "status": 0,
+      "duration": 0.552,
+      "status": 1,
       "stdout": "",
-      "stderr": "\n  [webkit] \u203a tests/example.spec.ts:10:5 \u203a get started link \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()\n\n    Locator: getByRole('heading', { name: 'Installation!' })\n    Expected: visible\n    Received: hidden\n    Call log:\n      - expect.toBeVisible with timeout 5000ms\n      - waiting for getByRole('heading', { name: 'Installation!' })\n\n\n      15 |\n      16 |   // Expects page to have a heading with the name of Installation.\n    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();\n         |                                                                      ^\n      18 | });\n      19 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 16.859,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-chromium-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 16.74,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-example-retry-chromium-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.298,
+      "status": 0,
+      "stdout": "\n\n[[ATTACHMENT|test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip]]\n\n",
+      "stderr": "\n  [chromium] \u203a tests/timeout-example.spec.ts:3:5 \u203a time-out \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #1 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    attachment #1: trace (application/zip) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n    test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip\n    Usage:\n\n        npx playwright show-trace test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip\n\n    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Retry #2 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #3 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should allow me to add todo items"
+        }
+      ],
+      "duration": 0.973,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should clear text input field when an item is added"
+        }
+      ],
+      "duration": 0.909,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should append new items to the bottom of the list"
+        }
+      ],
+      "duration": 0.94,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
+        }
+      ],
+      "duration": 0.586,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
+        }
+      ],
+      "duration": 0.578,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.625,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.528,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.514,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.569,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.46,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.459,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.469,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.374,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.449,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.488,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.507,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.651,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.522,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.712,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display completed items"
+        }
+      ],
+      "duration": 0.582,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display all items"
+        }
+      ],
+      "duration": 0.733,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should highlight the currently applied filter"
+        }
+      ],
+      "duration": 0.554,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.446,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "get started link"
+        }
+      ],
+      "duration": 0.597,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 18.529,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-firefox-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 18.435,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-example-retry-firefox-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 1.287,
+      "status": 0,
+      "stdout": "\n\n[[ATTACHMENT|test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip]]\n\n",
+      "stderr": "\n  [firefox] \u203a tests/timeout-example.spec.ts:3:5 \u203a time-out \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #1 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    attachment #1: trace (application/zip) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n    test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip\n    Usage:\n\n        npx playwright show-trace test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip\n\n    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Retry #2 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #3 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should allow me to add todo items"
+        }
+      ],
+      "duration": 0.695,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should clear text input field when an item is added"
+        }
+      ],
+      "duration": 0.545,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "New Todo \u203a should append new items to the bottom of the list"
+        }
+      ],
+      "duration": 0.612,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
+        }
+      ],
+      "duration": 0.618,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
+        }
+      ],
+      "duration": 0.644,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.755,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.586,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 1.075,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.596,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.639,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.589,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.613,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.632,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.599,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.553,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.582,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.537,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.537,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.535,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.522,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.619,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display completed items"
+        }
+      ],
+      "duration": 0.534,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display all items"
+        }
+      ],
+      "duration": 0.597,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should highlight the currently applied filter"
+        }
+      ],
+      "duration": 0.542,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.506,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "get started link"
+        }
+      ],
+      "duration": 0.643,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 17.206,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-webkit-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-and-skip-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 17.145,
+      "status": 1,
+      "stdout": "\nRetry count: [33m0[39m\nRetry count: [33m1[39m\n\n[[ATTACHMENT|test-results/tests-retry-example-retry-webkit-retry1/trace.zip]]\nRetry count: [33m2[39m\nRetry count: [33m3[39m\n\n",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "\n",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.614,
+      "status": 0,
+      "stdout": "\n\n[[ATTACHMENT|test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip]]\n\n",
+      "stderr": "\n  [webkit] \u203a tests/timeout-example.spec.ts:3:5 \u203a time-out \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #1 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    attachment #1: trace (application/zip) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n    test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip\n    Usage:\n\n        npx playwright show-trace test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip\n\n    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Retry #2 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n    Retry #3 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    Test timeout of 1ms exceeded.\n\n    Error: page.goto: Test timeout of 1ms exceeded.\n    Call log:\n      - navigating to \"https://playwright.dev/\", waiting until \"load\"\n\n\n      3 | test(\"time-out\", async ({ page }, testInfo) => {\n      4 |   test.setTimeout(1);\n    > 5 |   await page.goto(\"https://playwright.dev/\");\n        |              ^\n      6 |   await expect(page).toHaveTitle(new RegExp(\"Playwright\"));\n      7 | });\n      8 |\n\n        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\n\n",
       "data": null
     }
   ],

--- a/tests/data/playwright/record_test_result_with_json.json
+++ b/tests/data/playwright/record_test_result_with_json.json
@@ -12,7 +12,7 @@
           "name": "New Todo \u203a should allow me to add todo items"
         }
       ],
-      "duration": 1.011,
+      "duration": 0.715,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -32,7 +32,7 @@
           "name": "New Todo \u203a should allow me to add todo items"
         }
       ],
-      "duration": 1.212,
+      "duration": 0.973,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -52,7 +52,7 @@
           "name": "New Todo \u203a should allow me to add todo items"
         }
       ],
-      "duration": 0.874,
+      "duration": 0.695,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -70,946 +70,6 @@
         {
           "type": "testcase",
           "name": "New Todo \u203a should clear text input field when an item is added"
-        }
-      ],
-      "duration": 0.992,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 38
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should clear text input field when an item is added"
-        }
-      ],
-      "duration": 1.164,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 38
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should clear text input field when an item is added"
-        }
-      ],
-      "duration": 0.826,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 38
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should append new items to the bottom of the list"
-        }
-      ],
-      "duration": 1.035,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 53
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should append new items to the bottom of the list"
-        }
-      ],
-      "duration": 1.269,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 53
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "New Todo \u203a should append new items to the bottom of the list"
-        }
-      ],
-      "duration": 0.595,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 53
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
-        }
-      ],
-      "duration": 1.093,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 84
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
-        }
-      ],
-      "duration": 1.165,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 84
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
-        }
-      ],
-      "duration": 0.684,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 84
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
-        }
-      ],
-      "duration": 1.133,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 97
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
-        }
-      ],
-      "duration": 0.701,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 97
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
-        }
-      ],
-      "duration": 0.698,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 97
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
-        }
-      ],
-      "duration": 0.53,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 109
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
-        }
-      ],
-      "duration": 0.818,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 109
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
-        }
-      ],
-      "duration": 0.675,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 109
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to mark items as complete"
-        }
-      ],
-      "duration": 0.43,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 133
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to mark items as complete"
-        }
-      ],
-      "duration": 0.679,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 133
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to mark items as complete"
-        }
-      ],
-      "duration": 0.68,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 133
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to un-mark items as complete"
-        }
-      ],
-      "duration": 0.461,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 158
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to un-mark items as complete"
-        }
-      ],
-      "duration": 0.688,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 158
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to un-mark items as complete"
-        }
-      ],
-      "duration": 0.69,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 158
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to edit an item"
-        }
-      ],
-      "duration": 0.438,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 183
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to edit an item"
-        }
-      ],
-      "duration": 0.619,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 183
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Item \u203a should allow me to edit an item"
-        }
-      ],
-      "duration": 0.703,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 183
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.429,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 213
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.557,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 213
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should hide other controls when editing"
-        }
-      ],
-      "duration": 0.538,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 213
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.438,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 225
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.579,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 225
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should save edits on blur"
-        }
-      ],
-      "duration": 0.621,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 225
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.493,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 245
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.565,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 245
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should trim entered text"
-        }
-      ],
-      "duration": 0.828,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 245
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.507,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 265
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.545,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 265
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should remove the item if an empty text string was entered"
-        }
-      ],
-      "duration": 0.509,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 265
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.517,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 279
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.558,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 279
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Editing \u203a should cancel edits on escape"
-        }
-      ],
-      "duration": 0.613,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 279
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.431,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 295
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.466,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 295
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Counter \u203a should display the current number of todo items"
-        }
-      ],
-      "duration": 0.523,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 295
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.39,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 320
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.477,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 320
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should display the correct text"
-        }
-      ],
-      "duration": 0.501,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 320
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
-        }
-      ],
-      "duration": 0.414,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 327
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
-        }
-      ],
-      "duration": 0.578,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 327
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/demo-todo-app.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "Clear completed button \u203a should remove completed items when clicked"
         }
       ],
       "duration": 0.692,
@@ -1017,7 +77,7 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 327
+        "lineNumber": 40
       }
     },
     {
@@ -1029,15 +89,15 @@
         },
         {
           "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+          "name": "New Todo \u203a should clear text input field when an item is added"
         }
       ],
-      "duration": 0.41,
+      "duration": 0.909,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 335
+        "lineNumber": 40
       }
     },
     {
@@ -1049,15 +109,15 @@
         },
         {
           "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+          "name": "New Todo \u203a should clear text input field when an item is added"
         }
       ],
-      "duration": 0.56,
+      "duration": 0.545,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 335
+        "lineNumber": 40
       }
     },
     {
@@ -1069,15 +129,15 @@
         },
         {
           "type": "testcase",
-          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+          "name": "New Todo \u203a should append new items to the bottom of the list"
         }
       ],
-      "duration": 0.577,
+      "duration": 0.742,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 335
+        "lineNumber": 53
       }
     },
     {
@@ -1089,15 +149,15 @@
         },
         {
           "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
+          "name": "New Todo \u203a should append new items to the bottom of the list"
         }
       ],
-      "duration": 0.445,
+      "duration": 0.94,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 347
+        "lineNumber": 53
       }
     },
     {
@@ -1109,15 +169,15 @@
         },
         {
           "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
+          "name": "New Todo \u203a should append new items to the bottom of the list"
         }
       ],
-      "duration": 0.76,
+      "duration": 0.612,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 347
+        "lineNumber": 53
       }
     },
     {
@@ -1129,15 +189,15 @@
         },
         {
           "type": "testcase",
-          "name": "Persistence \u203a should persist its data"
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
         }
       ],
-      "duration": 0.6,
+      "duration": 0.799,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 347
+        "lineNumber": 82
       }
     },
     {
@@ -1149,15 +209,15 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
         }
       ],
-      "duration": 0.422,
+      "duration": 0.586,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 383
+        "lineNumber": 82
       }
     },
     {
@@ -1169,15 +229,15 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
+          "name": "Mark all as completed \u203a should allow me to mark all items as completed"
         }
       ],
-      "duration": 0.679,
+      "duration": 0.618,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 383
+        "lineNumber": 82
       }
     },
     {
@@ -1189,15 +249,15 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should allow me to display active items"
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
         }
       ],
-      "duration": 0.643,
+      "duration": 0.844,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 383
+        "lineNumber": 91
       }
     },
     {
@@ -1209,15 +269,15 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should respect the back button"
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
         }
       ],
-      "duration": 0.485,
+      "duration": 0.578,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 393
+        "lineNumber": 91
       }
     },
     {
@@ -1229,15 +289,15 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should respect the back button"
+          "name": "Mark all as completed \u203a should allow me to clear the complete state of all items"
         }
       ],
-      "duration": 0.812,
+      "duration": 0.644,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 393
+        "lineNumber": 91
       }
     },
     {
@@ -1249,7 +309,287 @@
         },
         {
           "type": "testcase",
-          "name": "Routing \u203a should respect the back button"
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.648,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 101
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.625,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 101
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Mark all as completed \u203a complete all checkbox should update state when items are completed / cleared"
+        }
+      ],
+      "duration": 0.755,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 101
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.579,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 124
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.528,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 124
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to mark items as complete"
+        }
+      ],
+      "duration": 0.586,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 124
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.622,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 149
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 0.514,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 149
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to un-mark items as complete"
+        }
+      ],
+      "duration": 1.075,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 149
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.578,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 174
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.569,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 174
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Item \u203a should allow me to edit an item"
+        }
+      ],
+      "duration": 0.596,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 174
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.532,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 200
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 200
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should hide other controls when editing"
         }
       ],
       "duration": 0.639,
@@ -1257,7 +597,667 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 393
+        "lineNumber": 200
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.394,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 210
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.46,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 210
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should save edits on blur"
+        }
+      ],
+      "duration": 0.589,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 210
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.423,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 224
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.459,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 224
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should trim entered text"
+        }
+      ],
+      "duration": 0.613,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 224
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.429,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 238
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.469,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 238
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should remove the item if an empty text string was entered"
+        }
+      ],
+      "duration": 0.632,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 238
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.418,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 250
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 250
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Editing \u203a should cancel edits on escape"
+        }
+      ],
+      "duration": 0.599,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 250
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.348,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 260
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.374,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 260
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Counter \u203a should display the current number of todo items"
+        }
+      ],
+      "duration": 0.553,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 260
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.38,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 285
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.449,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 285
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should display the correct text"
+        }
+      ],
+      "duration": 0.582,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 285
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.424,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 290
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.488,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 290
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should remove completed items when clicked"
+        }
+      ],
+      "duration": 0.537,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 290
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.418,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 298
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.507,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 298
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Clear completed button \u203a should be hidden when there are no items that are completed"
+        }
+      ],
+      "duration": 0.537,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 298
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.457,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 306
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.651,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 306
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Persistence \u203a should persist its data"
+        }
+      ],
+      "duration": 0.535,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 306
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.441,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 342
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.522,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 342
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should allow me to display active items"
+        }
+      ],
+      "duration": 0.522,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 342
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.471,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 352
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.712,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 352
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/demo-todo-app.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "Routing \u203a should respect the back button"
+        }
+      ],
+      "duration": 0.619,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 352
       }
     },
     {
@@ -1272,12 +1272,12 @@
           "name": "Routing \u203a should allow me to display completed items"
         }
       ],
-      "duration": 0.417,
+      "duration": 0.418,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 419
+        "lineNumber": 378
       }
     },
     {
@@ -1292,12 +1292,12 @@
           "name": "Routing \u203a should allow me to display completed items"
         }
       ],
-      "duration": 0.683,
+      "duration": 0.582,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 419
+        "lineNumber": 378
       }
     },
     {
@@ -1312,12 +1312,12 @@
           "name": "Routing \u203a should allow me to display completed items"
         }
       ],
-      "duration": 0.761,
+      "duration": 0.534,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 419
+        "lineNumber": 378
       }
     },
     {
@@ -1332,12 +1332,12 @@
           "name": "Routing \u203a should allow me to display all items"
         }
       ],
-      "duration": 0.479,
+      "duration": 0.466,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 426
+        "lineNumber": 385
       }
     },
     {
@@ -1352,12 +1352,12 @@
           "name": "Routing \u203a should allow me to display all items"
         }
       ],
-      "duration": 0.784,
+      "duration": 0.733,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 426
+        "lineNumber": 385
       }
     },
     {
@@ -1372,12 +1372,12 @@
           "name": "Routing \u203a should allow me to display all items"
         }
       ],
-      "duration": 0.663,
+      "duration": 0.597,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 426
+        "lineNumber": 385
       }
     },
     {
@@ -1397,7 +1397,7 @@
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 435
+        "lineNumber": 394
       }
     },
     {
@@ -1412,12 +1412,12 @@
           "name": "Routing \u203a should highlight the currently applied filter"
         }
       ],
-      "duration": 0.684,
+      "duration": 0.554,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 435
+        "lineNumber": 394
       }
     },
     {
@@ -1432,12 +1432,12 @@
           "name": "Routing \u203a should highlight the currently applied filter"
         }
       ],
-      "duration": 0.688,
+      "duration": 0.542,
       "status": 1,
       "stdout": "",
       "stderr": "",
       "data": {
-        "lineNumber": 435
+        "lineNumber": 394
       }
     },
     {
@@ -1452,27 +1452,7 @@
           "name": "has title"
         }
       ],
-      "duration": 0.359,
-      "status": 1,
-      "stdout": "",
-      "stderr": "",
-      "data": {
-        "lineNumber": 3
-      }
-    },
-    {
-      "type": "case",
-      "testPath": [
-        {
-          "type": "file",
-          "name": "tests/example.spec.ts"
-        },
-        {
-          "type": "testcase",
-          "name": "has title"
-        }
-      ],
-      "duration": 0.529,
+      "duration": 0.526,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1492,7 +1472,27 @@
           "name": "has title"
         }
       ],
-      "duration": 0.581,
+      "duration": 0.446,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "has title"
+        }
+      ],
+      "duration": 0.506,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1512,7 +1512,7 @@
           "name": "get started link"
         }
       ],
-      "duration": 0.593,
+      "duration": 0.552,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1532,7 +1532,7 @@
           "name": "get started link"
         }
       ],
-      "duration": 0.853,
+      "duration": 0.597,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1552,7 +1552,7 @@
           "name": "get started link"
         }
       ],
-      "duration": 0.83,
+      "duration": 0.643,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -1572,7 +1572,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.32,
+      "duration": 5.346,
       "status": 0,
       "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1592,10 +1592,10 @@
           "name": "retry"
         }
       ],
-      "duration": 5.681,
+      "duration": 5.556,
       "status": 0,
       "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
-      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
       "data": {
         "lineNumber": 3
       }
@@ -1612,7 +1612,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.503,
+      "duration": 5.404,
       "status": 0,
       "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1632,7 +1632,7 @@
           "name": "retry"
         }
       ],
-      "duration": 0.398,
+      "duration": 0.553,
       "status": 1,
       "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
       "stderr": "",
@@ -1652,10 +1652,10 @@
           "name": "retry"
         }
       ],
-      "duration": 5.433,
+      "duration": 5.542,
       "status": 0,
       "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
-      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
       "data": {
         "lineNumber": 3
       }
@@ -1672,7 +1672,7 @@
           "name": "retry"
         }
       ],
-      "duration": 6.139,
+      "duration": 6.203,
       "status": 0,
       "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1692,7 +1692,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.824,
+      "duration": 6.017,
       "status": 0,
       "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1712,7 +1712,7 @@
           "name": "retry"
         }
       ],
-      "duration": 0.805,
+      "duration": 0.767,
       "status": 1,
       "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
       "stderr": "",
@@ -1732,7 +1732,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.589,
+      "duration": 5.528,
       "status": 0,
       "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1752,7 +1752,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.719,
+      "duration": 5.633,
       "status": 0,
       "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1772,7 +1772,7 @@
           "name": "retry"
         }
       ],
-      "duration": 5.509,
+      "duration": 5.502,
       "status": 0,
       "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
       "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m",
@@ -1792,7 +1792,7 @@
           "name": "retry"
         }
       ],
-      "duration": 0.614,
+      "duration": 0.543,
       "status": 1,
       "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
       "stderr": "",
@@ -1858,6 +1858,546 @@
       "stderr": "",
       "data": {
         "lineNumber": 10
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.333,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.562,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.374,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 0.471,
+      "status": 1,
+      "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
+      "stderr": "",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.458,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 6.172,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 6.014,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 0.791,
+      "status": 1,
+      "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
+      "stderr": "",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.526,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m0\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.634,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m1\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 5.522,
+      "status": 0,
+      "stdout": "Retry count: \u001b[33m2\u001b[39m\n",
+      "stderr": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-\u2026>\u2026</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "retry"
+        }
+      ],
+      "duration": 0.463,
+      "status": 1,
+      "stdout": "Retry count: \u001b[33m3\u001b[39m\n",
+      "stderr": "",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 10
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 10
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/retry-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "skip this test"
+        }
+      ],
+      "duration": 0.0,
+      "status": 2,
+      "stdout": "",
+      "stderr": "",
+      "data": {
+        "lineNumber": 10
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.05,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.079,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.07,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.099,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.07,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.382,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.455,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.38,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.125,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.175,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.155,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
+      }
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "file",
+          "name": "tests/timeout-example.spec.ts"
+        },
+        {
+          "type": "testcase",
+          "name": "time-out"
+        }
+      ],
+      "duration": 0.159,
+      "status": 0,
+      "stdout": "",
+      "stderr": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m\nError: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m",
+      "data": {
+        "lineNumber": 3
       }
     }
   ],

--- a/tests/data/playwright/report.json
+++ b/tests/data/playwright/report.json
@@ -109,12 +109,12 @@
                     {
                       "workerIndex": 0,
                       "status": "passed",
-                      "duration": 1011,
+                      "duration": 715,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:46.579Z",
+                      "startTime": "2024-08-27T05:12:38.593Z",
                       "attachments": []
                     }
                   ],
@@ -128,14 +128,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 1212,
+                      "duration": 973,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:50.134Z",
+                      "startTime": "2024-08-27T05:12:41.883Z",
                       "attachments": []
                     }
                   ],
@@ -149,14 +149,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 874,
+                      "duration": 695,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:56.395Z",
+                      "startTime": "2024-08-27T05:12:59.390Z",
                       "attachments": []
                     }
                   ],
@@ -183,12 +183,12 @@
                     {
                       "workerIndex": 1,
                       "status": "passed",
-                      "duration": 992,
+                      "duration": 692,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:46.573Z",
+                      "startTime": "2024-08-27T05:12:38.593Z",
                       "attachments": []
                     }
                   ],
@@ -202,14 +202,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 7,
                       "status": "passed",
-                      "duration": 1164,
+                      "duration": 909,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:50.184Z",
+                      "startTime": "2024-08-27T05:12:42.240Z",
                       "attachments": []
                     }
                   ],
@@ -223,14 +223,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 826,
+                      "duration": 545,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:56.504Z",
+                      "startTime": "2024-08-27T05:12:59.608Z",
                       "attachments": []
                     }
                   ],
@@ -239,7 +239,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-f7ec3a657b9005f48420",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 38,
+              "line": 40,
               "column": 7
             },
             {
@@ -257,12 +257,12 @@
                     {
                       "workerIndex": 2,
                       "status": "passed",
-                      "duration": 1035,
+                      "duration": 742,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:46.575Z",
+                      "startTime": "2024-08-27T05:12:38.601Z",
                       "attachments": []
                     }
                   ],
@@ -276,14 +276,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 7,
+                      "workerIndex": 10,
                       "status": "passed",
-                      "duration": 1269,
+                      "duration": 940,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:50.188Z",
+                      "startTime": "2024-08-27T05:12:43.223Z",
                       "attachments": []
                     }
                   ],
@@ -297,14 +297,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 595,
+                      "duration": 612,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:56.860Z",
+                      "startTime": "2024-08-27T05:12:59.720Z",
                       "attachments": []
                     }
                   ],
@@ -321,7 +321,7 @@
         {
           "title": "Mark all as completed",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 74,
+          "line": 72,
           "column": 6,
           "specs": [
             {
@@ -339,12 +339,12 @@
                     {
                       "workerIndex": 3,
                       "status": "passed",
-                      "duration": 1093,
+                      "duration": 799,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:46.576Z",
+                      "startTime": "2024-08-27T05:12:38.596Z",
                       "attachments": []
                     }
                   ],
@@ -358,14 +358,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 1165,
+                      "duration": 586,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:50.647Z",
+                      "startTime": "2024-08-27T05:12:43.490Z",
                       "attachments": []
                     }
                   ],
@@ -379,14 +379,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 684,
+                      "duration": 618,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:57.439Z",
+                      "startTime": "2024-08-27T05:13:00.218Z",
                       "attachments": []
                     }
                   ],
@@ -395,7 +395,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-c7cd4e71e299a39303c7",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 84,
+              "line": 82,
               "column": 7
             },
             {
@@ -413,12 +413,12 @@
                     {
                       "workerIndex": 4,
                       "status": "passed",
-                      "duration": 1133,
+                      "duration": 844,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:46.574Z",
+                      "startTime": "2024-08-27T05:12:38.592Z",
                       "attachments": []
                     }
                   ],
@@ -432,14 +432,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 7,
                       "status": "passed",
-                      "duration": 701,
+                      "duration": 578,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:51.958Z",
+                      "startTime": "2024-08-27T05:12:43.709Z",
                       "attachments": []
                     }
                   ],
@@ -453,14 +453,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 698,
+                      "duration": 644,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:57.458Z",
+                      "startTime": "2024-08-27T05:13:00.272Z",
                       "attachments": []
                     }
                   ],
@@ -469,7 +469,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-3416faeba7b9497734ab",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 97,
+              "line": 91,
               "column": 7
             },
             {
@@ -487,12 +487,12 @@
                     {
                       "workerIndex": 1,
                       "status": "passed",
-                      "duration": 530,
+                      "duration": 648,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.042Z",
+                      "startTime": "2024-08-27T05:12:39.537Z",
                       "attachments": []
                     }
                   ],
@@ -506,14 +506,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 818,
+                      "duration": 625,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.009Z",
+                      "startTime": "2024-08-27T05:12:44.078Z",
                       "attachments": []
                     }
                   ],
@@ -527,14 +527,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 675,
+                      "duration": 755,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:57.582Z",
+                      "startTime": "2024-08-27T05:13:00.462Z",
                       "attachments": []
                     }
                   ],
@@ -543,7 +543,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-d5d66b0d04c9075eb614",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 109,
+              "line": 101,
               "column": 7
             }
           ]
@@ -551,7 +551,7 @@
         {
           "title": "Item",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 132,
+          "line": 122,
           "column": 6,
           "specs": [
             {
@@ -569,12 +569,12 @@
                     {
                       "workerIndex": 0,
                       "status": "passed",
-                      "duration": 430,
+                      "duration": 579,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.061Z",
+                      "startTime": "2024-08-27T05:12:39.561Z",
                       "attachments": []
                     }
                   ],
@@ -590,12 +590,12 @@
                     {
                       "workerIndex": 7,
                       "status": "passed",
-                      "duration": 679,
+                      "duration": 528,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.061Z",
+                      "startTime": "2024-08-27T05:12:44.288Z",
                       "attachments": []
                     }
                   ],
@@ -609,14 +609,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 680,
+                      "duration": 586,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.124Z",
+                      "startTime": "2024-08-27T05:13:00.838Z",
                       "attachments": []
                     }
                   ],
@@ -625,7 +625,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-9fa33b8ee6b644366790",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 133,
+              "line": 124,
               "column": 7
             },
             {
@@ -643,12 +643,12 @@
                     {
                       "workerIndex": 2,
                       "status": "passed",
-                      "duration": 461,
+                      "duration": 622,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.083Z",
+                      "startTime": "2024-08-27T05:12:39.587Z",
                       "attachments": []
                     }
                   ],
@@ -662,14 +662,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 688,
+                      "duration": 514,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.454Z",
+                      "startTime": "2024-08-27T05:12:44.705Z",
                       "attachments": []
                     }
                   ],
@@ -683,14 +683,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 690,
+                      "duration": 1075,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.159Z",
+                      "startTime": "2024-08-27T05:13:00.919Z",
                       "attachments": []
                     }
                   ],
@@ -699,7 +699,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-01c1b596f29e29014e76",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 158,
+              "line": 149,
               "column": 7
             },
             {
@@ -717,12 +717,12 @@
                     {
                       "workerIndex": 3,
                       "status": "passed",
-                      "duration": 438,
+                      "duration": 578,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.140Z",
+                      "startTime": "2024-08-27T05:12:39.642Z",
                       "attachments": []
                     }
                   ],
@@ -736,14 +736,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 6,
+                      "workerIndex": 10,
                       "status": "passed",
-                      "duration": 619,
+                      "duration": 569,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.661Z",
+                      "startTime": "2024-08-27T05:12:44.759Z",
                       "attachments": []
                     }
                   ],
@@ -757,14 +757,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 703,
+                      "duration": 596,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.259Z",
+                      "startTime": "2024-08-27T05:13:01.219Z",
                       "attachments": []
                     }
                   ],
@@ -773,7 +773,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-61bd35b1120a20e67999",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 183,
+              "line": 174,
               "column": 7
             }
           ]
@@ -781,7 +781,7 @@
         {
           "title": "Editing",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 207,
+          "line": 194,
           "column": 6,
           "specs": [
             {
@@ -799,12 +799,12 @@
                     {
                       "workerIndex": 4,
                       "status": "passed",
-                      "duration": 429,
+                      "duration": 532,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.179Z",
+                      "startTime": "2024-08-27T05:12:39.692Z",
                       "attachments": []
                     }
                   ],
@@ -820,12 +820,12 @@
                     {
                       "workerIndex": 7,
                       "status": "passed",
-                      "duration": 557,
+                      "duration": 457,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.742Z",
+                      "startTime": "2024-08-27T05:12:44.818Z",
                       "attachments": []
                     }
                   ],
@@ -839,14 +839,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 538,
+                      "duration": 639,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.805Z",
+                      "startTime": "2024-08-27T05:13:01.428Z",
                       "attachments": []
                     }
                   ],
@@ -855,7 +855,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-50a0d09efbf896088591",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 213,
+              "line": 200,
               "column": 7
             },
             {
@@ -873,160 +873,12 @@
                     {
                       "workerIndex": 0,
                       "status": "passed",
-                      "duration": 438,
+                      "duration": 394,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.493Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "firefox",
-                  "projectName": "firefox",
-                  "results": [
-                    {
-                      "workerIndex": 5,
-                      "status": "passed",
-                      "duration": 579,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:52.829Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "webkit",
-                  "projectName": "webkit",
-                  "results": [
-                    {
-                      "workerIndex": 10,
-                      "status": "passed",
-                      "duration": 621,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.853Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                }
-              ],
-              "id": "f8b37aaddd8ecd14ecd4-b4ee82d3f09959086711",
-              "file": "tests/demo-todo-app.spec.ts",
-              "line": 225,
-              "column": 7
-            },
-            {
-              "title": "should trim entered text",
-              "ok": true,
-              "tags": [],
-              "tests": [
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "chromium",
-                  "projectName": "chromium",
-                  "results": [
-                    {
-                      "workerIndex": 2,
-                      "status": "passed",
-                      "duration": 493,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.546Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "firefox",
-                  "projectName": "firefox",
-                  "results": [
-                    {
-                      "workerIndex": 8,
-                      "status": "passed",
-                      "duration": 565,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.144Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "webkit",
-                  "projectName": "webkit",
-                  "results": [
-                    {
-                      "workerIndex": 12,
-                      "status": "passed",
-                      "duration": 828,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:58.963Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                }
-              ],
-              "id": "f8b37aaddd8ecd14ecd4-ba4380806d93e11d8a08",
-              "file": "tests/demo-todo-app.spec.ts",
-              "line": 245,
-              "column": 7
-            },
-            {
-              "title": "should remove the item if an empty text string was entered",
-              "ok": true,
-              "tags": [],
-              "tests": [
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "chromium",
-                  "projectName": "chromium",
-                  "results": [
-                    {
-                      "workerIndex": 1,
-                      "status": "passed",
-                      "duration": 507,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.573Z",
+                      "startTime": "2024-08-27T05:12:40.141Z",
                       "attachments": []
                     }
                   ],
@@ -1042,12 +894,12 @@
                     {
                       "workerIndex": 6,
                       "status": "passed",
-                      "duration": 545,
+                      "duration": 460,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.282Z",
+                      "startTime": "2024-08-27T05:12:45.220Z",
                       "attachments": []
                     }
                   ],
@@ -1061,14 +913,162 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 509,
+                      "duration": 589,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:59.345Z",
+                      "startTime": "2024-08-27T05:13:01.817Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "f8b37aaddd8ecd14ecd4-b4ee82d3f09959086711",
+              "file": "tests/demo-todo-app.spec.ts",
+              "line": 210,
+              "column": 7
+            },
+            {
+              "title": "should trim entered text",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "status": "passed",
+                      "duration": 423,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:40.187Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "firefox",
+                  "projectName": "firefox",
+                  "results": [
+                    {
+                      "workerIndex": 7,
+                      "status": "passed",
+                      "duration": 459,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:45.276Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "webkit",
+                  "projectName": "webkit",
+                  "results": [
+                    {
+                      "workerIndex": 23,
+                      "status": "passed",
+                      "duration": 613,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:13:01.995Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "f8b37aaddd8ecd14ecd4-ba4380806d93e11d8a08",
+              "file": "tests/demo-todo-app.spec.ts",
+              "line": 224,
+              "column": 7
+            },
+            {
+              "title": "should remove the item if an empty text string was entered",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 2,
+                      "status": "passed",
+                      "duration": 429,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:40.210Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "firefox",
+                  "projectName": "firefox",
+                  "results": [
+                    {
+                      "workerIndex": 10,
+                      "status": "passed",
+                      "duration": 469,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:45.330Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "webkit",
+                  "projectName": "webkit",
+                  "results": [
+                    {
+                      "workerIndex": 22,
+                      "status": "passed",
+                      "duration": 632,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:13:02.070Z",
                       "attachments": []
                     }
                   ],
@@ -1077,7 +1077,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-5f1641cf177927369cd8",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 265,
+              "line": 238,
               "column": 7
             },
             {
@@ -1095,12 +1095,12 @@
                     {
                       "workerIndex": 3,
                       "status": "passed",
-                      "duration": 517,
+                      "duration": 418,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.579Z",
+                      "startTime": "2024-08-27T05:12:40.222Z",
                       "attachments": []
                     }
                   ],
@@ -1114,14 +1114,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 7,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 558,
+                      "duration": 457,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.300Z",
+                      "startTime": "2024-08-27T05:12:45.681Z",
                       "attachments": []
                     }
                   ],
@@ -1135,14 +1135,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 613,
+                      "duration": 599,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:59.475Z",
+                      "startTime": "2024-08-27T05:13:02.408Z",
                       "attachments": []
                     }
                   ],
@@ -1151,7 +1151,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-d0385473fad9fa86d44f",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 279,
+              "line": 250,
               "column": 7
             }
           ]
@@ -1159,7 +1159,7 @@
         {
           "title": "Counter",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 294,
+          "line": 259,
           "column": 6,
           "specs": [
             {
@@ -1177,12 +1177,12 @@
                     {
                       "workerIndex": 4,
                       "status": "passed",
-                      "duration": 431,
+                      "duration": 348,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.610Z",
+                      "startTime": "2024-08-27T05:12:40.226Z",
                       "attachments": []
                     }
                   ],
@@ -1196,14 +1196,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 7,
                       "status": "passed",
-                      "duration": 466,
+                      "duration": 374,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.409Z",
+                      "startTime": "2024-08-27T05:12:45.736Z",
                       "attachments": []
                     }
                   ],
@@ -1217,14 +1217,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 523,
+                      "duration": 553,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:59.792Z",
+                      "startTime": "2024-08-27T05:13:02.610Z",
                       "attachments": []
                     }
                   ],
@@ -1233,7 +1233,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-076c8dd5273b2ae86c40",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 295,
+              "line": 260,
               "column": 7
             }
           ]
@@ -1241,7 +1241,7 @@
         {
           "title": "Clear completed button",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 315,
+          "line": 280,
           "column": 6,
           "specs": [
             {
@@ -1259,12 +1259,12 @@
                     {
                       "workerIndex": 0,
                       "status": "passed",
-                      "duration": 390,
+                      "duration": 380,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:48.932Z",
+                      "startTime": "2024-08-27T05:12:40.537Z",
                       "attachments": []
                     }
                   ],
@@ -1278,14 +1278,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 10,
                       "status": "passed",
-                      "duration": 477,
+                      "duration": 449,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.711Z",
+                      "startTime": "2024-08-27T05:12:45.800Z",
                       "attachments": []
                     }
                   ],
@@ -1299,14 +1299,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 501,
+                      "duration": 582,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:59.855Z",
+                      "startTime": "2024-08-27T05:13:02.704Z",
                       "attachments": []
                     }
                   ],
@@ -1315,7 +1315,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-c290d8cfb1323b180ffe",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 320,
+              "line": 285,
               "column": 7
             },
             {
@@ -1331,88 +1331,14 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 2,
-                      "status": "passed",
-                      "duration": 414,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.041Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "firefox",
-                  "projectName": "firefox",
-                  "results": [
-                    {
-                      "workerIndex": 6,
-                      "status": "passed",
-                      "duration": 578,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.828Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                },
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "webkit",
-                  "projectName": "webkit",
-                  "results": [
-                    {
-                      "workerIndex": 10,
-                      "status": "passed",
-                      "duration": 692,
-                      "errors": [],
-                      "stdout": [],
-                      "stderr": [],
-                      "retry": 0,
-                      "startTime": "2024-04-08T06:05:00.091Z",
-                      "attachments": []
-                    }
-                  ],
-                  "status": "expected"
-                }
-              ],
-              "id": "f8b37aaddd8ecd14ecd4-8dcc9c34da2774d16c08",
-              "file": "tests/demo-todo-app.spec.ts",
-              "line": 327,
-              "column": 7
-            },
-            {
-              "title": "should be hidden when there are no items that are completed",
-              "ok": true,
-              "tags": [],
-              "tests": [
-                {
-                  "timeout": 30000,
-                  "annotations": [],
-                  "expectedStatus": "passed",
-                  "projectId": "chromium",
-                  "projectName": "chromium",
-                  "results": [
-                    {
                       "workerIndex": 4,
                       "status": "passed",
-                      "duration": 410,
+                      "duration": 424,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.043Z",
+                      "startTime": "2024-08-27T05:12:40.575Z",
                       "attachments": []
                     }
                   ],
@@ -1428,12 +1354,12 @@
                     {
                       "workerIndex": 7,
                       "status": "passed",
-                      "duration": 560,
+                      "duration": 488,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.860Z",
+                      "startTime": "2024-08-27T05:12:46.111Z",
                       "attachments": []
                     }
                   ],
@@ -1447,14 +1373,88 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 577,
+                      "duration": 537,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:00.317Z",
+                      "startTime": "2024-08-27T05:13:03.009Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "f8b37aaddd8ecd14ecd4-8dcc9c34da2774d16c08",
+              "file": "tests/demo-todo-app.spec.ts",
+              "line": 290,
+              "column": 7
+            },
+            {
+              "title": "should be hidden when there are no items that are completed",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "status": "passed",
+                      "duration": 418,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:40.612Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "firefox",
+                  "projectName": "firefox",
+                  "results": [
+                    {
+                      "workerIndex": 6,
+                      "status": "passed",
+                      "duration": 507,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:12:46.139Z",
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                },
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "webkit",
+                  "projectName": "webkit",
+                  "results": [
+                    {
+                      "workerIndex": 23,
+                      "status": "passed",
+                      "duration": 537,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2024-08-27T05:13:03.165Z",
                       "attachments": []
                     }
                   ],
@@ -1463,7 +1463,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-6f9863f9b4b005e3b2f1",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 335,
+              "line": 298,
               "column": 7
             }
           ]
@@ -1471,7 +1471,7 @@
         {
           "title": "Persistence",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 346,
+          "line": 305,
           "column": 6,
           "specs": [
             {
@@ -1487,14 +1487,14 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 1,
+                      "workerIndex": 2,
                       "status": "passed",
-                      "duration": 445,
+                      "duration": 457,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.081Z",
+                      "startTime": "2024-08-27T05:12:40.641Z",
                       "attachments": []
                     }
                   ],
@@ -1508,14 +1508,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 10,
                       "status": "passed",
-                      "duration": 760,
+                      "duration": 651,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:53.877Z",
+                      "startTime": "2024-08-27T05:12:46.250Z",
                       "attachments": []
                     }
                   ],
@@ -1529,14 +1529,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 600,
+                      "duration": 535,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:00.359Z",
+                      "startTime": "2024-08-27T05:13:03.288Z",
                       "attachments": []
                     }
                   ],
@@ -1545,7 +1545,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-36436d48254577d3e978",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 347,
+              "line": 306,
               "column": 7
             }
           ]
@@ -1553,7 +1553,7 @@
         {
           "title": "Routing",
           "file": "tests/demo-todo-app.spec.ts",
-          "line": 374,
+          "line": 333,
           "column": 6,
           "specs": [
             {
@@ -1571,12 +1571,12 @@
                     {
                       "workerIndex": 3,
                       "status": "passed",
-                      "duration": 422,
+                      "duration": 441,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.098Z",
+                      "startTime": "2024-08-27T05:12:40.641Z",
                       "attachments": []
                     }
                   ],
@@ -1590,14 +1590,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 7,
                       "status": "passed",
-                      "duration": 679,
+                      "duration": 522,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:54.190Z",
+                      "startTime": "2024-08-27T05:12:46.601Z",
                       "attachments": []
                     }
                   ],
@@ -1611,14 +1611,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 643,
+                      "duration": 522,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:00.784Z",
+                      "startTime": "2024-08-27T05:13:03.547Z",
                       "attachments": []
                     }
                   ],
@@ -1627,7 +1627,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-80171ee243ff293e5cf0",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 383,
+              "line": 342,
               "column": 7
             },
             {
@@ -1645,7 +1645,7 @@
                     {
                       "workerIndex": 0,
                       "status": "passed",
-                      "duration": 485,
+                      "duration": 471,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
@@ -1653,18 +1653,18 @@
                       "steps": [
                         {
                           "title": "Showing all items",
-                          "duration": 34
+                          "duration": 32
                         },
                         {
                           "title": "Showing active items",
-                          "duration": 30
+                          "duration": 31
                         },
                         {
                           "title": "Showing completed items",
-                          "duration": 33
+                          "duration": 34
                         }
                       ],
-                      "startTime": "2024-04-08T06:04:49.324Z",
+                      "startTime": "2024-08-27T05:12:40.919Z",
                       "attachments": []
                     }
                   ],
@@ -1680,7 +1680,7 @@
                     {
                       "workerIndex": 6,
                       "status": "passed",
-                      "duration": 812,
+                      "duration": 712,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
@@ -1688,18 +1688,18 @@
                       "steps": [
                         {
                           "title": "Showing all items",
-                          "duration": 53
+                          "duration": 66
                         },
                         {
                           "title": "Showing active items",
-                          "duration": 60
+                          "duration": 86
                         },
                         {
                           "title": "Showing completed items",
-                          "duration": 54
+                          "duration": 67
                         }
                       ],
-                      "startTime": "2024-04-08T06:04:54.408Z",
+                      "startTime": "2024-08-27T05:12:46.647Z",
                       "attachments": []
                     }
                   ],
@@ -1713,9 +1713,9 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 639,
+                      "duration": 619,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
@@ -1723,18 +1723,18 @@
                       "steps": [
                         {
                           "title": "Showing all items",
-                          "duration": 35
+                          "duration": 47
                         },
                         {
                           "title": "Showing active items",
-                          "duration": 46
+                          "duration": 31
                         },
                         {
                           "title": "Showing completed items",
-                          "duration": 35
+                          "duration": 32
                         }
                       ],
-                      "startTime": "2024-04-08T06:05:00.896Z",
+                      "startTime": "2024-08-27T05:13:03.703Z",
                       "attachments": []
                     }
                   ],
@@ -1743,7 +1743,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-b5eaa4bfaee7ef23b6dd",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 393,
+              "line": 352,
               "column": 7
             },
             {
@@ -1761,12 +1761,12 @@
                     {
                       "workerIndex": 4,
                       "status": "passed",
-                      "duration": 417,
+                      "duration": 418,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.454Z",
+                      "startTime": "2024-08-27T05:12:41.000Z",
                       "attachments": []
                     }
                   ],
@@ -1780,14 +1780,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 7,
+                      "workerIndex": 10,
                       "status": "passed",
-                      "duration": 683,
+                      "duration": 582,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:54.422Z",
+                      "startTime": "2024-08-27T05:12:46.904Z",
                       "attachments": []
                     }
                   ],
@@ -1801,14 +1801,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 11,
+                      "workerIndex": 22,
                       "status": "passed",
-                      "duration": 761,
+                      "duration": 534,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:00.961Z",
+                      "startTime": "2024-08-27T05:13:03.825Z",
                       "attachments": []
                     }
                   ],
@@ -1817,7 +1817,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-09b9e67948bbf1e25ef2",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 419,
+              "line": 378,
               "column": 7
             },
             {
@@ -1833,14 +1833,14 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 2,
+                      "workerIndex": 1,
                       "status": "passed",
-                      "duration": 479,
+                      "duration": 466,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.456Z",
+                      "startTime": "2024-08-27T05:12:41.031Z",
                       "attachments": []
                     }
                   ],
@@ -1854,14 +1854,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 5,
+                      "workerIndex": 7,
                       "status": "passed",
-                      "duration": 784,
+                      "duration": 733,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:54.638Z",
+                      "startTime": "2024-08-27T05:12:47.124Z",
                       "attachments": []
                     }
                   ],
@@ -1875,14 +1875,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 10,
+                      "workerIndex": 24,
                       "status": "passed",
-                      "duration": 663,
+                      "duration": 597,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:01.429Z",
+                      "startTime": "2024-08-27T05:13:04.070Z",
                       "attachments": []
                     }
                   ],
@@ -1891,7 +1891,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-e561bcf02e908f8409d1",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 426,
+              "line": 385,
               "column": 7
             },
             {
@@ -1914,7 +1914,7 @@
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:49.521Z",
+                      "startTime": "2024-08-27T05:12:41.084Z",
                       "attachments": []
                     }
                   ],
@@ -1928,14 +1928,14 @@
                   "projectName": "firefox",
                   "results": [
                     {
-                      "workerIndex": 8,
+                      "workerIndex": 6,
                       "status": "passed",
-                      "duration": 684,
+                      "duration": 554,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:04:54.870Z",
+                      "startTime": "2024-08-27T05:12:47.361Z",
                       "attachments": []
                     }
                   ],
@@ -1949,14 +1949,14 @@
                   "projectName": "webkit",
                   "results": [
                     {
-                      "workerIndex": 12,
+                      "workerIndex": 23,
                       "status": "passed",
-                      "duration": 688,
+                      "duration": 542,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2024-04-08T06:05:01.537Z",
+                      "startTime": "2024-08-27T05:13:04.324Z",
                       "attachments": []
                     }
                   ],
@@ -1965,7 +1965,7 @@
               ],
               "id": "f8b37aaddd8ecd14ecd4-4d73ad01830ba2ac4839",
               "file": "tests/demo-todo-app.spec.ts",
-              "line": 435,
+              "line": 394,
               "column": 7
             }
           ]
@@ -1991,14 +1991,14 @@
               "projectName": "chromium",
               "results": [
                 {
-                  "workerIndex": 1,
+                  "workerIndex": 2,
                   "status": "passed",
-                  "duration": 359,
+                  "duration": 526,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:49.534Z",
+                  "startTime": "2024-08-27T05:12:41.106Z",
                   "attachments": []
                 }
               ],
@@ -2012,14 +2012,14 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 7,
+                  "workerIndex": 10,
                   "status": "passed",
-                  "duration": 529,
+                  "duration": 446,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:55.114Z",
+                  "startTime": "2024-08-27T05:12:47.494Z",
                   "attachments": []
                 }
               ],
@@ -2033,14 +2033,14 @@
               "projectName": "webkit",
               "results": [
                 {
-                  "workerIndex": 11,
+                  "workerIndex": 22,
                   "status": "passed",
-                  "duration": 581,
+                  "duration": 506,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:05:01.731Z",
+                  "startTime": "2024-08-27T05:13:04.369Z",
                   "attachments": []
                 }
               ],
@@ -2067,12 +2067,12 @@
                 {
                   "workerIndex": 0,
                   "status": "passed",
-                  "duration": 593,
+                  "duration": 552,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:49.817Z",
+                  "startTime": "2024-08-27T05:12:41.399Z",
                   "attachments": []
                 }
               ],
@@ -2086,14 +2086,14 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 6,
+                  "workerIndex": 7,
                   "status": "passed",
-                  "duration": 853,
+                  "duration": 597,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:55.229Z",
+                  "startTime": "2024-08-27T05:12:47.866Z",
                   "attachments": []
                 }
               ],
@@ -2107,14 +2107,14 @@
               "projectName": "webkit",
               "results": [
                 {
-                  "workerIndex": 10,
+                  "workerIndex": 24,
                   "status": "passed",
-                  "duration": 830,
+                  "duration": 643,
                   "errors": [],
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:05:02.100Z",
+                  "startTime": "2024-08-27T05:13:04.675Z",
                   "attachments": []
                 }
               ],
@@ -2149,7 +2149,7 @@
                 {
                   "workerIndex": 4,
                   "status": "failed",
-                  "duration": 5320,
+                  "duration": 5346,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2177,7 +2177,7 @@
                   ],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:49.878Z",
+                  "startTime": "2024-08-27T05:12:41.427Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2186,12 +2186,12 @@
                   }
                 },
                 {
-                  "workerIndex": 9,
+                  "workerIndex": 11,
                   "status": "failed",
-                  "duration": 5681,
+                  "duration": 5556,
                   "error": {
-                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
-                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
                     "location": {
                       "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
                       "column": 22,
@@ -2206,7 +2206,7 @@
                         "column": 22,
                         "line": 7
                       },
-                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m"
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m"
                     }
                   ],
                   "stdout": [
@@ -2216,7 +2216,7 @@
                   ],
                   "stderr": [],
                   "retry": 1,
-                  "startTime": "2024-04-08T06:04:55.455Z",
+                  "startTime": "2024-08-27T05:12:47.077Z",
                   "attachments": [
                     {
                       "name": "trace",
@@ -2231,9 +2231,9 @@
                   }
                 },
                 {
-                  "workerIndex": 14,
+                  "workerIndex": 15,
                   "status": "failed",
-                  "duration": 5503,
+                  "duration": 5404,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2261,7 +2261,7 @@
                   ],
                   "stderr": [],
                   "retry": 2,
-                  "startTime": "2024-04-08T06:05:01.651Z",
+                  "startTime": "2024-08-27T05:12:52.999Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2270,9 +2270,9 @@
                   }
                 },
                 {
-                  "workerIndex": 15,
+                  "workerIndex": 21,
                   "status": "passed",
-                  "duration": 398,
+                  "duration": 553,
                   "errors": [],
                   "stdout": [
                     {
@@ -2281,7 +2281,7 @@
                   ],
                   "stderr": [],
                   "retry": 3,
-                  "startTime": "2024-04-08T06:05:07.520Z",
+                  "startTime": "2024-08-27T05:12:58.804Z",
                   "attachments": []
                 }
               ],
@@ -2295,12 +2295,12 @@
               "projectName": "firefox",
               "results": [
                 {
-                  "workerIndex": 5,
+                  "workerIndex": 6,
                   "status": "failed",
-                  "duration": 5433,
+                  "duration": 5542,
                   "error": {
-                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
-                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
                     "location": {
                       "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
                       "column": 22,
@@ -2315,7 +2315,7 @@
                         "column": 22,
                         "line": 7
                       },
-                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m"
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22\u001b[22m"
                     }
                   ],
                   "stdout": [
@@ -2325,7 +2325,7 @@
                   ],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:55.430Z",
+                  "startTime": "2024-08-27T05:12:47.923Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2334,9 +2334,9 @@
                   }
                 },
                 {
-                  "workerIndex": 13,
+                  "workerIndex": 18,
                   "status": "failed",
-                  "duration": 6139,
+                  "duration": 6203,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2364,7 +2364,7 @@
                   ],
                   "stderr": [],
                   "retry": 1,
-                  "startTime": "2024-04-08T06:05:01.413Z",
+                  "startTime": "2024-08-27T05:12:53.961Z",
                   "attachments": [
                     {
                       "name": "trace",
@@ -2379,9 +2379,9 @@
                   }
                 },
                 {
-                  "workerIndex": 16,
+                  "workerIndex": 26,
                   "status": "failed",
-                  "duration": 5824,
+                  "duration": 6017,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2409,7 +2409,7 @@
                   ],
                   "stderr": [],
                   "retry": 2,
-                  "startTime": "2024-04-08T06:05:08.725Z",
+                  "startTime": "2024-08-27T05:13:01.357Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2418,9 +2418,9 @@
                   }
                 },
                 {
-                  "workerIndex": 18,
+                  "workerIndex": 31,
                   "status": "passed",
-                  "duration": 805,
+                  "duration": 767,
                   "errors": [],
                   "stdout": [
                     {
@@ -2429,7 +2429,7 @@
                   ],
                   "stderr": [],
                   "retry": 3,
-                  "startTime": "2024-04-08T06:05:15.523Z",
+                  "startTime": "2024-08-27T05:13:08.618Z",
                   "attachments": []
                 }
               ],
@@ -2443,9 +2443,9 @@
               "projectName": "webkit",
               "results": [
                 {
-                  "workerIndex": 12,
+                  "workerIndex": 23,
                   "status": "failed",
-                  "duration": 5589,
+                  "duration": 5528,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2473,7 +2473,7 @@
                   ],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:05:02.234Z",
+                  "startTime": "2024-08-27T05:13:04.874Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2482,9 +2482,9 @@
                   }
                 },
                 {
-                  "workerIndex": 11,
+                  "workerIndex": 33,
                   "status": "failed",
-                  "duration": 5719,
+                  "duration": 5633,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2512,7 +2512,7 @@
                   ],
                   "stderr": [],
                   "retry": 1,
-                  "startTime": "2024-04-08T06:05:07.837Z",
+                  "startTime": "2024-08-27T05:13:11.990Z",
                   "attachments": [
                     {
                       "name": "trace",
@@ -2527,9 +2527,9 @@
                   }
                 },
                 {
-                  "workerIndex": 17,
+                  "workerIndex": 35,
                   "status": "failed",
-                  "duration": 5509,
+                  "duration": 5502,
                   "error": {
                     "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
                     "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts:7:22",
@@ -2557,7 +2557,7 @@
                   ],
                   "stderr": [],
                   "retry": 2,
-                  "startTime": "2024-04-08T06:05:13.732Z",
+                  "startTime": "2024-08-27T05:13:17.933Z",
                   "attachments": [],
                   "errorLocation": {
                     "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-and-skip-example.spec.ts",
@@ -2566,9 +2566,9 @@
                   }
                 },
                 {
-                  "workerIndex": 19,
+                  "workerIndex": 36,
                   "status": "passed",
-                  "duration": 614,
+                  "duration": 543,
                   "errors": [],
                   "stdout": [
                     {
@@ -2577,7 +2577,7 @@
                   ],
                   "stderr": [],
                   "retry": 3,
-                  "startTime": "2024-04-08T06:05:19.822Z",
+                  "startTime": "2024-08-27T05:13:23.565Z",
                   "attachments": []
                 }
               ],
@@ -2613,7 +2613,7 @@
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:49.894Z",
+                  "startTime": "2024-08-27T05:12:41.498Z",
                   "attachments": []
                 }
               ],
@@ -2638,7 +2638,7 @@
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:04:55.555Z",
+                  "startTime": "2024-08-27T05:12:47.942Z",
                   "attachments": []
                 }
               ],
@@ -2663,7 +2663,7 @@
                   "stdout": [],
                   "stderr": [],
                   "retry": 0,
-                  "startTime": "2024-04-08T06:05:02.313Z",
+                  "startTime": "2024-08-27T05:13:04.875Z",
                   "attachments": []
                 }
               ],
@@ -2676,15 +2676,943 @@
           "column": 6
         }
       ]
+    },
+    {
+      "title": "tests/retry-example.spec.ts",
+      "file": "tests/retry-example.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [
+        {
+          "title": "retry",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": 3,
+                  "status": "failed",
+                  "duration": 5333,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m0\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:41.505Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 12,
+                  "status": "failed",
+                  "duration": 5562,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m1\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:12:47.102Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-retry-example-retry-chromium-retry1/trace.zip"
+                    }
+                  ],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 16,
+                  "status": "failed",
+                  "duration": 5374,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m2\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:12:53.031Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 20,
+                  "status": "passed",
+                  "duration": 471,
+                  "errors": [],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m3\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:12:58.788Z",
+                  "attachments": []
+                }
+              ],
+              "status": "flaky"
+            },
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "firefox",
+              "projectName": "firefox",
+              "results": [
+                {
+                  "workerIndex": 10,
+                  "status": "failed",
+                  "duration": 5458,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-rh=\"…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m0\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:47.943Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 17,
+                  "status": "failed",
+                  "duration": 6172,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m1\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:12:53.910Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-retry-example-retry-firefox-retry1/trace.zip"
+                    }
+                  ],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 25,
+                  "status": "failed",
+                  "duration": 6014,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m2\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:13:01.303Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 30,
+                  "status": "passed",
+                  "duration": 791,
+                  "errors": [],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m3\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:13:08.532Z",
+                  "attachments": []
+                }
+              ],
+              "status": "flaky"
+            },
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "webkit",
+              "projectName": "webkit",
+              "results": [
+                {
+                  "workerIndex": 22,
+                  "status": "failed",
+                  "duration": 5526,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m0\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:13:04.876Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 32,
+                  "status": "failed",
+                  "duration": 5634,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m1\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:13:10.615Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-retry-example-retry-webkit-retry1/trace.zip"
+                    }
+                  ],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 34,
+                  "status": "failed",
+                  "duration": 5522,
+                  "error": {
+                    "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n",
+                    "stack": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22",
+                    "location": {
+                      "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                      "column": 22,
+                      "line": 7
+                    },
+                    "snippet": "\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                        "column": 22,
+                        "line": 7
+                      },
+                      "message": "Error: \u001b[31mTimed out 5000ms waiting for \u001b[39m\u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveTitle\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nLocator: locator(':root')\nExpected pattern: \u001b[32m/Playflight/\u001b[39m\nReceived string:  \u001b[31m\"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[39m\nCall log:\n  \u001b[2m- expect.toHaveTitle with timeout 5000ms\u001b[22m\n\u001b[2m  - waiting for locator(':root')\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\u001b[2m  -   locator resolved to <html lang=\"en\" dir=\"ltr\" data-theme=\"light\" data-has-…>…</html>\u001b[22m\n\u001b[2m  -   unexpected value \"Fast and reliable end-to-end testing for modern web apps | Playwright\"\u001b[22m\n\n\n\u001b[0m \u001b[90m  5 |\u001b[39m   console\u001b[33m.\u001b[39mlog(\u001b[32m\"Retry count:\"\u001b[39m\u001b[33m,\u001b[39m testInfo\u001b[33m.\u001b[39mretry)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  6 |\u001b[39m   \u001b[36mconst\u001b[39m want \u001b[33m=\u001b[39m testInfo\u001b[33m.\u001b[39mretry \u001b[33m>\u001b[39m \u001b[35m2\u001b[39m \u001b[33m?\u001b[39m \u001b[32m\"Playwright\"\u001b[39m \u001b[33m:\u001b[39m \u001b[32m\"Playflight\"\u001b[39m\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  7 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(want))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m    |\u001b[39m                      \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  8 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m  9 |\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 10 |\u001b[39m test\u001b[33m.\u001b[39mskip(\u001b[32m\"skip this test\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }) \u001b[33m=>\u001b[39m {\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts:7:22\u001b[22m"
+                    }
+                  ],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m2\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:13:16.569Z",
+                  "attachments": [],
+                  "errorLocation": {
+                    "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/retry-example.spec.ts",
+                    "column": 22,
+                    "line": 7
+                  }
+                },
+                {
+                  "workerIndex": 36,
+                  "status": "passed",
+                  "duration": 463,
+                  "errors": [],
+                  "stdout": [
+                    {
+                      "text": "Retry count: \u001b[33m3\u001b[39m\n"
+                    }
+                  ],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:13:22.416Z",
+                  "attachments": []
+                }
+              ],
+              "status": "flaky"
+            }
+          ],
+          "id": "e3b84531e61904b94b5b-07695a7ece180e783fcc",
+          "file": "tests/retry-example.spec.ts",
+          "line": 3,
+          "column": 5
+        },
+        {
+          "title": "skip this test",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [
+                {
+                  "type": "skip"
+                }
+              ],
+              "expectedStatus": "skipped",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": -1,
+                  "status": "skipped",
+                  "duration": 0,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:41.498Z",
+                  "attachments": []
+                }
+              ],
+              "status": "skipped"
+            },
+            {
+              "timeout": 30000,
+              "annotations": [
+                {
+                  "type": "skip"
+                }
+              ],
+              "expectedStatus": "skipped",
+              "projectId": "firefox",
+              "projectName": "firefox",
+              "results": [
+                {
+                  "workerIndex": -1,
+                  "status": "skipped",
+                  "duration": 0,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:48.464Z",
+                  "attachments": []
+                }
+              ],
+              "status": "skipped"
+            },
+            {
+              "timeout": 30000,
+              "annotations": [
+                {
+                  "type": "skip"
+                }
+              ],
+              "expectedStatus": "skipped",
+              "projectId": "webkit",
+              "projectName": "webkit",
+              "results": [
+                {
+                  "workerIndex": -1,
+                  "status": "skipped",
+                  "duration": 0,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:13:05.320Z",
+                  "attachments": []
+                }
+              ],
+              "status": "skipped"
+            }
+          ],
+          "id": "e3b84531e61904b94b5b-900065ec54937c0c7e4b",
+          "file": "tests/retry-example.spec.ts",
+          "line": 10,
+          "column": 6
+        }
+      ]
+    },
+    {
+      "title": "tests/timeout-example.spec.ts",
+      "file": "tests/timeout-example.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [
+        {
+          "title": "time-out",
+          "ok": false,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 1,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": 1,
+                  "status": "timedOut",
+                  "duration": 50,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:41.505Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 5,
+                  "status": "timedOut",
+                  "duration": 79,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:12:41.791Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip"
+                    }
+                  ]
+                },
+                {
+                  "workerIndex": 8,
+                  "status": "timedOut",
+                  "duration": 70,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:12:42.293Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 9,
+                  "status": "timedOut",
+                  "duration": 99,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: net::ERR_ABORTED; maybe frame was detached?\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:12:42.732Z",
+                  "attachments": []
+                }
+              ],
+              "status": "unexpected"
+            },
+            {
+              "timeout": 1,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "firefox",
+              "projectName": "firefox",
+              "results": [
+                {
+                  "workerIndex": 7,
+                  "status": "timedOut",
+                  "duration": 70,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:12:48.465Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 13,
+                  "status": "timedOut",
+                  "duration": 382,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:12:49.021Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip"
+                    }
+                  ]
+                },
+                {
+                  "workerIndex": 14,
+                  "status": "timedOut",
+                  "duration": 455,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:12:52.494Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 19,
+                  "status": "timedOut",
+                  "duration": 380,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:12:55.950Z",
+                  "attachments": []
+                }
+              ],
+              "status": "unexpected"
+            },
+            {
+              "timeout": 1,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "webkit",
+              "projectName": "webkit",
+              "results": [
+                {
+                  "workerIndex": 24,
+                  "status": "timedOut",
+                  "duration": 125,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2024-08-27T05:13:05.321Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 27,
+                  "status": "timedOut",
+                  "duration": 175,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2024-08-27T05:13:05.642Z",
+                  "attachments": [
+                    {
+                      "name": "trace",
+                      "contentType": "application/zip",
+                      "path": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip"
+                    }
+                  ]
+                },
+                {
+                  "workerIndex": 28,
+                  "status": "timedOut",
+                  "duration": 155,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2024-08-27T05:13:06.134Z",
+                  "attachments": []
+                },
+                {
+                  "workerIndex": 29,
+                  "status": "timedOut",
+                  "duration": 159,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 1ms exceeded.\u001b[39m"
+                    },
+                    {
+                      "location": {
+                        "file": "/Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts",
+                        "column": 14,
+                        "line": 5
+                      },
+                      "message": "Error: page.goto: Test timeout of 1ms exceeded.\nCall log:\n  \u001b[2m- navigating to \"https://playwright.dev/\", waiting until \"load\"\u001b[22m\n\n\n\u001b[0m \u001b[90m 3 |\u001b[39m test(\u001b[32m\"time-out\"\u001b[39m\u001b[33m,\u001b[39m \u001b[36masync\u001b[39m ({ page }\u001b[33m,\u001b[39m testInfo) \u001b[33m=>\u001b[39m {\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m   test\u001b[33m.\u001b[39msetTimeout(\u001b[35m1\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 5 |\u001b[39m   \u001b[36mawait\u001b[39m page\u001b[33m.\u001b[39mgoto(\u001b[32m\"https://playwright.dev/\"\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m              \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 6 |\u001b[39m   \u001b[36mawait\u001b[39m expect(page)\u001b[33m.\u001b[39mtoHaveTitle(\u001b[36mnew\u001b[39m \u001b[33mRegExp\u001b[39m(\u001b[32m\"Playwright\"\u001b[39m))\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 7 |\u001b[39m })\u001b[33m;\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 8 |\u001b[39m\u001b[0m\n\n\u001b[2m    at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14\u001b[22m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 3,
+                  "startTime": "2024-08-27T05:13:06.573Z",
+                  "attachments": []
+                }
+              ],
+              "status": "unexpected"
+            }
+          ],
+          "id": "fd8c456ba0a564116d6a-75f6c7b72d99cb1d1ca6",
+          "file": "tests/timeout-example.spec.ts",
+          "line": 3,
+          "column": 5
+        }
+      ]
     }
   ],
   "errors": [],
   "stats": {
-    "startTime": "2024-04-08T06:04:46.279Z",
-    "duration": 34297.713,
+    "startTime": "2024-08-27T05:12:38.321Z",
+    "duration": 46054.078,
     "expected": 78,
-    "skipped": 3,
-    "unexpected": 0,
-    "flaky": 3
+    "skipped": 6,
+    "unexpected": 3,
+    "flaky": 6
   }
 }

--- a/tests/data/playwright/report.xml
+++ b/tests/data/playwright/report.xml
@@ -1,241 +1,581 @@
-<testsuites id="" name="" tests="78" failures="3" skipped="1" errors="0" time="29.558653">
-<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="chromium" tests="24" failures="0" skipped="0" time="13.874" errors="0">
-<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="1.22">
+<testsuites id="" name="" tests="93" failures="3" skipped="6" errors="0" time="45.984125999999996">
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="chromium" tests="24" failures="0" skipped="0" time="12.652" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="0.715">
 </testcase>
-<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="1.198">
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="0.692">
 </testcase>
-<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="1.24">
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="0.742">
 </testcase>
-<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="1.291">
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="0.799">
 </testcase>
-<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="1.316">
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.844">
 </testcase>
-<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.467">
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.648">
 </testcase>
-<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.409">
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.579">
 </testcase>
-<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.422">
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.622">
 </testcase>
-<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.392">
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.578">
 </testcase>
-<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.404">
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.532">
 </testcase>
-<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.382">
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.394">
 </testcase>
-<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.393">
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.423">
 </testcase>
-<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.392">
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.429">
 </testcase>
-<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.39">
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.418">
 </testcase>
-<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.318">
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.348">
 </testcase>
-<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.35">
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.38">
 </testcase>
-<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.387">
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.424">
 </testcase>
-<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.383">
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.418">
 </testcase>
-<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.423">
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.457">
 </testcase>
-<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.385">
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.441">
 </testcase>
-<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.47">
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.471">
 </testcase>
-<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.396">
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.418">
 </testcase>
-<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.451">
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.466">
 </testcase>
-<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.395">
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.414">
 </testcase>
 </testsuite>
-<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="chromium" tests="2" failures="1" skipped="0" time="5.93" errors="0">
-<testcase name="has title" classname="tests/example.spec.ts" time="0.513">
+<testsuite name="tests/example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="chromium" tests="2" failures="0" skipped="0" time="1.078" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.526">
 </testcase>
-<testcase name="get started link" classname="tests/example.spec.ts" time="5.417">
-<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
-<![CDATA[  [chromium] › tests/example.spec.ts:10:5 › get started link ───────────────────────────────────────
+<testcase name="get started link" classname="tests/example.spec.ts" time="0.552">
+</testcase>
+</testsuite>
+<testsuite name="tests/retry-and-skip-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="chromium" tests="2" failures="0" skipped="1" time="16.859" errors="0">
+<testcase name="retry" classname="tests/retry-and-skip-example.spec.ts" time="16.859">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
 
-    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
-
-    Locator: getByRole('heading', { name: 'Installation!' })
-    Expected: visible
-    Received: hidden
-    Call log:
-      - expect.toBeVisible with timeout 5000ms
-      - waiting for getByRole('heading', { name: 'Installation!' })
-
-
-      15 |
-      16 |   // Expects page to have a heading with the name of Installation.
-    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
-         |                                                                      ^
-      18 | });
-      19 |
-
-        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-chromium-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
 ]]>
-</failure>
+</system-out>
 </testcase>
-</testsuite>
-<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="firefox" tests="24" failures="0" skipped="1" time="38.037" errors="0">
-<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="24.745">
+<testcase name="skip this test" classname="tests/retry-and-skip-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
 <skipped>
 </skipped>
 </testcase>
-<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="1.02">
+</testsuite>
+<testsuite name="tests/retry-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="chromium" tests="2" failures="0" skipped="1" time="16.74" errors="0">
+<testcase name="retry" classname="tests/retry-example.spec.ts" time="16.74">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
+
+[[ATTACHMENT|test-results/tests-retry-example-retry-chromium-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
+]]>
+</system-out>
 </testcase>
-<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="1.068">
-</testcase>
-<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="1.211">
-</testcase>
-<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.565">
-</testcase>
-<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.621">
-</testcase>
-<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.551">
-</testcase>
-<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.499">
-</testcase>
-<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.462">
-</testcase>
-<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.449">
-</testcase>
-<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.446">
-</testcase>
-<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.455">
-</testcase>
-<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.442">
-</testcase>
-<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.47">
-</testcase>
-<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.386">
-</testcase>
-<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.443">
-</testcase>
-<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.462">
-</testcase>
-<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.453">
-</testcase>
-<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.619">
-</testcase>
-<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.504">
-</testcase>
-<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.608">
-</testcase>
-<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.478">
-</testcase>
-<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.576">
-</testcase>
-<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.504">
+<testcase name="skip this test" classname="tests/retry-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
 </testcase>
 </testsuite>
-<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="firefox" tests="2" failures="1" skipped="0" time="6.394" errors="0">
-<testcase name="has title" classname="tests/example.spec.ts" time="0.346">
-</testcase>
-<testcase name="get started link" classname="tests/example.spec.ts" time="6.048">
-<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
-<![CDATA[  [firefox] › tests/example.spec.ts:10:5 › get started link ────────────────────────────────────────
+<testsuite name="tests/timeout-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="chromium" tests="1" failures="1" skipped="0" time="0.298" errors="0">
+<testcase name="time-out" classname="tests/timeout-example.spec.ts" time="0.298">
+<failure message="timeout-example.spec.ts:3:5 time-out" type="FAILURE">
+<![CDATA[  [chromium] › tests/timeout-example.spec.ts:3:5 › time-out ────────────────────────────────────────
 
-    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+    Test timeout of 1ms exceeded.
 
-    Locator: getByRole('heading', { name: 'Installation!' })
-    Expected: visible
-    Received: hidden
+    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
     Call log:
-      - expect.toBeVisible with timeout 5000ms
-      - waiting for getByRole('heading', { name: 'Installation!' })
+      - navigating to "https://playwright.dev/", waiting until "load"
 
 
-      15 |
-      16 |   // Expects page to have a heading with the name of Installation.
-    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
-         |                                                                      ^
-      18 | });
-      19 |
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
 
-        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
+    test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip
+    Usage:
+
+        npx playwright show-trace test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #3 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
 ]]>
 </failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-timeout-example-time-out-chromium-retry1/trace.zip]]
+]]>
+</system-out>
 </testcase>
 </testsuite>
-<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="webkit" tests="24" failures="0" skipped="0" time="13.537" errors="0">
-<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="0.778">
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="firefox" tests="24" failures="0" skipped="0" time="14.096" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="0.973">
 </testcase>
-<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="0.746">
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="0.909">
 </testcase>
-<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="0.853">
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="0.94">
 </testcase>
-<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="0.576">
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="0.586">
 </testcase>
-<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.583">
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.578">
 </testcase>
-<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.639">
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.625">
 </testcase>
-<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.501">
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.528">
 </testcase>
-<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.512">
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.514">
 </testcase>
-<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.558">
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.569">
 </testcase>
-<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.487">
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.457">
 </testcase>
-<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.512">
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.46">
 </testcase>
-<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.505">
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.459">
 </testcase>
-<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.493">
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.469">
 </testcase>
-<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.498">
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.457">
 </testcase>
-<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.428">
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.374">
 </testcase>
-<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.501">
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.449">
 </testcase>
-<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.52">
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.488">
 </testcase>
-<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.519">
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.507">
 </testcase>
-<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.549">
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.651">
 </testcase>
-<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.532">
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.522">
 </testcase>
-<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.617">
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.712">
 </testcase>
-<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.529">
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.582">
 </testcase>
-<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.59">
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.733">
 </testcase>
-<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.511">
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.554">
 </testcase>
 </testsuite>
-<testsuite name="tests/example.spec.ts" timestamp="2024-01-31T07:12:52.585Z" hostname="webkit" tests="2" failures="1" skipped="0" time="6.071" errors="0">
-<testcase name="has title" classname="tests/example.spec.ts" time="0.485">
+<testsuite name="tests/example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="firefox" tests="2" failures="0" skipped="0" time="1.043" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.446">
 </testcase>
-<testcase name="get started link" classname="tests/example.spec.ts" time="5.586">
-<failure message="example.spec.ts:10:5 get started link" type="FAILURE">
-<![CDATA[  [webkit] › tests/example.spec.ts:10:5 › get started link ─────────────────────────────────────────
+<testcase name="get started link" classname="tests/example.spec.ts" time="0.597">
+</testcase>
+</testsuite>
+<testsuite name="tests/retry-and-skip-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="firefox" tests="2" failures="0" skipped="1" time="18.529" errors="0">
+<testcase name="retry" classname="tests/retry-and-skip-example.spec.ts" time="18.529">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
 
-    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-firefox-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
+]]>
+</system-out>
+</testcase>
+<testcase name="skip this test" classname="tests/retry-and-skip-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/retry-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="firefox" tests="2" failures="0" skipped="1" time="18.435" errors="0">
+<testcase name="retry" classname="tests/retry-example.spec.ts" time="18.435">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
 
-    Locator: getByRole('heading', { name: 'Installation!' })
-    Expected: visible
-    Received: hidden
+[[ATTACHMENT|test-results/tests-retry-example-retry-firefox-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
+]]>
+</system-out>
+</testcase>
+<testcase name="skip this test" classname="tests/retry-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/timeout-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="firefox" tests="1" failures="1" skipped="0" time="1.287" errors="0">
+<testcase name="time-out" classname="tests/timeout-example.spec.ts" time="1.287">
+<failure message="timeout-example.spec.ts:3:5 time-out" type="FAILURE">
+<![CDATA[  [firefox] › tests/timeout-example.spec.ts:3:5 › time-out ─────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
     Call log:
-      - expect.toBeVisible with timeout 5000ms
-      - waiting for getByRole('heading', { name: 'Installation!' })
+      - navigating to "https://playwright.dev/", waiting until "load"
 
 
-      15 |
-      16 |   // Expects page to have a heading with the name of Installation.
-    > 17 |   await expect(page.getByRole('heading', { name: 'Installation!' })).toBeVisible();
-         |                                                                      ^
-      18 | });
-      19 |
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
 
-        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/example.spec.ts:17:70
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
+    test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip
+    Usage:
+
+        npx playwright show-trace test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #3 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
 ]]>
 </failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-timeout-example-time-out-firefox-retry1/trace.zip]]
+]]>
+</system-out>
+</testcase>
+</testsuite>
+<testsuite name="tests/demo-todo-app.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="webkit" tests="24" failures="0" skipped="0" time="14.756" errors="0">
+<testcase name="New Todo › should allow me to add todo items" classname="tests/demo-todo-app.spec.ts" time="0.695">
+</testcase>
+<testcase name="New Todo › should clear text input field when an item is added" classname="tests/demo-todo-app.spec.ts" time="0.545">
+</testcase>
+<testcase name="New Todo › should append new items to the bottom of the list" classname="tests/demo-todo-app.spec.ts" time="0.612">
+</testcase>
+<testcase name="Mark all as completed › should allow me to mark all items as completed" classname="tests/demo-todo-app.spec.ts" time="0.618">
+</testcase>
+<testcase name="Mark all as completed › should allow me to clear the complete state of all items" classname="tests/demo-todo-app.spec.ts" time="0.644">
+</testcase>
+<testcase name="Mark all as completed › complete all checkbox should update state when items are completed / cleared" classname="tests/demo-todo-app.spec.ts" time="0.755">
+</testcase>
+<testcase name="Item › should allow me to mark items as complete" classname="tests/demo-todo-app.spec.ts" time="0.586">
+</testcase>
+<testcase name="Item › should allow me to un-mark items as complete" classname="tests/demo-todo-app.spec.ts" time="1.075">
+</testcase>
+<testcase name="Item › should allow me to edit an item" classname="tests/demo-todo-app.spec.ts" time="0.596">
+</testcase>
+<testcase name="Editing › should hide other controls when editing" classname="tests/demo-todo-app.spec.ts" time="0.639">
+</testcase>
+<testcase name="Editing › should save edits on blur" classname="tests/demo-todo-app.spec.ts" time="0.589">
+</testcase>
+<testcase name="Editing › should trim entered text" classname="tests/demo-todo-app.spec.ts" time="0.613">
+</testcase>
+<testcase name="Editing › should remove the item if an empty text string was entered" classname="tests/demo-todo-app.spec.ts" time="0.632">
+</testcase>
+<testcase name="Editing › should cancel edits on escape" classname="tests/demo-todo-app.spec.ts" time="0.599">
+</testcase>
+<testcase name="Counter › should display the current number of todo items" classname="tests/demo-todo-app.spec.ts" time="0.553">
+</testcase>
+<testcase name="Clear completed button › should display the correct text" classname="tests/demo-todo-app.spec.ts" time="0.582">
+</testcase>
+<testcase name="Clear completed button › should remove completed items when clicked" classname="tests/demo-todo-app.spec.ts" time="0.537">
+</testcase>
+<testcase name="Clear completed button › should be hidden when there are no items that are completed" classname="tests/demo-todo-app.spec.ts" time="0.537">
+</testcase>
+<testcase name="Persistence › should persist its data" classname="tests/demo-todo-app.spec.ts" time="0.535">
+</testcase>
+<testcase name="Routing › should allow me to display active items" classname="tests/demo-todo-app.spec.ts" time="0.522">
+</testcase>
+<testcase name="Routing › should respect the back button" classname="tests/demo-todo-app.spec.ts" time="0.619">
+</testcase>
+<testcase name="Routing › should allow me to display completed items" classname="tests/demo-todo-app.spec.ts" time="0.534">
+</testcase>
+<testcase name="Routing › should allow me to display all items" classname="tests/demo-todo-app.spec.ts" time="0.597">
+</testcase>
+<testcase name="Routing › should highlight the currently applied filter" classname="tests/demo-todo-app.spec.ts" time="0.542">
+</testcase>
+</testsuite>
+<testsuite name="tests/example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="webkit" tests="2" failures="0" skipped="0" time="1.149" errors="0">
+<testcase name="has title" classname="tests/example.spec.ts" time="0.506">
+</testcase>
+<testcase name="get started link" classname="tests/example.spec.ts" time="0.643">
+</testcase>
+</testsuite>
+<testsuite name="tests/retry-and-skip-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="webkit" tests="2" failures="0" skipped="1" time="17.206" errors="0">
+<testcase name="retry" classname="tests/retry-and-skip-example.spec.ts" time="17.206">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
+
+[[ATTACHMENT|test-results/tests-retry-and-skip-example-retry-webkit-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
+]]>
+</system-out>
+</testcase>
+<testcase name="skip this test" classname="tests/retry-and-skip-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/retry-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="webkit" tests="2" failures="0" skipped="1" time="17.145" errors="0">
+<testcase name="retry" classname="tests/retry-example.spec.ts" time="17.145">
+<system-out>
+<![CDATA[Retry count: [33m0[39m
+Retry count: [33m1[39m
+
+[[ATTACHMENT|test-results/tests-retry-example-retry-webkit-retry1/trace.zip]]
+Retry count: [33m2[39m
+Retry count: [33m3[39m
+]]>
+</system-out>
+</testcase>
+<testcase name="skip this test" classname="tests/retry-example.spec.ts" time="0">
+<properties>
+<property name="skip" value="">
+</property>
+</properties>
+<skipped>
+</skipped>
+</testcase>
+</testsuite>
+<testsuite name="tests/timeout-example.spec.ts" timestamp="2024-08-27T05:12:38.392Z" hostname="webkit" tests="1" failures="1" skipped="0" time="0.614" errors="0">
+<testcase name="time-out" classname="tests/timeout-example.spec.ts" time="0.614">
+<failure message="timeout-example.spec.ts:3:5 time-out" type="FAILURE">
+<![CDATA[  [webkit] › tests/timeout-example.spec.ts:3:5 › time-out ──────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
+    test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip
+    Usage:
+
+        npx playwright show-trace test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip
+
+    ────────────────────────────────────────────────────────────────────────────────────────────────
+
+    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+
+    Retry #3 ───────────────────────────────────────────────────────────────────────────────────────
+
+    Test timeout of 1ms exceeded.
+
+    Error: page.goto: Test timeout of 1ms exceeded.
+    Call log:
+      - navigating to "https://playwright.dev/", waiting until "load"
+
+
+      3 | test("time-out", async ({ page }, testInfo) => {
+      4 |   test.setTimeout(1);
+    > 5 |   await page.goto("https://playwright.dev/");
+        |              ^
+      6 |   await expect(page).toHaveTitle(new RegExp("Playwright"));
+      7 | });
+      8 |
+
+        at /Users/yabuki-ryosuke/src/github.com/launchableinc/examples/playwright/tests/timeout-example.spec.ts:5:14
+]]>
+</failure>
+<system-out>
+<![CDATA[
+[[ATTACHMENT|test-results/tests-timeout-example-time-out-webkit-retry1/trace.zip]]
+]]>
+</system-out>
 </testcase>
 </testsuite>
 </testsuites>

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -54,15 +54,13 @@ class PlaywrightTest(CliTestCase):
         target_test_path = "file=tests/timeout-example.spec.ts#testcase=time-out"
 
         # XML Report Case
-        self.cli('record', 'tests', '--session', self.session,
-                          'playwright', str(self.test_files_dir.joinpath("report.xml")))
+        self.cli('record', 'tests', '--session', self.session, 'playwright', str(self.test_files_dir.joinpath("report.xml")))
         xml_payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
 
         self.assertEqual(_test_test_path_status(xml_payload, target_test_path, CaseEvent.TEST_FAILED), True)
 
         # JSON Report Case
         self.cli('record', 'tests', '--session', self.session,
-                          'playwright', '--json', str(self.test_files_dir.joinpath("report.json")))
+                 'playwright', '--json', str(self.test_files_dir.joinpath("report.json")))
         json_payload = json.loads(gzip.decompress(self.find_request('/events', 1).request.body).decode())
         self.assertEqual(_test_test_path_status(json_payload, target_test_path, CaseEvent.TEST_FAILED), True)
-

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -1,3 +1,5 @@
+import gzip
+import json
 import os
 import sys
 import unittest
@@ -5,6 +7,8 @@ from unittest import mock
 
 import responses  # type: ignore
 
+from launchable.commands.record.case_event import CaseEvent
+from launchable.testpath import unparse_test_path
 from tests.cli_test_case import CliTestCase
 
 
@@ -33,3 +37,36 @@ class PlaywrightTest(CliTestCase):
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result_with_json.json')
+
+    @responses.activate
+    @mock.patch.dict(os.environ,
+                     {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test_timedOut_status(self):
+        # XML Report Case
+        self.cli('record', 'tests', '--session', self.session,
+                          'playwright', str(self.test_files_dir.joinpath("report.xml")))
+        xml_payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
+
+        checkedXML = False
+        for event in xml_payload.get("events"):
+            testPath = unparse_test_path(event.get("testPath"))
+            if testPath != "file=tests/timeout-example.spec.ts#testcase=time-out":
+                continue
+            self.assertEqual(event.get("status"), CaseEvent.TEST_FAILED)
+            checkedXML = True
+        self.assertEqual(checkedXML, True)
+
+        # JSON Report Case
+        self.cli('record', 'tests', '--session', self.session,
+                          'playwright', '--json', str(self.test_files_dir.joinpath("report.json")))
+        json_payload = json.loads(gzip.decompress(self.find_request('/events', 1).request.body).decode())
+
+        checkedJSON = False
+        for event in json_payload.get("events"):
+            testPath = unparse_test_path(event.get("testPath"))
+            if testPath != "file=tests/timeout-example.spec.ts#testcase=time-out":
+                continue
+            print(event)
+            self.assertEqual(event.get("status"), CaseEvent.TEST_FAILED)
+            checkedJSON = True
+        self.assertEqual(checkedJSON, True)


### PR DESCRIPTION
Playwright defines the test status type not only "passed","failed", and "skipped" but also "timedOut" and "interrupted".
see: https://playwright.dev/docs/api/class-testresult#test-result-status

However the cli hadn't supported it. So we updated to support the status of "timeOut" and "interrupted" 