### PR TITLE
Validate the `--timestamp` option value

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -12,7 +12,7 @@ from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...utils import subprocess
 from ...utils.authentication import get_org_workspace
-from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE
+from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE, validate_past_datetime
 from ...utils.launchable_client import LaunchableClient
 from ...utils.session import clean_session_files, write_build
 from .commit import commit
@@ -103,6 +103,7 @@ CODE_BUILD_WEBHOOK_HEAD_REF_KEY = "CODEBUILD_WEBHOOK_HEAD_REF"
     help='Used to overwrite the build time when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
     type=DATETIME_WITH_TZ,
     default=None,
+    callback=validate_past_datetime,
 )
 @click.pass_context
 def build(

--- a/launchable/commands/record/session.py
+++ b/launchable/commands/record/session.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence, Tuple
 
 import click
 
-from launchable.utils.click import DATETIME_WITH_TZ
+from launchable.utils.click import DATETIME_WITH_TZ, validate_past_datetime
 from launchable.utils.link import LinkKind, capture_link
 from launchable.utils.tracking import Tracking, TrackingClient
 
@@ -106,6 +106,7 @@ def _validate_session_name(ctx, param, value):
     help='Used to overwrite the session time when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
     type=DATETIME_WITH_TZ,
     default=None,
+    callback=validate_past_datetime,
 )
 @click.pass_context
 def session(

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -16,7 +16,7 @@ from launchable.utils.authentication import ensure_org_workspace
 from launchable.utils.tracking import Tracking, TrackingClient
 
 from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
-from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE
+from ...utils.click import DATETIME_WITH_TZ, KEY_VALUE, validate_past_datetime
 from ...utils.exceptions import InvalidJUnitXMLException
 from ...utils.launchable_client import LaunchableClient
 from ...utils.logger import Logger
@@ -165,6 +165,7 @@ def _validate_group(ctx, param, value):
     help='Used to overwrite the test executed times when importing historical data. Note: Format must be `YYYY-MM-DDThh:mm:ssTZD` or `YYYY-MM-DDThh:mm:ss` (local timezone applied)',  # noqa: E501
     type=DATETIME_WITH_TZ,
     default=None,
+    callback=validate_past_datetime,
 )
 @click.pass_context
 def tests(

--- a/launchable/utils/click.py
+++ b/launchable/utils/click.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import sys
 from typing import Dict, Optional, Tuple
@@ -100,7 +101,6 @@ class DateTimeWithTimezoneType(ParamType):
     name = "datetime"
 
     def convert(self, value: str, param: Optional[click.core.Parameter], ctx: Optional[click.core.Context]):
-
         try:
             dt = dateutil.parser.parse(value)
             if dt.tzinfo is None:
@@ -161,3 +161,20 @@ def convert_to_seconds(s: str):
 
 def ignorable_error(e: Exception):
     return "An error occurred on Launchable CLI. You can ignore this message since the process will continue. Error: {}".format(e)
+
+
+def validate_past_datetime(ctx, param, value):
+    """
+    Validates that the provided datetime is in the past.
+    """
+    if value is None:
+        return value
+
+    if not isinstance(value, datetime.datetime):
+        raise click.BadParameter("Expected a datetime object.")
+
+    now = datetime.datetime.now(tz=tzlocal())
+    if value >= now:
+        raise click.BadParameter("The provided datetime must be in the past. But the value is {}".format(value))
+
+    return value


### PR DESCRIPTION
`--timestamp` option is for importing historical data. So, added validation not to be able to set feature time