### PR TITLE
Update the Go version in e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.22
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Fixes https://github.com/launchableinc/cli/actions/runs/11129207798/job/30925742196#step:8:24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go version in the end-to-end testing workflow from 1.17 to 1.22 for improved compatibility.
	- Made minor formatting adjustments to ensure proper YAML syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->