### PR TITLE
Improvement around git-rev-parse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip wheel --no-cache-dir -w /wheels .
 FROM python:3.11-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-17-jre-headless && \
+    apt-get install -y --no-install-recommends openjdk-17-jre-headless git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels pip install --no-cache-dir /wheels/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip wheel --no-cache-dir -w /wheels .
 FROM python:3.11-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-17-jre-headless git && \
+    apt-get install -y --no-install-recommends openjdk-17-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels pip install --no-cache-dir /wheels/*.whl

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -76,22 +76,6 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
 
     cwd = os.path.abspath(source)
     try:
-        is_shallow = subprocess.check_output(
-            ['git', 'rev-parse', '--is-shallow-repository'],
-            stderr=subprocess.DEVNULL,
-            cwd=cwd,
-            universal_newlines=True).strip()
-        if is_shallow == "true":
-            tracking_client.send_event(
-                event_name=Tracking.Event.SHALLOW_CLONE
-            )
-    except Exception as e:
-        if os.getenv(REPORT_ERROR_KEY):
-            raise e
-        else:
-            click.echo(click.style("Failed to run git rev-parse in `{}`. ".format(cwd), fg='yellow'), err=True)
-            print(e)
-    try:
         exec_jar(cwd, max_days, ctx.obj, is_collect_message)
     except Exception as e:
         if os.getenv(REPORT_ERROR_KEY):

--- a/launchable/commands/record/commit.py
+++ b/launchable/commands/record/commit.py
@@ -89,6 +89,7 @@ def commit(ctx, source: str, executable: bool, max_days: int, scrub_pii: bool, i
         if os.getenv(REPORT_ERROR_KEY):
             raise e
         else:
+            click.echo(click.style("Failed to run git rev-parse in `{}`. ".format(cwd), fg='yellow'), err=True)
             print(e)
     try:
         exec_jar(cwd, max_days, ctx.obj, is_collect_message)


### PR DESCRIPTION
This is the problem they run into. Just `print(e)` is a bad idea because it doesn't put them on the right track to solve them.

```
$ launchable record commit 
[Errno 2] No such file or directory: 'git'
```

(In this case, the added injury is that we are requiring `git` that shouldn't really be needed, but I didn't tackle that problem here)