### PR TITLE
Support subtest case in go-test profile

### DIFF
--- a/tests/data/go_test/record_test_result.json
+++ b/tests/data/go_test/record_test_result.json
@@ -5,7 +5,7 @@
       "testPath": [
         {
           "type": "class",
-          "name": "rocket-car-gotest"
+          "name": "go"
         },
         {
           "type": "testcase",
@@ -23,7 +23,7 @@
       "testPath": [
         {
           "type": "class",
-          "name": "rocket-car-gotest"
+          "name": "go"
         },
         {
           "type": "testcase",
@@ -41,7 +41,7 @@
       "testPath": [
         {
           "type": "class",
-          "name": "rocket-car-gotest"
+          "name": "go"
         },
         {
           "type": "testcase",
@@ -59,7 +59,7 @@
       "testPath": [
         {
           "type": "class",
-          "name": "rocket-car-gotest"
+          "name": "go"
         },
         {
           "type": "testcase",
@@ -71,11 +71,109 @@
       "stdout": "",
       "stderr": "",
       "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "go"
+        },
+        {
+          "type": "testcase",
+          "name": "TestExample5"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "go"
+        },
+        {
+          "type": "testcase",
+          "name": "TestExample5"
+        },
+        {
+          "type": "subtest",
+          "name": "Test_case_1"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "go"
+        },
+        {
+          "type": "testcase",
+          "name": "TestExample5"
+        },
+        {
+          "type": "subtest",
+          "name": "Test_case_2_(fail_case)"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "example"
+        },
+        {
+          "type": "testcase",
+          "name": "TestGreeting"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
+    },
+    {
+      "type": "case",
+      "testPath": [
+        {
+          "type": "class",
+          "name": "example"
+        },
+        {
+          "type": "testcase",
+          "name": "ExampleGreeting"
+        }
+      ],
+      "duration": 0.0,
+      "status": 1,
+      "stdout": "",
+      "stderr": "",
+      "data": null
     }
   ],
   "testRunner": "go-test",
   "group": "",
   "noBuild": false,
-  "flavors": [],
-  "testSuite": ""
+  "testSuite": "",
+  "flavors": {}
 }

--- a/tests/data/go_test/reportv1/reportv1.xml
+++ b/tests/data/go_test/reportv1/reportv1.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="4" failures="0" time="5.262" name="github.com/launchableinc/rocket-car-gotest">
+	<testsuite tests="7" failures="0" time="0.000" name="github.com/launchableinc/examples/go">
 		<properties>
-			<property name="go.version" value="go1.15.5"></property>
+			<property name="go.version" value="go1.24.2"></property>
 		</properties>
-		<testcase classname="rocket-car-gotest" name="TestExample1" time="0.000"></testcase>
-		<testcase classname="rocket-car-gotest" name="TestExample2" time="3.000"></testcase>
-		<testcase classname="rocket-car-gotest" name="TestExample3" time="0.000"></testcase>
-		<testcase classname="rocket-car-gotest" name="TestExample4" time="2.000"></testcase>
+		<testcase classname="go" name="TestExample1" time="0.000"></testcase>
+		<testcase classname="go" name="TestExample2" time="3.000"></testcase>
+		<testcase classname="go" name="TestExample3" time="0.000"></testcase>
+		<testcase classname="go" name="TestExample4" time="2.000"></testcase>
+		<testcase classname="go" name="TestExample5" time="0.000"></testcase>
+		<testcase classname="go" name="TestExample5/Test_case_1" time="0.000"></testcase>
+		<testcase classname="go" name="TestExample5/Test_case_2_(fail_case)" time="0.000"></testcase>
+	</testsuite>
+	<testsuite tests="2" failures="0" time="0.000" name="github.com/launchableinc/examples/go/example">
+		<properties>
+			<property name="go.version" value="go1.24.2"></property>
+		</properties>
+		<testcase classname="example" name="TestGreeting" time="0.000"></testcase>
+		<testcase classname="example" name="ExampleGreeting" time="0.000"></testcase>
 	</testsuite>
 </testsuites>

--- a/tests/data/go_test/reportv2/reportv2.xml
+++ b/tests/data/go_test/reportv2/reportv2.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="6">
-        <testsuite name="github.com/launchableinc/rocket-car-gotest" tests="4" failures="0" errors="0" id="0" hostname="dummy" time="5.000" timestamp="2022-08-24T11:23:46+09:00">
-                <testcase name="TestExample1" classname="github.com/launchableinc/rocket-car-gotest" time="0.000"></testcase>
-                <testcase name="TestExample2" classname="github.com/launchableinc/rocket-car-gotest" time="3.000"></testcase>
-                <testcase name="TestExample3" classname="github.com/launchableinc/rocket-car-gotest" time="0.000"></testcase>
-                <testcase name="TestExample4" classname="github.com/launchableinc/rocket-car-gotest" time="2.000"></testcase>
-        </testsuite>
+<testsuites tests="9">
+	<testsuite name="github.com/launchableinc/examples/go" tests="7" failures="0" errors="0" id="0" hostname="MAC-ryabuki.local" time="5.000" timestamp="2025-06-16T16:31:58+09:00">
+		<testcase name="TestExample1" classname="github.com/launchableinc/examples/go" time="0.000"></testcase>
+		<testcase name="TestExample2" classname="github.com/launchableinc/examples/go" time="3.000"></testcase>
+		<testcase name="TestExample3" classname="github.com/launchableinc/examples/go" time="0.000"></testcase>
+		<testcase name="TestExample4" classname="github.com/launchableinc/examples/go" time="2.000"></testcase>
+		<testcase name="TestExample5" classname="github.com/launchableinc/examples/go" time="0.000"></testcase>
+		<testcase name="TestExample5/Test_case_1" classname="github.com/launchableinc/examples/go" time="0.000"></testcase>
+		<testcase name="TestExample5/Test_case_2_(fail_case)" classname="github.com/launchableinc/examples/go" time="0.000"></testcase>
+	</testsuite>
+	<testsuite name="github.com/launchableinc/examples/go/example" tests="2" failures="0" errors="0" id="1" hostname="MAC-ryabuki.local" time="0.000" timestamp="2025-06-16T16:31:58+09:00">
+		<testcase name="TestGreeting" classname="github.com/launchableinc/examples/go/example" time="0.000"></testcase>
+		<testcase name="ExampleGreeting" classname="github.com/launchableinc/examples/go/example" time="0.000"></testcase>
+	</testsuite>
 </testsuites>


### PR DESCRIPTION
# What 

In Go, we can define subtests like the example below.
However, in the test report, they are shown as a single test case using the format: `test function name / subtest name`.
But when using the `go test -list` command, which is used for subsetting, only the test function names are output—subtest names are not included.
So we need to update the Go test profile to support subtests.

e.g) subtest example
```go
t.Run(tt.title, func(t *testing.T) {...}
```

go test -llist result

```
go test -list="Test|Example" ./...
TestExample1
TestExample2
TestExample3
TestExample4
TestExample5
ok      github.com/launchableinc/examples/go    0.287s
TestGreeting
ExampleGreeting
ok      github.com/launchableinc/examples/go/example    0.475s
```

report example
```xml
        <testcase name="TestExample5/Test_case_2_(fail_case)" classname="github.com/launchableinc/examples/go" time="0.000">
            <failure message="Failed"><![CDATA[    example3_test.go:38: expected 8, got 7]]></failure>
        </testcase>
```


Created data used by this PR: https://github.com/launchableinc/examples/pull/89