### PR TITLE
Fix e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,10 +16,10 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4


### PR DESCRIPTION
e2e test is stopping....

![image](https://github.com/user-attachments/assets/f8bf6324-3377-4e27-b153-b42d1134e1d7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated end-to-end test workflow to use the latest Ubuntu runner and removed Python 3.6 from the test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->