### PR TITLE
subset: relax validation rule

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -218,20 +218,6 @@ def subset(
     app = context.obj
     tracking_client = TrackingClient(Tracking.Command.SUBSET, app=app)
 
-    if is_observation and is_get_tests_from_previous_sessions:
-        msg = "Cannot use --observation and --get-tests-from-previous-sessions options at the same time"
-        click.echo(
-            click.style(
-                msg,
-                fg="red"),
-            err=True,
-        )
-        tracking_client.send_error_event(
-            event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,
-            stack_trace=msg,
-        )
-        sys.exit(1)
-
     if is_observation and is_output_exclusion_rules:
         msg = (
             "WARNING: --observation and --output-exclusion-rules are set. "


### PR DESCRIPTION
[Ruby team](https://github.com/ruby/ruby) tries to use Zero Input Subsetting in the observation mode for their CI environment, but using both observation mode and Zero Input Subsetting are banned by CLI.

This validation rule has been introduced since https://github.com/launchableinc/cli/pull/435/files#diff-4c62e35fb4e3b2b6bff8593107cdddd1fd47eff90293edc9d838c9b2f3cff94aR138.

After discussion with @Konboi , we reached to the accord that we can relax the validation rule without any problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Modified flag handling in subset command to remove previous restrictions on conflicting options
  - Simplified option processing logic while maintaining core functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->