### PR TITLE
[LCHIB-612] Add a workaround for handling timezone abbreviations in d…

### DIFF
--- a/launchable/commands/record/case_event.py
+++ b/launchable/commands/record/case_event.py
@@ -4,7 +4,9 @@ from typing import Any, Callable, Dict, Optional
 
 import dateutil.parser
 from dateutil.tz import tzlocal
-from junitparser import Error, Failure, IntAttr, Skipped, TestCase, TestSuite  # type: ignore
+from junitparser import Error, Failure, IntAttr, Skipped, TestCase, TestSuite
+
+from launchable.utils.common_tz import COMMON_TIMEZONES  # type: ignore
 
 from ...testpath import FilePathNormalizer, TestPath
 
@@ -157,7 +159,7 @@ class CaseEvent:
             if ts is None:
                 return datetime.datetime.now(datetime.timezone.utc).isoformat()
             try:
-                date = dateutil.parser.parse(ts)
+                date = dateutil.parser.parse(timestr=ts, tzinfos=COMMON_TIMEZONES)
                 if date.tzinfo is None:
                     return date.replace(tzinfo=tzlocal()).isoformat()
                 return date.isoformat()

--- a/launchable/utils/common_tz.py
+++ b/launchable/utils/common_tz.py
@@ -1,0 +1,12 @@
+from dateutil.tz import gettz
+
+# The dateutil library does not recognize timezone abbreviations (like "PDT" or "JST") by default.
+# To handle these, we manually map common abbreviations to their corresponding timezones.
+# See: https://github.com/dateutil/dateutil/issues/932
+COMMON_TIMEZONES = {
+    "UTC": gettz("UTC"),
+    # https://time.now/timezones/pdt/
+    "PDT": gettz("America/Los_Angeles"),
+    # https://time.now/timezones/jst/
+    "JST": gettz("Asia/Tokyo"),
+}

--- a/tests/commands/record/test_case_event.py
+++ b/tests/commands/record/test_case_event.py
@@ -17,8 +17,7 @@ class TestCaseEventTimestamp(unittest.TestCase):
                 test_path=[], duration_secs=1.0, status=CaseEvent.TEST_PASSED, timestamp=ts
             )
             # Should parse to ISO format with correct offset
-            self.assertTrue(result["createdAt"].startswith("2024-06-23T12:34:56.789"))
-            self.assertIn("-07:00", result["createdAt"])
+            self.assertEqual(result["createdAt"], "2024-06-23T12:34:56.789000-07:00")
             # Should NOT output a warning to stderr
             self.assertNotIn(UNKNOWN_TIMEZONE_WARNING, stderr.getvalue())
 

--- a/tests/commands/record/test_case_event.py
+++ b/tests/commands/record/test_case_event.py
@@ -1,0 +1,35 @@
+
+import unittest
+from io import StringIO
+from unittest import mock
+
+from launchable.commands.record.case_event import CaseEvent
+
+UNKNOWN_TIMEZONE_WARNING = "UnknownTimezoneWarning"
+
+
+class TestCaseEventTimestamp(unittest.TestCase):
+    def test_timestamp_with_known_abbreviation(self):
+        # Use a known abbreviation from COMMON_TIMEZONES
+        ts = "2024-06-23T12:34:56.789 PDT"  # PDT is in COMMON_TIMEZONES
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            result = CaseEvent.create(
+                test_path=[], duration_secs=1.0, status=CaseEvent.TEST_PASSED, timestamp=ts
+            )
+            # Should parse to ISO format with correct offset
+            self.assertTrue(result["createdAt"].startswith("2024-06-23T12:34:56.789"))
+            self.assertIn("-07:00", result["createdAt"])
+            # Should NOT output a warning to stderr
+            self.assertNotIn(UNKNOWN_TIMEZONE_WARNING, stderr.getvalue())
+
+    def test_timestamp_with_unknown_abbreviation(self):
+        # Use an unknown abbreviation
+        ts = "2024-06-23T12:34:56.789 XYZ"  # XYZ is not in COMMON_TIMEZONES
+        with mock.patch('sys.stderr', new=StringIO()) as stderr:
+            result = CaseEvent.create(
+                test_path=[], duration_secs=1.0, status=CaseEvent.TEST_PASSED, timestamp=ts
+            )
+            # Should output a warning to stderr
+            self.assertIn(UNKNOWN_TIMEZONE_WARNING, stderr.getvalue())
+            # The createdAt may still start with the input timestamp, but should not have a timezone offset
+            self.assertTrue(result["createdAt"].startswith("2024-06-23T12:34:56.789"))

--- a/tests/commands/record/test_case_event.py
+++ b/tests/commands/record/test_case_event.py
@@ -1,4 +1,3 @@
-
 import unittest
 from io import StringIO
 from unittest import mock
@@ -31,4 +30,8 @@ class TestCaseEventTimestamp(unittest.TestCase):
             # Should output a warning to stderr
             self.assertIn(UNKNOWN_TIMEZONE_WARNING, stderr.getvalue())
             # The createdAt may still start with the input timestamp, but should not have a timezone offset
+            # We check that the prefix matches the input timestamp because
+            # `dateutil.parser` will use the system's default timezone if it
+            # encounters an unknown timezone abbreviation (e.g., 'XYZ'), resulting in
+            # a timestamp like '2024-06-23T12:34:56.789000+09:00'.
             self.assertTrue(result["createdAt"].startswith("2024-06-23T12:34:56.789"))


### PR DESCRIPTION
…ateutil

The dateutil package does not support timezone abbreviations like "PDT" by default.

We can reproduce the warning in the following script:

```
from dateutil import parser

date_str = "2024-04-01 10:00:00 PDT"
parsed = parser.parse(date_str)
print(parsed)
```

```
$ python foo.py 
/Users/ono-max/.local/share/virtualenvs/cli-tPknK2Me/lib/python3.12/site-packages/dateutil/parser/_parser.py:1207: UnknownTimezoneWarning: tzname PDT identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.
  warnings.warn("tzname {tzname} identified but not understood.  "
2024-04-01 10:00:00
```

As a workaround, we need to pass the map to `tzinfos` parameter.

See: https://github.com/dateutil/dateutil/issues/932

```
from dateutil import parser
from dateutil.tz import gettz

COMMON_TIMEZONES = {
    "UTC": gettz("UTC"),
    # https://time.now/timezones/pdt/
    "PDT": gettz("America/Los_Angeles"),
    # https://time.now/timezones/jst/
    "JST": gettz("Asia/Tokyo"),
}

date_str = "2024-04-01 10:00:00 PDT"
parsed = parser.parse(date_str, tzinfos=COMMON_TIMEZONES)
print(parsed)

```

```
$ python foo.py
2024-04-01 10:00:00-07:00
```

