### PR TITLE
To support `session-name` option to the subset command

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -275,7 +275,7 @@ def subset(
         if session_name:
             if not build_name:
                 raise click.UsageError(
-                    '--build option is required when you uses a --session-name option ')
+                    '--build option is required when you use a --session-name option ')
             sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
             client = LaunchableClient(test_runner=context.invoked_subcommand, app=context.obj, tracking_client=tracking_client)
             res = client.request("get", sub_path)

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -160,6 +160,14 @@ from .test_path_writer import TestPathWriter
     is_flag=True,
 )
 @click.option(
+    '--session-name',
+    'session_name',
+    help='test session name',
+    required=False,
+    type=str,
+    metavar='SESSION_NAME',
+)
+@click.option(
     '--lineage',
     'lineage',
     help='Set lineage name. This option value will be passed to the record session command if a session isn\'t created yet.',
@@ -210,6 +218,7 @@ def subset(
     ignore_flaky_tests_above: Optional[float],
     links: Sequence[Tuple[str, str]] = (),
     is_no_build: bool = False,
+    session_name: Optional[str] = None,
     lineage: Optional[str] = None,
     prioritize_tests_failed_within_hours: Optional[int] = None,
     prioritized_tests_mapping_file: Optional[TextIO] = None,
@@ -263,18 +272,36 @@ def subset(
     session_id = None
     tracking_client = TrackingClient(Tracking.Command.SUBSET, app=app)
     try:
-        session_id = find_or_create_session(
-            context=context,
-            session=session,
-            build_name=build_name,
-            flavor=flavor,
-            is_observation=is_observation,
-            links=links,
-            is_no_build=is_no_build,
-            lineage=lineage,
-            tracking_client=tracking_client,
-            test_suite=test_suite,
+        if session_name:
+            if not build_name:
+                raise click.UsageError(
+                    '--build option is required when you uses a --session-name option ')
+            sub_path = "builds/{}/test_session_names/{}".format(build_name, session_name)
+            client = LaunchableClient(test_runner=context.invoked_subcommand, app=context.obj, tracking_client=tracking_client)
+            res = client.request("get", sub_path)
+            res.raise_for_status()
+            session_id = "builds/{}/test_sessions/{}".format(build_name, res.json().get("id"))
+        else:
+            session_id = find_or_create_session(
+                context=context,
+                session=session,
+                build_name=build_name,
+                flavor=flavor,
+                is_observation=is_observation,
+                links=links,
+                is_no_build=is_no_build,
+                lineage=lineage,
+                tracking_client=tracking_client,
+                test_suite=test_suite,
+            )
+    except click.UsageError as e:
+        click.echo(
+            click.style(
+                str(e),
+                fg="red"),
+            err=True,
         )
+        sys.exit(1)
     except Exception as e:
         tracking_client.send_error_event(
             event_name=Tracking.ErrorEvent.INTERNAL_CLI_ERROR,

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -301,6 +301,7 @@ def subset(
                 fg="red"),
             err=True,
         )
+        tracking_client.send_error_event(event_name=Tracking.ErrorEvent.USER_ERROR, stack_trace=str(e))
         sys.exit(1)
     except Exception as e:
         tracking_client.send_error_event(


### PR DESCRIPTION
According to the documentation, it's supposed to be supported, but the subset isn't actually supported

![image](https://github.com/user-attachments/assets/0715ca64-76f0-4d98-ad0e-958c58cd0357)
ref: https://www.launchableinc.com/docs/resources/cli-reference/#3500790-subset

```sh
$ launchable subset --session-name test-session
Usage: launchable subset [OPTIONS] COMMAND [ARGS]...
Try 'launchable subset --help' for help.

Error: No such option: --session-name Did you mean --session?
```

Even in the record tests command with the session-name option, the build option is required.
So for case the session-name option is set and the build option isn't set, the CLI treated it as a miss integration, and made it exit with status code 1 to prevent the process from continuing.

### Checked Locally

```sh
$ launchable record build --name session-name-test
Launchable transferred 1 more commit from repository /Users/yabuki-ryosuke/src/github.com/launchableinc/cli
Launchable recorded build session-name-test to workspace launchableinc/mothership with commits from 1 repository:

| Name   | Path   | HEAD Commit                              |
|--------|--------|------------------------------------------|
| .      | .      | 1fdf4db7a34e5317c039212a292d90145a571d24 |

Visit https://app.launchableinc.com/organizations/launchable

$ launchable record session --build session-name-test --session-name this-is-a-session-name
builds/session-name-test/test_sessions/2909

$ find ./tests/**/test_*.py | launchable subset --target 60% --build session-name-test --session-name this-is-a-session-name file > subset.txt
Your model is currently in training
Launchable created subset 68 for build session-name-test (test session 2909) in workspace launchableinc/mothership

|           |   Candidates |   Estimated duration (%) |   Estimated duration (min) |
|-----------|--------------|--------------------------|----------------------------|
| Subset    |           24 |                    47.06 |                       0.00 |
| Remainder |           27 |                    52.94 |                       0.00 |
|           |              |                          |                            |
| Total     |           51 |                   100.00 |                       0.00 |

Run `launchable inspect subset --subset-id 68` to view full subset details
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `--session-name` option to the subset command to specify a test session by name.
- **Bug Fixes**
  - Enhanced error handling for the `--session-name` option with clearer user feedback on incorrect usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->