### PR TITLE
Trying to make `pipenv install --dev` work

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -75,6 +75,7 @@ jobs:
           pipenv install --dev --python ${{ matrix.python-version }}
     - name: Build
       run: |
+        pipenv run pip list
         pipenv run build
         pipenv run install
     - name: Type check

--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,8 @@ types-requests = "*"
 types-tabulate = "*"
 lxml = "<=5.2.2"
 unittest-xml-reporting = "*"
+# newer virtualenv creates a conflict with importlib-metadata. This is the latest version that seems to avoid that
+virtualenv = "==20.16.2"
 
 [packages]
 launchable = {editable = true, path = "."}


### PR DESCRIPTION
After a failure at https://github.com/launchableinc/cli/pull/955 I'm coming in for a minimal bandaid approach.

Also list the packages and their versions so that we can keep track of how dependencies have resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a command to list installed Python packages in the GitHub Actions workflow.
	- Introduced a new development dependency: `virtualenv` version `20.16.2` to resolve conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->