### PR TITLE
Introduce non-blocking mode in subset command

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -232,20 +232,6 @@ def subset(
         )
         sys.exit(1)
 
-    if (not is_observation) and is_non_blocking:
-        msg = "You have to specify --observation option to use non-blocking mode"
-        click.echo(
-            click.style(
-                msg,
-                fg="red"),
-            err=True,
-        )
-        tracking_client.send_error_event(
-            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
-            stack_trace=msg,
-        )
-        sys.exit(1)
-
     if is_observation and is_output_exclusion_rules:
         msg = (
             "WARNING: --observation and --output-exclusion-rules are set. "

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -135,11 +135,9 @@ from .test_path_writer import TestPathWriter
 @click.option(
     "--non-blocking",
     "is_non_blocking",
-    help="""
-    Do not wait for subset requests in observation mode.
-    Please note that the CLI does not output a subset list if you specify this option.
-    """,
+    help="Do not wait for subset requests in observation mode.",
     is_flag=True,
+    hidden=True,
 )
 @click.option(
     "--ignore-flaky-tests-above",
@@ -523,6 +521,7 @@ def subset(
                         process = Process(target=subset_request, args=(client, timeout, payload))
                         process.start()
                         click.echo("The subset was requested in non-blocking mode.")
+                        self.output_handler(self.test_paths, [])
                         return
 
                     res = subset_request(client=client, timeout=timeout, payload=payload)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -634,5 +634,5 @@ def subset(
     context.obj = Optimize(app=context.obj)
 
 
-def subset_request(client: LaunchableClient, timeout: Tuple[int, int], payload: dict[str, Any]):
+def subset_request(client: LaunchableClient, timeout: Tuple[int, int], payload: Dict[str, Any]):
     return client.request("post", "subset", timeout=timeout, payload=payload, compress=True)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -520,7 +520,7 @@ def subset(
                         # Create a new process for requesting a subset.
                         process = Process(target=subset_request, args=(client, timeout, payload))
                         process.start()
-                        click.echo("The subset was requested in non-blocking mode.")
+                        click.echo("The subset was requested in non-blocking mode.", err=True)
                         self.output_handler(self.test_paths, [])
                         return
 


### PR DESCRIPTION
## Summary

- **New Features**
  - Added a `--non-blocking` option to the `subset` command
  - Introduced ability to request a subset without waiting for a response in observation mode

```
$ find tests -name "test_*.py" | grep -v tests/data | /Users/ono-max/.local/share/virtualenvs/cli-tPknK2Me/bin/launchable subset --target 80% --observation --non-blocking file
The subset was requested in non-blocking mode.
```

@Konboi I've implemented this feature based on your suggestion. Can you review it? Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a non-blocking option for the subset command.
	- Enables asynchronous subset request processing.
- **Bug Fixes**
	- Improved error handling for non-blocking mode.
- **Documentation**
	- Updated command-line help text for the subset command, including corrections to typos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->