### PR TITLE
Update e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.22
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Installing bazelisk@latest now seems to require Go 1.22

https://github.com/launchableinc/cli/actions/runs/11133632530/job/30940136056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Go version used in the end-to-end testing workflow from 1.17 to 1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->