### PR TITLE
Improved a confusing message

### DIFF
--- a/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitIngester.java
@@ -148,7 +148,7 @@ public class CommitIngester {
       if (numCommits != 1) {
         suffix = "commits";
       }
-      System.out.printf("Launchable recorded %d %s from repository %s%n", numCommits, suffix, repo);
+      System.out.printf("Launchable transferred %d more %s from repository %s%n", numCommits, suffix, repo);
     }
   }
 


### PR DESCRIPTION
Many users get worried that this message is reporting "0 commits recorded". I'm trying to emphasize this is just transfer of new commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated logging output to indicate that commits are "transferred" instead of "recorded," enhancing clarity for users.
  
- **Bug Fixes**
	- Deprecated the `setNoCommitMessage(boolean b)` method to simplify the interface while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->