### PR TITLE
cucumber json reports sometimes add prefix to uri values

### DIFF
--- a/launchable/test_runners/cucumber.py
+++ b/launchable/test_runners/cucumber.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib
+import re
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
@@ -217,7 +218,7 @@ class JSONReportParser:
                 report_file), err=True)
 
         for d in data:
-            file_name = d.get("uri", "")
+            file_name = clean_uri(d.get("uri", ""))
             class_name = d.get("name", "")
 
             # Cucumber can define repeating the same `Given` steps as a `Background`
@@ -433,3 +434,11 @@ def _parse_test_case_info_from_element(element: Dict[str, List]) -> TestCaseInfo
 class CucumberElementType(Enum):
     BACKGROUND = 'background'
     SCENARIO = 'scenario'
+
+
+def clean_uri(uri: str) -> str:
+    """
+    Trim unused prefix from the URI string.
+    For example, if the URI is "file:features/foo.feature", it will return "features/foo.feature".
+    """
+    return re.sub(r'^[a-zA-Z]+:', '', uri)

--- a/tests/data/cucumber/report/result.json
+++ b/tests/data/cucumber/report/result.json
@@ -899,7 +899,7 @@
   },
   {
     "id": "is-it-friday-yet?",
-    "uri": "features/is_it_friday_yet.feature",
+    "uri": "file:features/is_it_friday_yet.feature",
     "keyword": "Feature",
     "name": "Is it Friday yet?",
     "description": "  Everybody wants to know when it's Friday",

--- a/tests/test_runners/test_cucumber.py
+++ b/tests/test_runners/test_cucumber.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import responses  # type: ignore
 
-from launchable.test_runners.cucumber import _create_file_candidate_list
+from launchable.test_runners.cucumber import _create_file_candidate_list, clean_uri
 from launchable.utils.session import write_build
 from tests.cli_test_case import CliTestCase
 
@@ -44,3 +44,8 @@ class CucumberTest(CliTestCase):
         self.assertCountEqual(_create_file_candidate_list("a-b"), ["a/b", "a-b"])
         self.assertCountEqual(_create_file_candidate_list("a-b-c"), ["a/b/c", "a-b/c", "a/b-c", "a-b-c"])
         self.assertCountEqual(_create_file_candidate_list("a_b_c"), ["a_b_c"])
+
+    def test_clean_uri(self):
+        self.assertEqual(clean_uri('foo/bar/baz.feature'), 'foo/bar/baz.feature')
+        self.assertEqual(clean_uri('file:foo/bar/baz.feature'), 'foo/bar/baz.feature')
+        self.assertEqual(clean_uri('classpath:foo/bar/baz.feature'), 'foo/bar/baz.feature')


### PR DESCRIPTION
to ignore it, introduced clean_uri method