### PR TITLE
Fix e2e part2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,10 +13,9 @@ env:
   # As a workaround, we configure the old version.
   USE_BAZEL_VERSION: "7.x"
 
-
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.24
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
:cry:

- The ubuntu latest (v24) doesn't support python 3.7
- Need go that is newer than v1.23 to install bazelisk
