### PR TITLE
Add Groovy config to jvm_test_pattern

### DIFF
--- a/launchable/utils/file_name_pattern.py
+++ b/launchable/utils/file_name_pattern.py
@@ -1,4 +1,4 @@
 import re
 
-# find *Test, *Tests, *TestCase + .java, .scala, .kt
-jvm_test_pattern = re.compile(r'^.*Test(?:Case|s)?\.(?:java|scala|kt)$')
+# find *Test, *Tests, *TestCase, *Spec + .java, .scala, .kt, .groovy
+jvm_test_pattern = re.compile(r'^.*(?:Test(?:Case|s)?|Spec)\.(?:java|scala|kt|groovy)$')

--- a/tests/utils/test_file_name_pattern.py
+++ b/tests/utils/test_file_name_pattern.py
@@ -8,7 +8,9 @@ class FileNameHeuristicTest(TestCase):
         file_names = [
             'LaunchableTest.java',
             'LaunchableTests.java',
-            'LaunchableTestCase.java'
+            'LaunchableTestCase.java',
+            'LaunchableTest.groovy',
+            'LaunchableSpec.groovy',
         ]
         for file_name in file_names:
             self.assertTrue(jvm_test_pattern.match(file_name))


### PR DESCRIPTION
Groovy lang works on JVM but we hadn't set the Groovy to the jvm_test_pattern and the cli couldn't find the test paths.
So we updated the rule.

The cli will be able to do like the below

```sh
launchable subset <OPTIONS> gradle src/test/java src/test/groovy
```