### PR TITLE
Measure the performance in `launchable record tests` command

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -1,3 +1,4 @@
+from time import time
 from typing import Optional, Sequence, Tuple
 
 import click
@@ -135,6 +136,12 @@ def find_or_create_session(
         test_suite=test_suite,
     )
     return read_session(saved_build_name)
+
+
+def time_ns():
+    # time.time_ns() method is new in Python version 3.7
+    # As a workaround, we convert time.time() to nanoseconds.
+    return int(time() * 1e9)
 
 
 def _check_observation_mode_status(session: str, is_observation: bool,

--- a/launchable/utils/tracking.py
+++ b/launchable/utils/tracking.py
@@ -13,6 +13,7 @@ class Tracking:
     # General events
     class Event(Enum):
         SHALLOW_CLONE = 'SHALLOW_CLONE'  # this event is an example
+        PERFORMANCE = 'PERFORMANCE'
 
     # Error events
     class ErrorEvent(Enum):

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -451,7 +451,7 @@ class APIErrorTest(CliTestCase):
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
-        self.assert_tracking_count(tracking=tracking, count=8)
+        self.assert_tracking_count(tracking=tracking, count=9)
 
     def assert_tracking_count(self, tracking, count: int):
         # Prior to 3.6, `Response` object can't be obtained.


### PR DESCRIPTION
- Added performance tracking capabilities to record time measurements for report file parsing and API event sending
- Introduced a new performance event type for more detailed tracking

Here is the example of metadata after executing `launchable record tests command`.

```
 {"workspace": "mothership", "elapsed_time": "3004330000", "organization": "cli", "measurement_target": "testcases method(parsing report file)"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added performance tracking capabilities to record time measurements for specific code operations.
	- Introduced a new `PERFORMANCE` event type for tracking performance-related events.

- **Tests**
	- Updated test case to reflect an additional tracking event when the server is down. 

- **Chores**
	- Added a utility function for obtaining the current time in nanoseconds to enhance time measurement accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->