### PR TITLE
Update the Ubuntu version on CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,12 +31,15 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        # Python 3.6 is not supported on Ubuntu 22.04.
+        os: [ubuntu-22.04, windows-latest]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        include:
+          - os: windows-latest
+            python-version: 3.6
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

* Update the Ubuntu version.
* Stop using Python 3.6 when running CI on Ubuntu.
  * https://github.com/actions/setup-python/issues/665
