### PR TITLE
Fix e2e workflow failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ on:
 env:
   LAUNCHABLE_DEBUG: 1
   LAUNCHABLE_REPORT_ERROR: 1
+  # The WORKSPACE file is disabled by default in Bazel 8.
+  # As a workaround, we configure the old version.
+  USE_BAZEL_VERSION: "7.x"
 
 
 jobs:


### PR DESCRIPTION
Currently, e2e workflow is failing right now. It's because the latest Bazel version 8 doesn't support WORKSPACE file. As a workaround, I configure version 7. I've already confirmed it worked.

```
ERROR: error loading package under directory '': error loading package 'src/test/java/com/ninjinkun': Unable to find package for @@[unknown repo 'rules_java' requested from @@]//java:defs.bzl: The repository '@@[unknown repo 'rules_java' requested from @@]' could not be resolved: No repository visible as '@rules_java' from main repository. Was the repository introduced in WORKSPACE? The WORKSPACE file is disabled by default in Bazel 8 (late 2024) and will be removed in Bazel 9 (late 2025), please migrate to Bzlmod. See https://bazel.build/external/migration.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to ensure compatibility with Bazel 7.x
	- Added environment variable to manage Bazel version settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->