### PR TITLE
deprecated to use master branch

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -60,7 +60,7 @@ jobs:
         .
     # actual publish
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or opt-in to [use a full Git commit SHA](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/) and Dependabot.

ref: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#-master-branch-sunset-


GitHub Actions already showed warning(?) message
ref: https://github.com/launchableinc/cli/actions/runs/15556345917