### PR TITLE
To publish the new version of the cli

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
     needs: tagpr
     if: needs.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu-20.04 is already deprecated ref: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

Also, the this job that was used ubuntu-20.04 was canceled see: https://github.com/launchableinc/cli/actions/runs/14918738650/job/41909954624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment workflow to use Ubuntu 22.04 for publishing the Python package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->