### PR TITLE
refactor fail-fast validation logic

### DIFF
--- a/launchable/utils/commands.py
+++ b/launchable/utils/commands.py
@@ -8,3 +8,7 @@ class Command(Enum):
     RECORD_SESSION = 'RECORD_SESSION'
     SUBSET = 'SUBSET'
     COMMIT = 'COMMIT'
+
+    def human_readable(self):
+        # Convert the enum value to lowercase and replace underscores with spaces
+        return self.value.lower().replace('_', ' ')

--- a/launchable/utils/fail_fast_mode.py
+++ b/launchable/utils/fail_fast_mode.py
@@ -49,7 +49,7 @@ def fail_fast_validate(ctx: FailFastContext, fail_fast: bool = False):
 
     # Now, there isn't any validation for the `record session` command in fail-fast mode.
     if ctx.command in {Command.RECORD_TESTS, Command.SUBSET} and ctx.session:
-        cmd_name = ctx.command.value.lower().replace("_", " ")
+        cmd_name = ctx.command.human_readable()
         if ctx.test_suite:
             errors.append(f"`--test-suite` is ignored in {cmd_name}. Add it to `record session` instead.")
         if ctx.is_observation:


### PR DESCRIPTION
* Turn too many arguments into a data class.
* Stop splitting the processing into the method, since it's harder to understand it.
* Rename _print_errors to exit_if_errors.

