### PR TITLE
[AIENG-168] Fix Docker image tag formatting in workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -103,7 +103,7 @@ jobs:
             - linux/amd64
             - linux/arm64
           push: true
-          tags: ${{ env.IMAGE_NAME }}\:${{ needs.tagpr.outputs.tag }}
+          tags: ${{ env.IMAGE_NAME }}:${{ needs.tagpr.outputs.tag }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0


### PR DESCRIPTION
https://github.com/launchableinc/cli/actions/runs/15527660601/job/43710216131
```
  Build summary requires a build reference
Error: buildx failed with: ERROR: invalid tag "cloudbees/launchable\\:v1.101.5": invalid reference format
```