### PR TITLE
Redone the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM eclipse-temurin:8
+FROM python:3.11-slim
 
-USER root
+# Install Java runtime
+RUN apt-get update && \
+    apt-get install -y openjdk-17-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  python3 \
-  python3-setuptools \
-  pipx \
-  && apt-get -y clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir wheel
+RUN pip install --no-cache-dir launchable
 
-ENV PATH="$PATH:/root/.local/bin"
+RUN useradd -m launchable
+USER launchable
 
-RUN pipx install wheel
-RUN pipx install launchable
+# ENTRYPOINT, as opposed to CMD, ensure that user-provided additional options get passed to launchable,
+# and eliminate the need for users to duplicate 'launchable' in their command line.
+ENTRYPOINT ["launchable"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends openjdk-17-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /wheels/*.whl /wheels/
-RUN pip install --no-cache-dir /wheels/*.whl && \
-    rm -rf /wheels
+RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels pip install --no-cache-dir /wheels/*.whl
 
 # get rid of a warning that talks about pkg_resources deprecation
 # see https://setuptools.pypa.io/en/latest/history.html#v67-3-0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS builder
 
-# Install Java runtime
 RUN apt-get update && \
-    apt-get install -y openjdk-17-jre-headless && \
-    apt-get clean && \
+    apt-get install -y git && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir wheel
-RUN pip install --no-cache-dir launchable
+WORKDIR /src
+COPY . .
+RUN pip wheel --no-cache-dir -w /wheels .
+RUN ls /wheels
+
+FROM python:3.11-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-17-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels/*.whl /wheels/
+RUN pip install --no-cache-dir /wheels/*.whl && \
+    rm -rf /wheels
+
+# get rid of a warning that talks about pkg_resources deprecation
+# see https://setuptools.pypa.io/en/latest/history.html#v67-3-0
+RUN pip install setuptools==66.1.1
 
 RUN useradd -m launchable
 USER launchable
 
-# ENTRYPOINT, as opposed to CMD, ensure that user-provided additional options get passed to launchable,
-# and eliminate the need for users to duplicate 'launchable' in their command line.
 ENTRYPOINT ["launchable"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && \
 WORKDIR /src
 COPY . .
 RUN pip wheel --no-cache-dir -w /wheels .
-RUN ls /wheels
 
 FROM python:3.11-slim
 


### PR DESCRIPTION
The immediate motivation for the change was from a prospect who had the opsec policy to avoid root in containers. That in turn revealed the problem that the current container is built with venv, a rather odd choise for a container!

It turns out that we probably didn't choose venv because we were clever. Rather, the base image was ubuntu and it disabled/discouraged global pip package installation as it collides with APT.

I could have ignored that warning anyway, but at this point it seems to me that Ubuntu is not helping, it's hurting. So I switched to python:3.x-slim, which appears to be built with the `pip install --global xyz` mindset.

The other key change was to build the package from local source tree, as opposed to install from PyPI. I expect this will be key to automate this into the release process.