### PR TITLE
Error message improvement

### DIFF
--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -289,7 +289,7 @@ class SubsetTest(CliTestCase):
         # check error when input candidates are empty without --get-tests-from-previous-sessions option
         result = self.cli("subset", "--target", "30%", "--session", self.session, "file")
         self.assert_exit_code(result, 1)
-        self.assertTrue("Please set subset candidates or use `--get-tests-from-previous-sessions` option" in result.stdout)
+        self.assertIn("use the `--get-tests-from-previous-sessions` option", result.stdout)
 
         responses.replace(
             responses.POST,


### PR DESCRIPTION
People who forget to give any tests do not understand that 'subset candidates' are expected, so better to rework the message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages to clearly distinguish between missing test input and unmatched arguments when no tests are found.
- **Tests**
  - Updated test assertions to align with the revised error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->