### PR TITLE
Support XCTest 

### DIFF
--- a/launchable/test_runners/xctest.py
+++ b/launchable/test_runners/xctest.py
@@ -18,14 +18,13 @@ def record_tests(client, reports):
 
         for testsuite in root.findall('testsuite'):
             for testcase in testsuite.findall('testcase'):
-                print(testcase)
                 failure = testcase.find('failure')
                 if failure is not None:
                     # Note(Konboi): XCTest escape `"` to `&quot;` in the message, so save as unescaped text
                     message = html.unescape(failure.get('message', ''))
                     body = failure.text or ''
                     failure.text = f"{message}\n{body}"
-                    print("failure", failure.text)
+
         return tree
 
     def path_builder(case: TestCase, suite: TestSuite, report_path: str) -> TestPath:

--- a/launchable/test_runners/xctest.py
+++ b/launchable/test_runners/xctest.py
@@ -24,3 +24,29 @@ def record_tests(client, reports):
     for r in reports:
         client.report(r)
         client.run()
+
+
+@launchable.subset
+def subset(client):
+    if not client.is_get_tests_from_previous_sessions or not client.is_output_exclusion_rules:
+        click.echo(
+            click.style(
+                "XCTest profile only supports the subset with `--get-tests-from-previous-sessions` and `--output-exclusion-rules` options",  # noqa: E501
+                fg="red"),
+            err=True,
+        )
+
+    def formatter(test_path: TestPath) -> str:
+        if len(test_path) == 0:
+            return ""
+
+        # only target case
+        if len(test_path) == 1:
+            return "-skip-testing:{}".format(test_path[0]['name'])
+
+        # default target/class format
+        return "-skip-testing:{}/{}".format(test_path[0]['name'], test_path[1]['name'])
+
+    client.formatter = formatter
+    client.separator = "\n"
+    client.run()

--- a/launchable/test_runners/xctest.py
+++ b/launchable/test_runners/xctest.py
@@ -29,9 +29,8 @@ def record_tests(client, reports):
 
     def path_builder(case: TestCase, suite: TestSuite, report_path: str) -> TestPath:
         class_attr = case.classname
-        splits = class_attr.split('.')
-        target = splits[0]
-        class_name = '/'.join(splits[1:])
+        [target, *rest] = class_attr.split('.')
+        class_name = '/'.join(rest)
         return [
             {"type": "target", "name": target},
             {"type": "class", "name": class_name},

--- a/launchable/test_runners/xctest.py
+++ b/launchable/test_runners/xctest.py
@@ -1,0 +1,26 @@
+import click
+from junitparser import TestCase, TestSuite
+
+from ..testpath import TestPath
+from . import launchable
+
+
+@click.argument('reports', nargs=-1, required=True)
+@launchable.record.tests
+def record_tests(client, reports):
+    def path_builder(case: TestCase, suite: TestSuite, report_path: str) -> TestPath:
+        class_attr = case.classname
+        splits = class_attr.split('.')
+        target = splits[0]
+        class_name = '/'.join(splits[1:])
+        return [
+            {"type": "target", "name": target},
+            {"type": "class", "name": class_name},
+            {"type": "testcase", "name": case.name},
+        ]
+
+    client.path_builder = path_builder
+
+    for r in reports:
+        client.report(r)
+        client.run()

--- a/launchable/test_runners/xctest.py
+++ b/launchable/test_runners/xctest.py
@@ -20,10 +20,7 @@ def record_tests(client, reports):
         ]
 
     client.path_builder = path_builder
-
-    for r in reports:
-        client.report(r)
-        client.run()
+    launchable.CommonRecordTestImpls.load_report_files(client=client, source_roots=reports)
 
 
 @launchable.subset

--- a/tests/data/xctest/junit.xml
+++ b/tests/data/xctest/junit.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites name='XCTestSampleUITests.xctest' tests='9' failures='2'>
+  <testsuite name='XCTestSampleTests.XCTestSampleTests' tests='2' failures='1'>
+    <testcase classname='XCTestSampleTests.XCTestSampleTests' name='testExample' time='0.001'/>
+    <testcase classname='XCTestSampleTests.XCTestSampleTests' name='testMulti'>
+      <failure message='XCTAssertEqual failed: (&amp;quot;12&amp;quot;) is not equal to (&amp;quot;10&amp;quot;)'>XCTestSampleTests/XCTestSampleTests.swift:17</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name='XCTestSampleTests.XCTestSampleTests2' tests='1' failures='1'>
+    <testcase classname='XCTestSampleTests.XCTestSampleTests2' name='testMinus'>
+      <failure message='XCTAssertEqual failed: (&amp;quot;2&amp;quot;) is not equal to (&amp;quot;1&amp;quot;)'>XCTestSampleTests/XCTestSampleTests2.swift:12</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name='XCTestSampleUITests.XCTestSampleUITests' tests='2' failures='0'>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITests' name='testExample' time='2.114'/>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITests' name='testLaunchPerformance' time='20.601'/>
+  </testsuite>
+  <testsuite name='XCTestSampleUITests.XCTestSampleUITestsLaunchTests' tests='4' failures='0'>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITestsLaunchTests' name='testLaunch' time='3.697'/>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITestsLaunchTests' name='testLaunch' time='3.433'/>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITestsLaunchTests' name='testLaunch' time='3.981'/>
+    <testcase classname='XCTestSampleUITests.XCTestSampleUITestsLaunchTests' name='testLaunch' time='3.499'/>
+  </testsuite>
+</testsuites>

--- a/tests/data/xctest/record_test_result.json
+++ b/tests/data/xctest/record_test_result.json
@@ -41,7 +41,7 @@
       "duration": 0.0,
       "status": 0,
       "stdout": "",
-      "stderr": "XCTestSampleTests/XCTestSampleTests.swift:17",
+      "stderr": "XCTAssertEqual failed: (\"12\") is not equal to (\"10\")\nXCTestSampleTests/XCTestSampleTests.swift:17",
       "data": null
     },
     {
@@ -63,7 +63,7 @@
       "duration": 0.0,
       "status": 0,
       "stdout": "",
-      "stderr": "XCTestSampleTests/XCTestSampleTests2.swift:12",
+      "stderr": "XCTAssertEqual failed: (\"2\") is not equal to (\"1\")\nXCTestSampleTests/XCTestSampleTests2.swift:12",
       "data": null
     },
     {

--- a/tests/data/xctest/record_test_result.json
+++ b/tests/data/xctest/record_test_result.json
@@ -1,0 +1,207 @@
+{
+  "events": [
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleTests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testExample"
+        }
+      ],
+      "duration": 0.001,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleTests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testMulti"
+        }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "XCTestSampleTests/XCTestSampleTests.swift:17",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleTests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleTests2"
+        },
+        {
+          "type": "testcase",
+          "name": "testMinus"
+        }
+      ],
+      "duration": 0.0,
+      "status": 0,
+      "stdout": "",
+      "stderr": "XCTestSampleTests/XCTestSampleTests2.swift:12",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "testcase",
+          "name": "testExample"
+        }
+      ],
+      "duration": 2.114,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "testcase",
+          "name": "testLaunchPerformance"
+        }
+      ],
+      "duration": 20.601,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITestsLaunchTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testLaunch"
+        }
+      ],
+      "duration": 3.697,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITestsLaunchTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testLaunch"
+        }
+      ],
+      "duration": 3.433,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITestsLaunchTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testLaunch"
+        }
+      ],
+      "duration": 3.981,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "target",
+          "name": "XCTestSampleUITests"
+        },
+        {
+          "type": "class",
+          "name": "XCTestSampleUITestsLaunchTests"
+        },
+        {
+          "type": "testcase",
+          "name": "testLaunch"
+        }
+      ],
+      "duration": 3.499,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    }
+  ],
+  "testRunner": "xctest",
+  "group": "",
+  "noBuild": false,
+  "testSuite": "",
+  "flavors": {}
+}

--- a/tests/data/xctest/subset_result.json
+++ b/tests/data/xctest/subset_result.json
@@ -1,0 +1,10 @@
+{
+  "testPaths": [],
+  "testRunner": "xctest",
+  "session": {
+    "id": "16"
+  },
+  "ignoreNewTests": false,
+  "getTestsFromPreviousSessions": true,
+  "useServerSideOptimizationTarget": true
+}

--- a/tests/test_runners/test_xctest.py
+++ b/tests/test_runners/test_xctest.py
@@ -1,0 +1,59 @@
+import os
+from unittest import mock
+
+import responses  # type: ignore
+
+from launchable.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class XCTestTest(CliTestCase):
+    @responses.activate
+    @mock.patch.dict(os.environ,
+                     {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test(self):
+        result = self.cli('record', 'tests', '--session', self.session,
+                          'xctest', str(self.test_files_dir.joinpath("junit.xml")))
+
+        self.assert_success(result)
+        self.assert_record_tests_payload('record_test_result.json')
+
+    @responses.activate
+    @mock.patch.dict(os.environ,
+                     {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset(self):
+        mock_response = {
+            "testPaths": [
+                [{"type": "target", "name": "XCTestSampleTests"}, {"type": "class", "name": "XCTestSampleTests"}],
+                [{"type": "target", "name": "XCTestSampleTests"}, {"type": "class", "name": "XCTestSampleTests2"}],
+            ],
+            "testRunner": "cts",
+            "rest": [
+                [{"type": "target", "name": "XCTestSampleUITests"}, {"type": "class", "name": "XCTestSampleUITestsLaunchTests"}],
+                [{"type": "target", "name": "XCTestSampleUITests"}, {"type": "class", "name": "XCTestSampleUITests"}],
+            ],
+            "subsettingId": 123,
+            "summary": {
+                "subset": {"duration": 30, "candidates": 2, "rate": 30},
+                "rest": {"duration": 70, "candidates": 2, "rate": 70}
+            },
+            "isObservation": False,
+        }
+
+        responses.replace(responses.POST, "{}/intake/organizations/{}/workspaces/{}/subset".format(
+            get_base_url(),
+            self.organization,
+            self.workspace),
+            json=mock_response,
+            status=200)
+
+        result = self.cli('subset',
+                          '--session', self.session,
+                          '--get-tests-from-previous-sessions',
+                          '--output-exclusion-rules',
+                          'xctest',
+                          mix_stderr=False)
+
+        self.assert_success(result)
+        self.assert_subset_payload('subset_result.json')
+        self.assertEqual(result.stdout, "-skip-testing:XCTestSampleUITests/XCTestSampleUITestsLaunchTests\n-skip-testing:XCTestSampleUITests/XCTestSampleUITests\n")  # noqa: E501


### PR DESCRIPTION
# What

Implemented to the XCTest profile. XCTest is the test framework for XCode project ref: https://developer.apple.com/documentation/xctest

This is an example project to try XCTest profile https://github.com/launchableinc/examples/pull/87

# How to use 

## subset

Since there aren't any solutions to list test target without executing test, we'll support subset with the [Zero Input Subsetting](https://www.launchableinc.com/docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/subsetting-with-the-launchable-cli/zero-input-subsetting/). And we'll use the subset result with `-skip-testing` option of XCTest

```sh
$ launchable subset --target 80% --get-tests-from-previous-sessions --output-exclusion-rules xctest > subset.txt
$ cat $subst.txt
-skip-testing:XCTestSampleTests/XCTestSampleTests
-skip-testing:XCTestSampleTests/XCTestSampleTests2
$ xcodebuild test -scheme <SCHEMA> -destination <DESTINATION> -parallel-testing-enabled NO $(subset.txt)
```

## record build

XCTest profile requires [xcpretty](https://github.com/xcpretty/xcpretty) to produce test report file.


```sh
$ xcodebuild test -scheme <SCHEMA> -destination <DESTINATION> -parallel-testing-enabled NO | xcpretty -r junit && exit ${PIPESTATUS[0]}
# xcpretty produces JUnit Report under the build/reports/ as default
$ launchable record tests xctest build/reports/*.xml
```

