### PR TITLE
To support for importing historical data

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -1,3 +1,4 @@
+import datetime
 from time import time
 from typing import Optional, Sequence, Tuple
 
@@ -64,6 +65,7 @@ def find_or_create_session(
     is_no_build: bool = False,
     lineage: Optional[str] = None,
     test_suite: Optional[str] = None,
+    timestamp: Optional[datetime.datetime] = None,
 ) -> Optional[str]:
     """Determine the test session ID to be used.
 
@@ -134,6 +136,7 @@ def find_or_create_session(
         is_no_build=is_no_build,
         lineage=lineage,
         test_suite=test_suite,
+        timestamp=timestamp,
     )
     return read_session(saved_build_name)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -12,7 +12,7 @@ from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...utils import subprocess
 from ...utils.authentication import get_org_workspace
-from ...utils.click import KEY_VALUE
+from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE
 from ...utils.launchable_client import LaunchableClient
 from ...utils.session import clean_session_files, write_build
 from .commit import commit
@@ -98,9 +98,10 @@ CODE_BUILD_WEBHOOK_HEAD_REF_KEY = "CODEBUILD_WEBHOOK_HEAD_REF"
     hidden=True,
 )
 @click.option(
-    '--timestamp', 'timestamp',
+    '--timestamp',
+    'timestamp',
     help='Import historical data with the original build timestamp. Note: Format is `YYYY-MM-DD HH:MM:SS`, timezone is UTC by default.',  # noqa: E501
-    type=click.DateTime(formats=["%Y-%m-%d %H:%M:%S"]),
+    type=DATETIME_WITH_TZ,
     default=None,
 )
 @click.pass_context

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -100,7 +100,7 @@ CODE_BUILD_WEBHOOK_HEAD_REF_KEY = "CODEBUILD_WEBHOOK_HEAD_REF"
 @click.option(
     '--timestamp',
     'timestamp',
-    help='Import historical data with the original build timestamp. Note: Format is `YYYY-MM-DD HH:MM:SS`, timezone is UTC by default.',  # noqa: E501
+    help='Used to overwrite the build time when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
     type=DATETIME_WITH_TZ,
     default=None,
 )

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import sys
@@ -6,6 +7,7 @@ from typing import Optional, Sequence, Tuple
 
 import click
 
+from launchable.utils.click import DATETIME_WITH_TZ
 from launchable.utils.link import LinkKind, capture_link
 from launchable.utils.tracking import Tracking, TrackingClient
 
@@ -98,6 +100,13 @@ def _validate_session_name(ctx, param, value):
     type=str,
     metavar='TEST_SUITE',
 )
+@click.option(
+    '--timestamp',
+    'timestamp',
+    help='Used to overwrite the session time when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
+    type=DATETIME_WITH_TZ,
+    default=None,
+)
 @click.pass_context
 def session(
     ctx: click.core.Context,
@@ -111,6 +120,7 @@ def session(
     session_name: Optional[str] = None,
     lineage: Optional[str] = None,
     test_suite: Optional[str] = None,
+    timestamp: Optional[datetime.datetime] = None,
 ):
     """
     print_session is for backward compatibility.
@@ -166,6 +176,7 @@ def session(
         "noBuild": is_no_build,
         "lineage": lineage,
         "testSuite": test_suite,
+        "timestamp": timestamp.isoformat() if timestamp else None,
     }
 
     _links = capture_link(os.environ)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -16,7 +16,7 @@ from launchable.utils.authentication import ensure_org_workspace
 from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
-from ...utils.click import KEY_VALUE
+from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE
 from ...utils.exceptions import InvalidJUnitXMLException
 from ...utils.launchable_client import LaunchableClient
 from ...utils.logger import Logger
@@ -159,6 +159,13 @@ def _validate_group(ctx, param, value):
     type=str,
     metavar='TEST_SUITE',
 )
+@click.option(
+    '--timestamp',
+    'timestamp',
+    help='Used to overwrite the test executed times when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
+    type=DATETIME_WITH_TZ,
+    default=None,
+)
 @click.pass_context
 def tests(
     context: click.core.Context,
@@ -177,6 +184,7 @@ def tests(
     session_name: Optional[str] = None,
     lineage: Optional[str] = None,
     test_suite: Optional[str] = None,
+    timestamp: Optional[datetime.datetime] = None,
 ):
     logger = Logger()
 
@@ -436,6 +444,10 @@ def tests(
                             # trim empty test path
                             if len(tc.get('testPath', [])) == 0:
                                 continue
+
+                            # Set specific time for importing historical data
+                            if timestamp is not None:
+                                tc["createdAt"] = timestamp.isoformat()
 
                             yield tc
 

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -412,8 +412,13 @@ def tests(
             ctime = datetime.datetime.fromtimestamp(
                 os.path.getctime(junit_report_file))
 
-            if not self.is_allow_test_before_build and not self.is_no_build and (
-                    self.check_timestamp and ctime.timestamp() < record_start_at.timestamp()):
+            if (
+                    not self.is_allow_test_before_build  # nlqa: W503
+                    and not self.is_no_build  # noqa: W503
+                    and timestamp is None  # noqa: W503
+                    and self.check_timestamp  # noqa: W503
+                    and ctime.timestamp() < record_start_at.timestamp()  # noqa: W503
+            ):
                 format = "%Y-%m-%d %H:%M:%S"
                 logger.warning("skip: {} is too old to report. start_record_at: {} file_created_at: {}".format(
                     junit_report_file, record_start_at.strftime(format), ctime.strftime(format)))

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -244,6 +244,7 @@ def tests(
                 links=links,
                 lineage=lineage,
                 test_suite=test_suite,
+                timestamp=timestamp,
                 tracking_client=tracking_client))
             build_name = read_build()
             record_start_at = get_record_start_at(session_id, client)

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -1,10 +1,11 @@
 import re
 import sys
-from datetime import datetime, timezone
 from typing import Dict, Optional, Tuple
 
 import click
+import dateutil.parser
 from click import ParamType
+from dateutil.tz import tzlocal
 
 # click.Group has the notion of hidden commands but it doesn't allow us to easily add
 # the same command under multiple names and hide all but one.
@@ -101,10 +102,12 @@ class DateTimeWithTimezoneType(ParamType):
     def convert(self, value: str, param: Optional[click.core.Parameter], ctx: Optional[click.core.Context]):
 
         try:
-            dt = datetime.fromisoformat(value.replace(" ", "T"))
-            return dt.replace(tzinfo=timezone.utc)
+            dt = dateutil.parser.parse(value)
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=tzlocal())
+            return dt
         except ValueError:
-            self.fail("Expected datetime like 2023-10-01T12:00:00but got '{}'".format(value), param, ctx)
+            self.fail("Expected datetime like 2023-10-01T12:00:00 but got '{}'".format(value), param, ctx)
 
 
 PERCENTAGE = PercentageType()

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from datetime import datetime, timezone
 from typing import Dict, Optional, Tuple
 
 import click
@@ -94,10 +95,23 @@ class FractionType(ParamType):
         self.fail("Expected fraction like 1/2 but got '{}'".format(value), param, ctx)
 
 
+class DateTimeWithTimezoneType(ParamType):
+    name = "datetime"
+
+    def convert(self, value: str, param: Optional[click.core.Parameter], ctx: Optional[click.core.Context]):
+
+        try:
+            dt = datetime.fromisoformat(value.replace(" ", "T"))
+            return dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            self.fail("Expected datetime like 2023-10-01T12:00:00but got '{}'".format(value), param, ctx)
+
+
 PERCENTAGE = PercentageType()
 DURATION = DurationType()
 FRACTION = FractionType()
 KEY_VALUE = KeyValueType()
+DATETIME_WITH_TZ = DateTimeWithTimezoneType()
 
 # Can the output deal with Unicode emojis?
 try:

--- a/tests/commands/record/test_build.py
+++ b/tests/commands/record/test_build.py
@@ -59,7 +59,8 @@ class BuildTest(CliTestCase):
                         "branchName": ""
                     },
                 ],
-                "links": []
+                "links": [],
+                "timestamp": None
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)
@@ -93,7 +94,8 @@ class BuildTest(CliTestCase):
                         "branchName": ""
                     },
                 ],
-                "links": []
+                "links": [],
+                "timestamp": None
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)
@@ -124,7 +126,8 @@ class BuildTest(CliTestCase):
                             "branchName": "",
                         },
                     ],
-                    "links": []
+                    "links": [],
+                    "timestamp": None
                 }, payload)
 
             self.assertEqual(read_build(), self.build_name)
@@ -153,7 +156,8 @@ class BuildTest(CliTestCase):
                         "branchName": ""
                     },
                 ],
-                "links": []
+                "links": [],
+                'timestamp': None
             }, payload)
         responses.calls.reset()
 
@@ -182,7 +186,8 @@ class BuildTest(CliTestCase):
                         "branchName": "feature-xxx"
                     },
                 ],
-                "links": []
+                "links": [],
+                "timestamp": None
             }, payload)
         responses.calls.reset()
 
@@ -211,7 +216,8 @@ class BuildTest(CliTestCase):
                         "branchName": ""
                     },
                 ],
-                "links": []
+                "links": [],
+                "timestamp": None
             }, payload)
         responses.calls.reset()
         self.assertIn("Invalid repository name B in a --branch option. ", result.output)
@@ -250,7 +256,8 @@ class BuildTest(CliTestCase):
                         "branchName": "feature-yyy"
                     },
                 ],
-                "links": []
+                "links": [],
+                "timestamp": None
             }, payload)
         responses.calls.reset()
 
@@ -264,7 +271,9 @@ class BuildTest(CliTestCase):
 # make sure the output of git-submodule is properly parsed
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    # to tests on GitHub Actions
     @mock.patch.dict(os.environ, {"GITHUB_ACTIONS": ""})
+    @mock.patch.dict(os.environ, {"GITHUB_PULL_REQUEST_URL": ""})
     @mock.patch('launchable.utils.subprocess.check_output')
     def test_with_timestamp(self, mock_check_output):
         self.assertEqual(read_build(), None)
@@ -272,20 +281,28 @@ class BuildTest(CliTestCase):
             "record",
             "build",
             "--no-commit-collection",
+            "--commit",
+            "repo=abc12",
             "--name",
             self.build_name,
             '--timestamp',
-            "2025-01-23 12:34:56")
+            "2025-01-23 12:34:56Z")
         self.assert_success(result)
 
         payload = json.loads(responses.calls[0].request.body.decode())
         self.assert_json_orderless_equal(
             {
                 "buildNumber": "123",
-                "lineage": "main",
-                "commitHashes": [],
+                "lineage": None,
+                "commitHashes": [
+                    {
+                        "repositoryName": "repo",
+                        "commitHash": "abc12",
+                        "branchName": ""
+                    },
+                ],
                 "links": [],
-                "timestamp": "2025-01-23T12:34:56Z"
+                "timestamp": "2025-01-23T12:34:56+00:00"
             }, payload)
 
         self.assertEqual(read_build(), self.build_name)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -160,4 +160,26 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": None,
             "testSuite": "example-test-suite",
+            "timestamp": None,
+        }, payload)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {
+        "LAUNCHABLE_TOKEN": CliTestCase.launchable_token,
+        'LANG': 'C.UTF-8',
+    }, clear=True)
+    def test_run_session_with_timestamp(self):
+        result = self.cli("record", "session", "--build", self.build_name,
+                          "--timestamp", "2023-10-01T12:00:00Z")
+        self.assert_success(result)
+
+        payload = json.loads(responses.calls[0].request.body.decode())
+        self.assert_json_orderless_equal({
+            "flavors": {},
+            "isObservation": False,
+            "links": [],
+            "noBuild": False,
+            "lineage": None,
+            "testSuite": None,
+            "timestamp": "2023-10-01T12:00:00+00:00",
         }, payload)

--- a/tests/commands/record/test_session.py
+++ b/tests/commands/record/test_session.py
@@ -34,6 +34,7 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": None,
             "testSuite": None,
+            "timestamp": None,
         }, payload)
 
     @responses.activate
@@ -58,6 +59,7 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": None,
             "testSuite": None,
+            "timestamp": None,
         }, payload)
 
         result = self.cli("record", "session", "--build", self.build_name, "--flavor", "only-key")
@@ -82,6 +84,7 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": None,
             "testSuite": None,
+            "timestamp": None,
         }, payload)
 
     @responses.activate
@@ -120,6 +123,7 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": None,
             "testSuite": None,
+            "timestamp": None,
         }, payload)
 
     @responses.activate
@@ -140,6 +144,7 @@ class SessionTest(CliTestCase):
             "noBuild": False,
             "lineage": "example-lineage",
             "testSuite": None,
+            "timestamp": None,
         }, payload)
 
     @responses.activate

--- a/tests/utils/test_click.py
+++ b/tests/utils/test_click.py
@@ -1,9 +1,12 @@
 import datetime
+from datetime import timezone
 from typing import Sequence, Tuple
 from unittest import TestCase
+from zoneinfo import ZoneInfo
 
 import click
 from click.testing import CliRunner
+from dateutil.tz import tzlocal
 
 from launchable.utils.click import DATETIME_WITH_TZ, KEY_VALUE, convert_to_seconds
 

--- a/tests/utils/test_click.py
+++ b/tests/utils/test_click.py
@@ -2,7 +2,6 @@ import datetime
 from datetime import timezone
 from typing import Sequence, Tuple
 from unittest import TestCase
-from zoneinfo import ZoneInfo
 
 import click
 from click.testing import CliRunner


### PR DESCRIPTION
To use PTS, data is required, but collecting new data from scratch takes time.
Therefore, we will provide a `--timestamp` option to allow importing past data as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new optional --timestamp command-line option to the build, tests, and session commands, allowing users to specify custom datetimes (with or without timezone) for importing historical data.
- **Bug Fixes**
  - Improved handling of datetime inputs by automatically assigning local timezone if none is provided.
- **Tests**
  - Added tests to verify correct parsing and handling of the new --timestamp option and datetime inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->