### PR TITLE
Restructure commands with nested command options

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_BAZEL }}
         working-directory: examples/bazel/java
       - name: "bazel: Subset"
-        run: bazelisk query 'tests(//...)' | smart-tests subset --target 30% bazel > subset.txt
+        run: bazelisk query 'tests(//...)' | smart-tests subset bazel --target 30% > subset.txt
         env:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_BAZEL }}
         working-directory: examples/bazel/java
@@ -79,7 +79,7 @@ jobs:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_GO }}
         working-directory: examples/go
       - name: "go: Subset"
-        run: go test -list="Test|Example" ./... | smart-tests subset --confidence 80%  go-test > smart-tests-subset.txt
+        run: go test -list="Test|Example" ./... | smart-tests subset go-test --confidence 80% > smart-tests-subset.txt
         env:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_GO }}
         working-directory: examples/go
@@ -103,7 +103,7 @@ jobs:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_GRADLE }}
         working-directory: examples/gradle
       - name: "gradle: Subset"
-        run: smart-tests subset --target 80%  gradle src/test/java > smart-tests-subset.txt
+        run: smart-tests subset gradle --target 80% src/test/java > smart-tests-subset.txt
         env:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_GRADLE }}
         working-directory: examples/gradle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
         smart-tests record session --build ${GITHUB_RUN_ID} --flavor os=${{ matrix.os }} --flavor python=$(cat .python-version) > session.txt
 
         # Find 25% of the relevant tests to run for this change
-        find tests -name test_*.py | grep -v tests/data | smart-tests subset --target 25% --session $(cat session.txt) --rest smart-tests-remainder.txt file > subset.txt
+        find tests -name test_*.py | grep -v tests/data | smart-tests subset file --target 25% --session $(cat session.txt) --rest smart-tests-remainder.txt > subset.txt
 
         function record() {
           # Record test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
         function record() {
           # Record test results
-          SMART_TESTS_SLACK_NOTIFICATION=true smart-tests record tests --session $(cat session.txt) file test-results/*.xml
+          SMART_TESTS_SLACK_NOTIFICATION=true smart-tests record test file --session $(cat session.txt) test-results/*.xml
         }
 
         trap record EXIT

--- a/smart_tests/__main__.py
+++ b/smart_tests/__main__.py
@@ -51,8 +51,8 @@ def _rebuild_nested_commands_with_plugins():
             module = importlib.import_module(module_name)
             if hasattr(module, 'nested_command_app'):
                 nested_app = module.nested_command_app
-                nested_app.commands.clear()
-                nested_app.groups.clear()
+                nested_app.registered_commands.clear()
+                nested_app.registered_groups.clear()
             if hasattr(module, 'create_nested_commands'):
                 module.create_nested_commands()
 

--- a/smart_tests/__main__.py
+++ b/smart_tests/__main__.py
@@ -70,9 +70,7 @@ def _rebuild_nested_commands_with_plugins():
 
 def _on_test_runner_registered():
     """Callback triggered when new test runners are registered."""
-    global _plugins_loaded
-    if not _plugins_loaded:  # Only rebuild once for plugins
-        _rebuild_nested_commands_with_plugins()
+    _rebuild_nested_commands_with_plugins()
 
 
 get_registry().set_on_register_callback(_on_test_runner_registered)

--- a/smart_tests/__main__.py
+++ b/smart_tests/__main__.py
@@ -51,8 +51,8 @@ def _rebuild_nested_commands_with_plugins():
             module = importlib.import_module(module_name)
             if hasattr(module, 'nested_command_app'):
                 nested_app = module.nested_command_app
-                nested_app.registered_commands.clear()
-                nested_app.registered_groups.clear()
+                nested_app.commands.clear()
+                nested_app.groups.clear()
             if hasattr(module, 'create_nested_commands'):
                 module.create_nested_commands()
 

--- a/smart_tests/commands/record/__init__.py
+++ b/smart_tests/commands/record/__init__.py
@@ -1,13 +1,12 @@
 import typer
 
-from . import attachment, build, commit, session, tests
+from . import attachment, build, commit, session
 
 app = typer.Typer(name="record", help="Record test results, builds, commits, and sessions")
 
 app.add_typer(build.app, name="build")
 app.add_typer(commit.app, name="commit")
-app.add_typer(tests.app, name="tests")
-# for backward compatibility
-app.add_typer(tests.app, name="test")
+# NestedCommand version will be added in __main__.py
+# Remove old tests command registration - it will be replaced by NestedCommand in __main__.py
 app.add_typer(session.app, name="session")
 app.add_typer(attachment.app, name="attachment")

--- a/smart_tests/commands/record/tests.py
+++ b/smart_tests/commands/record/tests.py
@@ -140,7 +140,7 @@ def tests_main(
         # In NestedCommand, the test runner name should be available from the command structure
         # For now, temporarily extract from command chain
         command_chain = []
-        current_ctx = ctx
+        current_ctx: Optional[typer.Context] = ctx
         while current_ctx:
             if current_ctx.info_name:
                 command_chain.append(current_ctx.info_name)

--- a/smart_tests/commands/record/tests.py
+++ b/smart_tests/commands/record/tests.py
@@ -17,6 +17,7 @@ from smart_tests.utils.authentication import ensure_org_workspace
 from smart_tests.utils.tracking import Tracking, TrackingClient
 
 from ...testpath import FilePathNormalizer, TestPathComponent, unparse_test_path
+from ...utils.dynamic_commands import DynamicCommandBuilder, extract_callback_options
 from ...utils.exceptions import InvalidJUnitXMLException
 from ...utils.launchable_client import LaunchableClient
 from ...utils.logger import Logger
@@ -131,6 +132,23 @@ def tests_main(
     org, workspace = ensure_org_workspace()
 
     test_runner = ctx.invoked_subcommand
+    # Fallback for NestedCommand where invoked_subcommand might not be set correctly
+    if test_runner is None and hasattr(ctx, 'test_runner'):
+        test_runner = ctx.test_runner
+    # Additional fallback: check if we're in NestedCommand mode and extract from command info
+    if test_runner is None and hasattr(ctx, 'info_name'):
+        # In NestedCommand, the test runner name should be available from the command structure
+        # For now, temporarily extract from command chain
+        command_chain = []
+        current_ctx = ctx
+        while current_ctx:
+            if current_ctx.info_name:
+                command_chain.append(current_ctx.info_name)
+            current_ctx = getattr(current_ctx, 'parent', None)
+        # Test runner should be the last command in chain for NestedCommand
+        if len(command_chain) >= 1 and command_chain[0] not in ['test', 'record']:
+            test_runner = command_chain[0]
+    logger.debug(f"DEBUG: test_runner resolved = {test_runner}")
 
     # Convert default values for lists are no longer needed since we use [] as defaults
 
@@ -715,3 +733,21 @@ def get_env_values(client: LaunchableClient) -> Dict[str, str]:
         metadata[key] = val
 
     return metadata
+
+
+# NestedCommand implementation: create test runner-specific commands
+# This section adds the new command structure where test runners come before options
+nested_command_app = typer.Typer(name="record", help="Record test results (NestedCommand)")
+
+
+def create_nested_commands():
+    """Create NestedCommand commands after all test runners are loaded."""
+    builder = DynamicCommandBuilder()
+
+    # Extract options from the original tests callback
+    callback_options = extract_callback_options(tests_main)
+
+    # Create test runner-specific record test commands
+    builder.create_record_test_commands(nested_command_app, tests_main, callback_options)
+
+# The commands will be created when test runners are loaded

--- a/smart_tests/test_runners/ant.py
+++ b/smart_tests/test_runners/ant.py
@@ -1,13 +1,19 @@
 import os
-from typing import List
+from typing import Annotated, List
+
+import typer
 
 from ..utils.file_name_pattern import jvm_test_pattern
 from . import smart_tests
 
 
-# This decorator is converted to Typer annotations in the function signature
 @smart_tests.subset
-def subset(client, source_roots: List[str]):
+def subset(
+    client,
+    source_roots: Annotated[List[str], typer.Argument(
+        help="Source directories to scan for test files"
+    )]
+):
     def file2test(f: str):
         if jvm_test_pattern.match(f):
             f = f[:f.rindex('.')]   # remove extension

--- a/smart_tests/test_runners/cts.py
+++ b/smart_tests/test_runners/cts.py
@@ -157,7 +157,9 @@ def subset(client):
     """
 
     for t in client.stdin():
-        if "starting command" in t:
+        line = t.rstrip("\n") if isinstance(t, str) else str(t).rstrip("\n")
+
+        if "starting command" in line:
             start_module = True
             continue
 
@@ -165,11 +167,10 @@ def subset(client):
             continue
 
         # e.g) armeabi-v7a CtsAbiOverrideHostTestCases
-        device_and_module = t.rstrip("\n").split()
+        device_and_module = line.split()
         if len(device_and_module) != 2:
             typer.secho(
-                "Warning: {line} is not expected Module format and skipped".format(
-                    line=t),
+                f"Warning: {line} is not expected Module format and skipped",
                 fg=typer.colors.YELLOW,
                 err=True)
             continue

--- a/smart_tests/test_runners/dotnet.py
+++ b/smart_tests/test_runners/dotnet.py
@@ -70,6 +70,7 @@ def subset(
             "`--get-tests-from-previous-sessions` option",
             fg=typer.colors.RED,
             err=True)
+        raise typer.Exit(1)
 
     do_subset(client, bare)
 

--- a/smart_tests/utils/dynamic_commands.py
+++ b/smart_tests/utils/dynamic_commands.py
@@ -150,7 +150,7 @@ class DynamicCommandBuilder:
             return test_runner_func(*test_runner_args, **test_runner_kwargs)
 
         # Set the signature for the combined function
-        combined_function.__signature__ = inspect.Signature(combined_params)
+        setattr(combined_function, '__signature__', inspect.Signature(combined_params))
         combined_function.__name__ = f"subset_{test_runner_name.replace('-', '_')}"
 
         return combined_function
@@ -242,7 +242,7 @@ class DynamicCommandBuilder:
             return test_runner_func(*test_runner_args, **test_runner_kwargs)
 
         # Set the signature for the combined function
-        combined_function.__signature__ = inspect.Signature(combined_params)
+        setattr(combined_function, '__signature__', inspect.Signature(combined_params))
         combined_function.__name__ = f"record_{test_runner_name.replace('-', '_')}"
 
         return combined_function

--- a/smart_tests/utils/dynamic_commands.py
+++ b/smart_tests/utils/dynamic_commands.py
@@ -1,0 +1,272 @@
+"""
+Dynamic Command Builder for NestedCommand Pattern
+
+This module provides functionality to dynamically generate Typer commands
+that combine command-level options with test runner-specific logic,
+enabling the NestedCommand pattern where test runners come before options.
+"""
+
+import inspect
+from typing import Any, Callable, Dict
+
+import typer
+
+from smart_tests.utils.test_runner_registry import get_registry
+
+
+class DynamicCommandBuilder:
+    """Builder for creating dynamic Typer commands using NestedCommand pattern where test runners come before options."""
+
+    def __init__(self):
+        self.registry = get_registry()
+
+    def create_subset_commands(self, base_app: typer.Typer,
+                               base_callback_func: Callable,
+                               base_callback_options: Dict[str, Any]) -> None:
+        """
+        Create subset commands for each test runner with combined options.
+
+        Args:
+            base_app: The Typer app to add commands to
+            base_callback_func: The original subset callback function
+            base_callback_options: Options from the original subset callback
+        """
+        subset_functions = self.registry.get_subset_functions()
+
+        for test_runner_name, test_runner_func in subset_functions.items():
+            # Create a combined command that merges base options with test runner logic
+            combined_command = self._create_combined_subset_command(
+                test_runner_name,
+                test_runner_func,
+                base_callback_func,
+                base_callback_options
+            )
+
+            # Register the command with the app
+            base_app.command(name=test_runner_name, help=f"Subset tests using {test_runner_name}")(combined_command)
+
+    def create_record_test_commands(self, base_app: typer.Typer,
+                                    base_callback_func: Callable,
+                                    base_callback_options: Dict[str, Any]) -> None:
+        """
+        Create record test commands for each test runner with combined options.
+
+        Args:
+            base_app: The Typer app to add commands to
+            base_callback_func: The original record tests callback function
+            base_callback_options: Options from the original record tests callback
+        """
+        record_functions = self.registry.get_record_test_functions()
+
+        for test_runner_name, test_runner_func in record_functions.items():
+            # Create a combined command that merges base options with test runner logic
+            combined_command = self._create_combined_record_command(
+                test_runner_name,
+                test_runner_func,
+                base_callback_func,
+                base_callback_options
+            )
+
+            # Register the command with the app
+            base_app.command(name=test_runner_name, help=f"Record test results using {test_runner_name}")(combined_command)
+
+    def _create_combined_subset_command(self, test_runner_name: str,
+                                        test_runner_func: Callable,
+                                        base_callback_func: Callable,
+                                        base_callback_options: Dict[str, Any]) -> Callable:
+        """Create a combined subset command for a specific test runner."""
+
+        # Get signatures from both functions
+        base_sig = inspect.signature(base_callback_func)
+        test_runner_sig = inspect.signature(test_runner_func)
+
+        # Combine parameters from both functions
+        combined_params = []
+
+        # Add ctx parameter first
+        combined_params.append(
+            inspect.Parameter('ctx', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=typer.Context)
+        )
+
+        # Add parameters from base callback (excluding ctx)
+        for param_name, param in base_sig.parameters.items():
+            if param_name != 'ctx':
+                combined_params.append(param)
+
+        # Add parameters from test runner function (excluding client)
+        test_runner_params = list(test_runner_sig.parameters.values())[1:]  # Skip 'client'
+        for param in test_runner_params:
+            # Avoid duplicate parameter names
+            if param.name not in [p.name for p in combined_params]:
+                # Ensure parameter has a default value to avoid "non-default follows default" error
+                if param.default == inspect.Parameter.empty:
+                    # Add a default value for parameters without one
+                    param = param.replace(default=None)
+                combined_params.append(param)
+
+        # Create the combined function
+        def combined_function(*args, **kwargs):
+            # Extract ctx from args/kwargs
+            ctx = kwargs.get('ctx') or (args[0] if args else None)
+
+            if not ctx:
+                raise ValueError("Context not found in function arguments")
+
+            # Prepare arguments for base callback
+            base_args = {}
+            # base_param_names = list(base_sig.parameters.keys())  # Unused variable removed
+
+            for i, (param_name, param) in enumerate(base_sig.parameters.items()):
+                if param_name == 'ctx':
+                    base_args[param_name] = ctx
+                elif param_name in kwargs:
+                    base_args[param_name] = kwargs[param_name]
+                elif i < len(args):
+                    base_args[param_name] = args[i]
+                elif param.default != inspect.Parameter.empty:
+                    base_args[param_name] = param.default
+
+            # Call base callback to set up context
+            base_callback_func(**base_args)
+
+            # Get client from context
+            client = ctx.obj
+
+            # Store test runner name in client if possible
+            if hasattr(client, 'set_test_runner'):
+                client.set_test_runner(test_runner_name)
+
+            # Prepare arguments for test runner function
+            test_runner_args = [client]  # First argument is always client
+            test_runner_kwargs = {}
+
+            test_runner_param_names = list(test_runner_sig.parameters.keys())[1:]  # Skip 'client'
+
+            for param_name in test_runner_param_names:
+                if param_name in kwargs:
+                    test_runner_kwargs[param_name] = kwargs[param_name]
+
+            # Call test runner function
+            return test_runner_func(*test_runner_args, **test_runner_kwargs)
+
+        # Set the signature for the combined function
+        combined_function.__signature__ = inspect.Signature(combined_params)
+        combined_function.__name__ = f"subset_{test_runner_name.replace('-', '_')}"
+
+        return combined_function
+
+    def _create_combined_record_command(self, test_runner_name: str,
+                                        test_runner_func: Callable,
+                                        base_callback_func: Callable,
+                                        base_callback_options: Dict[str, Any]) -> Callable:
+        """Create a combined record test command for a specific test runner."""
+
+        # Get signatures from both functions
+        base_sig = inspect.signature(base_callback_func)
+        test_runner_sig = inspect.signature(test_runner_func)
+
+        # Combine parameters from both functions
+        combined_params = []
+
+        # Add ctx parameter first
+        combined_params.append(
+            inspect.Parameter('ctx', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=typer.Context)
+        )
+
+        # Add parameters from base callback (excluding ctx)
+        for param_name, param in base_sig.parameters.items():
+            if param_name != 'ctx':
+                combined_params.append(param)
+
+        # Add parameters from test runner function (excluding client)
+        test_runner_params = list(test_runner_sig.parameters.values())[1:]  # Skip 'client'
+        for param in test_runner_params:
+            # Avoid duplicate parameter names
+            if param.name not in [p.name for p in combined_params]:
+                # Ensure parameter has a default value to avoid "non-default follows default" error
+                if param.default == inspect.Parameter.empty:
+                    # Add a default value for parameters without one
+                    param = param.replace(default=None)
+                combined_params.append(param)
+
+        # Create the combined function
+        def combined_function(*args, **kwargs):
+            # Extract ctx from args/kwargs
+            ctx = kwargs.get('ctx') or (args[0] if args else None)
+
+            if not ctx:
+                raise ValueError("Context not found in function arguments")
+
+            # Store test runner name in context BEFORE calling base callback
+            ctx.invoked_subcommand = test_runner_name
+            # Also set as attribute for direct access
+            if hasattr(ctx, 'params'):
+                ctx.params['test_runner'] = test_runner_name
+            else:
+                ctx.test_runner = test_runner_name
+
+            # Prepare arguments for base callback
+            base_args = {}
+
+            for i, (param_name, param) in enumerate(base_sig.parameters.items()):
+                if param_name == 'ctx':
+                    base_args[param_name] = ctx
+                elif param_name in kwargs:
+                    base_args[param_name] = kwargs[param_name]
+                elif i < len(args):
+                    base_args[param_name] = args[i]
+                elif param.default != inspect.Parameter.empty:
+                    base_args[param_name] = param.default
+
+            # Call base callback to set up context
+            base_callback_func(**base_args)
+
+            # Get client from context
+            client = ctx.obj
+
+            # Store test runner name in client if possible
+            if hasattr(client, 'set_test_runner'):
+                client.set_test_runner(test_runner_name)
+
+            # Prepare arguments for test runner function
+            test_runner_args = [client]  # First argument is always client
+            test_runner_kwargs = {}
+
+            test_runner_param_names = list(test_runner_sig.parameters.keys())[1:]  # Skip 'client'
+
+            for param_name in test_runner_param_names:
+                if param_name in kwargs:
+                    test_runner_kwargs[param_name] = kwargs[param_name]
+
+            # Call test runner function
+            return test_runner_func(*test_runner_args, **test_runner_kwargs)
+
+        # Set the signature for the combined function
+        combined_function.__signature__ = inspect.Signature(combined_params)
+        combined_function.__name__ = f"record_{test_runner_name.replace('-', '_')}"
+
+        return combined_function
+
+
+def extract_callback_options(callback_func: Callable) -> Dict[str, Any]:
+    """
+    Extract option definitions from a Typer callback function.
+
+    This function analyzes the signature and annotations of a callback function
+    to extract the option definitions that can be reused in dynamic commands.
+    """
+    sig = inspect.signature(callback_func)
+    options = {}
+
+    for param_name, param in sig.parameters.items():
+        if param_name == 'ctx':
+            continue
+
+        # Store parameter information for later use
+        options[param_name] = {
+            'annotation': param.annotation,
+            'default': param.default,
+            'kind': param.kind
+        }
+
+    return options

--- a/smart_tests/utils/dynamic_commands.py
+++ b/smart_tests/utils/dynamic_commands.py
@@ -114,7 +114,7 @@ class DynamicCommandBuilder:
 
             # Prepare arguments for base callback
             base_args = {}
-            # base_param_names = list(base_sig.parameters.keys())  # Unused variable removed
+            # Unused variable removed
 
             for i, (param_name, param) in enumerate(base_sig.parameters.items()):
                 if param_name == 'ctx':

--- a/smart_tests/utils/launchable_client.py
+++ b/smart_tests/utils/launchable_client.py
@@ -99,3 +99,7 @@ class LaunchableClient:
 
         if warning:
             typer.secho(warning, fg=getattr(typer.colors, warning_color.upper(), typer.colors.YELLOW), err=True)
+
+    def set_test_runner(self, test_runner: str):
+        """Update the test runner name for this client."""
+        self.http_client.test_runner = test_runner

--- a/smart_tests/utils/test_runner_registry.py
+++ b/smart_tests/utils/test_runner_registry.py
@@ -1,0 +1,105 @@
+"""
+Test Runner Registry System
+
+This module provides a registry system for collecting test runner functions
+before registering them as Typer commands, enabling the NestedCommand where
+test runners come before options in command structure.
+"""
+
+import inspect
+from functools import wraps
+from typing import Callable, Dict, List
+
+import typer
+
+
+class TestRunnerRegistry:
+    """Registry for collecting test runner functions by command type."""
+
+    def __init__(self):
+        # Dictionary to store test runner functions by command type
+        # Format: {command_type: {test_runner_name: function}}
+        self._subset_functions: Dict[str, Callable] = {}
+        self._record_test_functions: Dict[str, Callable] = {}
+        self._split_subset_functions: Dict[str, Callable] = {}
+
+    def register_subset(self, test_runner_name: str, func: Callable):
+        """Register a subset function for a test runner."""
+        self._subset_functions[test_runner_name] = func
+
+    def register_record_tests(self, test_runner_name: str, func: Callable):
+        """Register a record tests function for a test runner."""
+        self._record_test_functions[test_runner_name] = func
+
+    def register_split_subset(self, test_runner_name: str, func: Callable):
+        """Register a split subset function for a test runner."""
+        self._split_subset_functions[test_runner_name] = func
+
+    def get_subset_functions(self) -> Dict[str, Callable]:
+        """Get all registered subset functions."""
+        return self._subset_functions.copy()
+
+    def get_record_test_functions(self) -> Dict[str, Callable]:
+        """Get all registered record test functions."""
+        return self._record_test_functions.copy()
+
+    def get_split_subset_functions(self) -> Dict[str, Callable]:
+        """Get all registered split subset functions."""
+        return self._split_subset_functions.copy()
+
+    def get_all_test_runner_names(self) -> List[str]:
+        """Get all unique test runner names across all command types."""
+        all_names = set()
+        all_names.update(self._subset_functions.keys())
+        all_names.update(self._record_test_functions.keys())
+        all_names.update(self._split_subset_functions.keys())
+        return sorted(list(all_names))
+
+
+# Global registry instance
+_registry = TestRunnerRegistry()
+
+
+def get_registry() -> TestRunnerRegistry:
+    """Get the global test runner registry instance."""
+    return _registry
+
+
+def cmdname(module_name: str) -> str:
+    """Figure out the sub-command name from a test runner module name."""
+    # a.b.cde -> cde
+    # xyz -> xyz
+    # In python module name the conventional separator is '_' but in command name,
+    # it is '-', so we do replace that
+    return module_name[module_name.rfind('.') + 1:].replace('_', '-')
+
+
+def create_test_runner_wrapper(func: Callable, test_runner_name: str) -> Callable:
+    """
+    Create a wrapper for test runner functions that handles client injection.
+
+    This preserves the original function signature while adding ctx parameter
+    and handling client object injection.
+    """
+    # Get the original function signature (excluding 'client' parameter)
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())[1:]  # Skip 'client' parameter
+
+    # Create a wrapper that matches the original signature
+    @wraps(func)
+    def typer_wrapper(ctx: typer.Context, *args, **kwargs):
+        client = ctx.obj
+
+        # Store the test runner name in the client object for later use
+        if hasattr(client, 'set_test_runner'):
+            client.set_test_runner(test_runner_name)
+
+        # Call the function with client as first argument, then remaining args
+        return func(client, *args, **kwargs)
+
+    # Copy parameter annotations from original function (excluding client)
+    new_params = [inspect.Parameter('ctx', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=typer.Context)]
+    new_params.extend(params)
+    typer_wrapper.__signature__ = sig.replace(parameters=new_params)
+
+    return typer_wrapper

--- a/smart_tests/utils/test_runner_registry.py
+++ b/smart_tests/utils/test_runner_registry.py
@@ -8,7 +8,7 @@ test runners come before options in command structure.
 
 import inspect
 from functools import wraps
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import typer
 
@@ -23,25 +23,25 @@ class TestRunnerRegistry:
         self._record_test_functions: Dict[str, Callable] = {}
         self._split_subset_functions: Dict[str, Callable] = {}
         # Callback to trigger when new test runners are registered
-        self._on_register_callback: Callable = None
+        self._on_register_callback: Optional[Callable[[], None]] = None
 
-    def set_on_register_callback(self, callback: Callable):
+    def set_on_register_callback(self, callback: Callable[[], None]) -> None:
         """Set a callback to be called when new test runners are registered."""
         self._on_register_callback = callback
 
-    def register_subset(self, test_runner_name: str, func: Callable):
+    def register_subset(self, test_runner_name: str, func: Callable) -> None:
         """Register a subset function for a test runner."""
         self._subset_functions[test_runner_name] = func
         if self._on_register_callback:
             self._on_register_callback()
 
-    def register_record_tests(self, test_runner_name: str, func: Callable):
+    def register_record_tests(self, test_runner_name: str, func: Callable) -> None:
         """Register a record tests function for a test runner."""
         self._record_test_functions[test_runner_name] = func
         if self._on_register_callback:
             self._on_register_callback()
 
-    def register_split_subset(self, test_runner_name: str, func: Callable):
+    def register_split_subset(self, test_runner_name: str, func: Callable) -> None:
         """Register a split subset function for a test runner."""
         self._split_subset_functions[test_runner_name] = func
         if self._on_register_callback:

--- a/smart_tests/utils/test_runner_registry.py
+++ b/smart_tests/utils/test_runner_registry.py
@@ -49,7 +49,7 @@ class TestRunnerRegistry:
 
     def get_all_test_runner_names(self) -> List[str]:
         """Get all unique test runner names across all command types."""
-        all_names = set()
+        all_names: set[str] = set()
         all_names.update(self._subset_functions.keys())
         all_names.update(self._record_test_functions.keys())
         all_names.update(self._split_subset_functions.keys())
@@ -100,6 +100,6 @@ def create_test_runner_wrapper(func: Callable, test_runner_name: str) -> Callabl
     # Copy parameter annotations from original function (excluding client)
     new_params = [inspect.Parameter('ctx', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=typer.Context)]
     new_params.extend(params)
-    typer_wrapper.__signature__ = sig.replace(parameters=new_params)
+    setattr(typer_wrapper, '__signature__', sig.replace(parameters=new_params))
 
     return typer_wrapper

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -24,8 +24,8 @@ class TestsTest(CliTestCase):
         # emulate launchable record build & session
         write_session(self.build_name, self.session_id)
 
-        result = self.cli('record', 'tests', '--session',
-                          self.session, '--group', 'hoge', 'maven', str(
+        result = self.cli('record', 'test', 'maven', '--session',
+                          self.session, '--group', 'hoge', str(
                               self.report_files_dir) + "**/reports/")
 
         self.assert_success(result)
@@ -40,7 +40,7 @@ class TestsTest(CliTestCase):
 
         normal_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/normal.xml').resolve())
         broken_xml = str(Path(__file__).parent.joinpath('../../data/broken_xml/broken.xml').resolve())
-        result = self.cli('record', 'tests', '--build', self.build_name, 'file', normal_xml, broken_xml)
+        result = self.cli('record', 'test', 'file', '--build', self.build_name, normal_xml, broken_xml)
 
         def remove_backslash(input: str) -> str:
             # Hack for Windowns. They containts double escaped backslash such
@@ -80,7 +80,7 @@ class TestsTest(CliTestCase):
             },
             status=200)
 
-        result = self.cli('record', 'tests', '--no-build', 'maven', str(self.report_files_dir) + "**/reports/")
+        result = self.cli('record', 'test', 'maven', '--no-build', str(self.report_files_dir) + "**/reports/")
         self.assert_success(result)
 
     def test_parse_launchable_timeformat(self):

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -255,13 +255,13 @@ class APIErrorTest(CliTestCase):
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             result = self.cli(
                 "subset",
+                "minitest",
                 "--target",
                 "30%",
                 "--session",
                 self.session,
                 "--rest",
                 rest_file.name,
-                "minitest",
                 str(self.test_files_dir) + "/test/**/*.rb",
                 mix_stderr=False)
 
@@ -276,8 +276,8 @@ class APIErrorTest(CliTestCase):
             base=get_base_url(), org=self.organization, ws=self.workspace), status=404)
 
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
-            result = self.cli("subset", "--target", "30%", "--session", self.session, "--rest", rest_file.name,
-                              "minitest", str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
+            result = self.cli("subset", "minitest", "--target", "30%", "--session", self.session, "--rest", rest_file.name,
+                              str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assert_success(result)
 
             self.assertEqual(len(result.stdout.rstrip().split("\n")), 1)
@@ -300,6 +300,7 @@ class APIErrorTest(CliTestCase):
             body=ReadTimeout("error"))
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             result = self.cli("subset",
+                              "minitest",
                               "--target",
                               "30%",
                               "--session",
@@ -307,7 +308,6 @@ class APIErrorTest(CliTestCase):
                               "--rest",
                               rest_file.name,
                               "--observation",
-                              "minitest",
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assert_success(result)
             # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
@@ -330,7 +330,7 @@ class APIErrorTest(CliTestCase):
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
-        result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
+        result = self.cli("record", "test", "minitest", "--session", self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=2)
@@ -349,7 +349,7 @@ class APIErrorTest(CliTestCase):
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
-        result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
+        result = self.cli("record", "test", "minitest", "--session", self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since HTTPError is occurred outside of LaunchableClient, the count is 1.
         self.assert_tracking_count(tracking=tracking, count=2)
@@ -369,7 +369,7 @@ class APIErrorTest(CliTestCase):
                 base=get_base_url()),
             body=ReadTimeout("error"))
 
-        result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
+        result = self.cli("record", "test", "minitest", "--session", self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
 
         self.assert_tracking_count(tracking=tracking, count=2)
@@ -434,6 +434,7 @@ class APIErrorTest(CliTestCase):
         # set delete=False to solve the error `PermissionError: [Errno 13] Permission denied:` on Windows.
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
             result = self.cli("subset",
+                              "minitest",
                               "--target",
                               "30%",
                               "--session",
@@ -441,14 +442,13 @@ class APIErrorTest(CliTestCase):
                               "--rest",
                               rest_file.name,
                               "--observation",
-                              "minitest",
                               str(self.test_files_dir) + "/test/**/*.rb", mix_stderr=False)
             self.assert_success(result)
 
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=6)
 
-        result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
+        result = self.cli("record", "test", "minitest", "--session", self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
         self.assert_tracking_count(tracking=tracking, count=9)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -42,8 +42,8 @@ class SubsetTest(CliTestCase):
             status=200)
 
         rest = tempfile.NamedTemporaryFile(delete=False)
-        result = self.cli("subset", "--target", "30%", "--session",
-                          self.session, "--rest", rest.name, "file", mix_stderr=False, input=pipe)
+        result = self.cli("subset", "file", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name, mix_stderr=False, input=pipe)
         self.assert_success(result)
         self.assertEqual(result.stdout, "test_1.py\ntest_2.py\n")
         self.assertEqual(rest.read().decode(), os.linesep.join(["test_3.py", "test_4.py"]))
@@ -75,8 +75,8 @@ class SubsetTest(CliTestCase):
             status=200)
 
         rest = tempfile.NamedTemporaryFile(delete=False)
-        result = self.cli("subset", "--target", "30%", "--session",
-                          self.session, "--rest", rest.name, "file", mix_stderr=False, input=pipe)
+        result = self.cli("subset", "file", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name, mix_stderr=False, input=pipe)
         self.assert_success(result)
         self.assertEqual(result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
         self.assertEqual(rest.read().decode(), "")
@@ -116,6 +116,7 @@ class SubsetTest(CliTestCase):
         observation_mode_rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "30%",
             "--session",
@@ -123,7 +124,6 @@ class SubsetTest(CliTestCase):
             "--rest",
             observation_mode_rest.name,
             "--observation",
-            "file",
             input=pipe,
             mix_stderr=False)
         self.assert_success(result)
@@ -158,8 +158,8 @@ class SubsetTest(CliTestCase):
             status=200)
 
         rest = tempfile.NamedTemporaryFile(delete=False)
-        result = self.cli("subset", "--target", "30%", "--session",
-                          self.session, "--rest", rest.name, "--observation", "file", mix_stderr=False, input=pipe)
+        result = self.cli("subset", "file", "--target", "30%", "--session",
+                          self.session, "--rest", rest.name, "--observation", mix_stderr=False, input=pipe)
         self.assert_success(result)
         self.assertEqual(result.stdout, "test_1.py\ntest_2.py\ntest_3.py\ntest_4.py\n")
         self.assertEqual(rest.read().decode(), "")
@@ -198,9 +198,9 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
+            "file",
             "--session",
             self.session,
-            "file",
             input=pipe,
             mix_stderr=False)
         self.assert_success(result)
@@ -230,11 +230,11 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
+            "file",
             "--session",
             self.session,
             "--goal-spec",
             "foo(),bar(zot=3%)",
-            "file",
             input="test_aaa.py")
         self.assert_success(result)
 
@@ -271,11 +271,11 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
+            "file",
             "--session",
             self.session,
             "--ignore-flaky-tests-above",
             0.05,
-            "file",
             input=pipe,
             mix_stderr=False)
         self.assert_success(result)
@@ -287,7 +287,7 @@ class SubsetTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset_with_get_tests_from_previous_full_runs(self):
         # check error when input candidates are empty without --get-tests-from-previous-sessions option
-        result = self.cli("subset", "--target", "30%", "--session", self.session, "file")
+        result = self.cli("subset", "file", "--target", "30%", "--session", self.session)
         self.assert_exit_code(result, 1)
         self.assertIn("use the `--get-tests-from-previous-sessions` option", result.stdout)
 
@@ -320,6 +320,7 @@ class SubsetTest(CliTestCase):
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "30%",
             "--session",
@@ -327,7 +328,6 @@ class SubsetTest(CliTestCase):
             "--rest",
             rest.name,
             "--get-tests-from-previous-sessions",
-            "file",
             mix_stderr=False)
 
         self.assert_success(result)
@@ -368,13 +368,13 @@ class SubsetTest(CliTestCase):
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "70%",
             "--session",
             self.session,
             "--rest",
             rest.name,
-            "file",
             input=pipe,
             mix_stderr=False)
 
@@ -387,6 +387,7 @@ class SubsetTest(CliTestCase):
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "70%",
             "--session",
@@ -394,7 +395,6 @@ class SubsetTest(CliTestCase):
             "--rest",
             rest.name,
             "--output-exclusion-rules",
-            "file",
             input=pipe,
             mix_stderr=False)
 
@@ -433,6 +433,7 @@ class SubsetTest(CliTestCase):
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "70%",
             "--session",
@@ -440,7 +441,6 @@ class SubsetTest(CliTestCase):
             "--rest",
             rest.name,
             "--output-exclusion-rules",
-            "file",
             input=pipe,
             mix_stderr=False)
 
@@ -485,6 +485,7 @@ class SubsetTest(CliTestCase):
         rest = tempfile.NamedTemporaryFile(delete=False)
         result = self.cli(
             "subset",
+            "file",
             "--target",
             "70%",
             "--session",
@@ -493,7 +494,6 @@ class SubsetTest(CliTestCase):
             rest.name,
             "--output-exclusion-rules",
             "--observation",
-            "file",
             input=pipe,
             mix_stderr=False)
 
@@ -536,11 +536,11 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
+            "file",
             "--session",
             self.session,
             "--prioritize-tests-failed-within-hours",
             24,
-            "file",
             input=pipe,
             mix_stderr=False)
         self.assert_success(result)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,8 +46,8 @@ class PluginTest(CliTestCase):
         Load plugins/foo.py as a plugin and execute its code
         """
         plugin_dir = Path(__file__).parent.joinpath('plugins').resolve()
-        result = self.cli('--plugins', str(plugin_dir), 'record', 'tests',
-                          '--session', 'builds/dummy/test_sessions/123', 'foo', 'alpha', 'bravo', 'charlie')
+        result = self.cli('--plugins', str(plugin_dir), 'record', 'test', 'foo',
+                          '--session', 'builds/dummy/test_sessions/123', 'alpha', 'bravo', 'charlie')
         self.assertTrue("foo:alpha" in result.stdout, result.stdout)
         self.assertTrue("foo:bravo" in result.stdout, result.stdout)
         self.assertTrue("foo:charlie" in result.stdout, result.stdout)

--- a/tests/test_runners/test_adb.py
+++ b/tests/test_runners/test_adb.py
@@ -54,7 +54,7 @@ INSTRUMENTATION_CODE: -1
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '10%', 'adb', input=self.subset_input)
+        result = self.cli('subset', 'adb', '--target', '10%', input=self.subset_input)
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)

--- a/tests/test_runners/test_ant.py
+++ b/tests/test_runners/test_ant.py
@@ -10,15 +10,15 @@ class AntTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):
-        result = self.cli('subset', '--target', '10%', '--session',
-                          self.session, 'ant', str(self.test_files_dir.joinpath('src').resolve()))
+        result = self.cli('subset', 'ant', '--session', self.session, '--target',
+                          '10%', str(self.test_files_dir.joinpath('src').resolve()))
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_ant(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'ant', str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
+        result = self.cli('record', 'test', 'ant', '--session', self.session,
+                          str(self.test_files_dir) + "/junitreport/TESTS-TestSuites.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_bazel.py
+++ b/tests/test_runners/test_bazel.py
@@ -30,7 +30,7 @@ Loading: 2 packages loaded
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '10%', 'bazel', input=self.subset_input)
+        result = self.cli('subset', 'bazel', '--target', '10%', input=self.subset_input)
         self.assert_success(result)
         self.assertEqual(read_session(self.build_name), self.session)
         self.assert_subset_payload('subset_result.json')
@@ -41,7 +41,7 @@ Loading: 2 packages loaded
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'bazel', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'test', 'bazel', str(self.test_files_dir) + "/")
         self.assert_success(result)
         self.assertEqual(read_session(self.build_name), self.session)
         self.assert_record_tests_payload('record_test_result.json')
@@ -52,7 +52,7 @@ Loading: 2 packages loaded
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'bazel', '--build-event-json', str(
+        result = self.cli('record', 'test', 'bazel', '--build-event-json', str(
             self.test_files_dir.joinpath("build_event.json")), str(self.test_files_dir) + "/")
         self.assert_success(result)
         self.assertEqual(read_session(self.build_name), self.session)
@@ -64,7 +64,7 @@ Loading: 2 packages loaded
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'bazel', '--build-event-json',
+        result = self.cli('record', 'test', 'bazel', '--build-event-json',
                           str(self.test_files_dir.joinpath("build_event.json")),
                           '--build-event-json', str(self.test_files_dir.joinpath("build_event_rest.json")),
                           str(self.test_files_dir) + "/")
@@ -81,13 +81,13 @@ Loading: 2 packages loaded
         """
         Test recorded test results contain subset's test path
         """
-        result = self.cli('subset', '--target', '10%', 'bazel', input=self.subset_input)
+        result = self.cli('subset', 'bazel', '--target', '10%', input=self.subset_input)
 
         self.assert_success(result)
 
         subset_payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
 
-        result = self.cli('record', 'tests', 'bazel', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'test', 'bazel', str(self.test_files_dir) + "/")
         self.assert_success(result)
 
         record_payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())

--- a/tests/test_runners/test_behave.py
+++ b/tests/test_runners/test_behave.py
@@ -11,14 +11,14 @@ class BehaveTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):
         pipe = "tutorial.feature"
-        result = self.cli('subset', '--target', '10%', '--session', self.session, 'behave', input=pipe)
+        result = self.cli('subset', 'behave', '--session', self.session, '--target', '10%', input=pipe)
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test(self):
-        result = self.cli('record', 'tests', '--session', self.session, 'behave',
+        result = self.cli('record', 'test', 'behave', '--session', self.session,
                           str(self.test_files_dir) + "/reports/report.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_ctest.py
+++ b/tests/test_runners/test_ctest.py
@@ -42,8 +42,7 @@ class CTestTest(CliTestCase):
             # emulate launchable record build
             write_build(self.build_name)
 
-            result = self.cli('subset', '--target', '10%', 'ctest',
-                              '--output-regex-files',
+            result = self.cli('subset', 'ctest', '--target', '10%', '--output-regex-files',
                               '--output-regex-files-dir=' + output_dir,
                               '--output-regex-files-size=32',
                               str(self.test_files_dir.joinpath("ctest_list.json")))
@@ -79,7 +78,7 @@ class CTestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '10%', 'ctest', str(self.test_files_dir.joinpath("ctest_list.json")))
+        result = self.cli('subset', 'ctest', '--target', '10%', str(self.test_files_dir.joinpath("ctest_list.json")))
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -89,7 +88,7 @@ class CTestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'ctest', str(self.test_files_dir) + "/Testing/**/Test.xml")
+        result = self.cli('record', 'test', 'ctest', str(self.test_files_dir) + "/Testing/**/Test.xml")
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -54,11 +54,11 @@ armeabi-v7a CtsAbiOverrideHostTestCases
 
         result = self.cli(
             "subset",
+            "cts",
             "--target",
             "30%",
             "--session",
             self.session,
-            "cts",
             input=pipe,
             mix_stderr=False)
         self.assert_success(result)
@@ -86,7 +86,7 @@ armeabi-v7a CtsAbiOverrideHostTestCases
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_tests(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'cts', str(self.test_files_dir) + "/test_result.xml")
+        result = self.cli('record', 'test', 'cts', '--session', self.session,
+                          str(self.test_files_dir) + "/test_result.xml")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_cts.py
+++ b/tests/test_runners/test_cts.py
@@ -69,12 +69,12 @@ armeabi-v7a CtsAbiOverrideHostTestCases
 
         result = self.cli(
             "subset",
+            "cts",
             "--target",
             "30%",
             "--session",
             self.session,
             "--output-exclusion-rules",
-            "cts",
             input=pipe,
             mix_stderr=False)
 

--- a/tests/test_runners/test_cucumber.py
+++ b/tests/test_runners/test_cucumber.py
@@ -20,7 +20,7 @@ class CucumberTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', '--base', str(self.test_files_dir), 'cucumber', *reports)
+        result = self.cli('record', 'test', 'cucumber', '--base', str(self.test_files_dir), *reports)
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
@@ -35,7 +35,7 @@ class CucumberTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'cucumber', "--json", *reports)
+        result = self.cli('record', 'test', 'cucumber', "--json", *reports)
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_json_result.json')

--- a/tests/test_runners/test_cypress.py
+++ b/tests/test_runners/test_cypress.py
@@ -12,8 +12,8 @@ class CypressTest(CliTestCase):
     def test_record_test_cypress(self):
         # test-result.xml was generated used to cypress-io/cypress-example-kitchensink
         # cypress run --reporter junit report.xml
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'cypress', str(self.test_files_dir) + "/test-result.xml")
+        result = self.cli('record', 'test', 'cypress', '--session', self.session,
+                          str(self.test_files_dir) + "/test-result.xml")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
@@ -23,7 +23,7 @@ class CypressTest(CliTestCase):
         # test-report.xml is outputed from
         # cypress/integration/examples/window.spec.js, so set it
         pipe = "cypress/integration/examples/window.spec.js"
-        result = self.cli('subset', '--target', '10%', '--session', self.session, 'cypress', input=pipe)
+        result = self.cli('subset', 'cypress', '--session', self.session, '--target', '10%', input=pipe)
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -31,8 +31,8 @@ class CypressTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_empty_xml(self):
         # parse empty test report XML
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'cypress', str(self.test_files_dir) + "/empty.xml")
+        result = self.cli('record', 'test', 'cypress', '--session', self.session,
+                          str(self.test_files_dir) + "/empty.xml")
         self.assert_success(result)
         for call in responses.calls:
             self.assertFalse(call.request.url.endswith('/events'), 'there should be no calls to the /events endpoint')

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -62,10 +62,9 @@ class DotnetTest(CliTestCase):
         self.assert_exit_code(result, 1)
 
         result = self.cli(
-            'subset', 'dotnet', '--session',
-            self.session,
-            '--target',
-            '25%',
+            'subset', 'dotnet',
+            '--session', self.session,
+            '--target', '25%',
             '--get-tests-from-previous-sessions',
             mix_stderr=False)
         self.assert_success(result)
@@ -74,12 +73,11 @@ class DotnetTest(CliTestCase):
         self.assertEqual(result.output, output)
 
         result = self.cli(
-            'subset', '--session', '--target',
-            '25%',
-            self.session,
+            'subset', 'dotnet',
+            '--session', self.session,
+            '--target', '25%',
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
-            'dotnet',
             mix_stderr=False)
         self.assert_success(result)
 
@@ -135,10 +133,9 @@ class DotnetTest(CliTestCase):
             status=200)
 
         result = self.cli(
-            'subset', 'dotnet', '--session',
-            self.session,
-            '--target',
-            '25%',
+            'subset', 'dotnet',
+            '--session', self.session,
+            '--target', '25%',
             '--get-tests-from-previous-sessions',
             '--bare',
             mix_stderr=False)
@@ -148,12 +145,11 @@ class DotnetTest(CliTestCase):
         self.assertEqual(result.output, output)
 
         result = self.cli(
-            'subset', '--session', '--target',
-            '25%',
-            self.session,
+            'subset', 'dotnet',
+            '--session', self.session,
+            '--target', '25%',
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
-            'dotnet',
             '--bare',
             mix_stderr=False)
         self.assert_success(result)
@@ -196,16 +192,21 @@ class DotnetTest(CliTestCase):
             },
             status=200)
 
-        result = self.cli('split-subset', '--subset-id', 'subset/456',
-                          '--bin', '1/2', 'dotnet')
+        result = self.cli('split-subset',
+                          '--subset-id', 'subset/456',
+                          '--bin', '1/2',
+                          'dotnet')
 
         self.assert_success(result)
 
         output = "FullyQualifiedName=rocket_car_dotnet.ExampleTest.TestSub\n"  # noqa: E501
         self.assertEqual(result.output, output)
 
-        result = self.cli('split-subset', '--subset-id', 'subset/456',
-                          '--bin', '1/2', '--output-exclusion-rules', 'dotnet')
+        result = self.cli('split-subset',
+                          '--subset-id', 'subset/456',
+                          '--bin', '1/2',
+                          '--output-exclusion-rules',
+                          'dotnet')
         self.assert_success(result)
 
         output = "FullyQualifiedName!=rocket_car_dotnet.ExampleTest.TestAdd\n"  # noqa: E501

--- a/tests/test_runners/test_dotnet.py
+++ b/tests/test_runners/test_dotnet.py
@@ -58,17 +58,15 @@ class DotnetTest(CliTestCase):
             status=200)
 
         # dotnet profiles requires Zero Input Subsetting
-        result = self.cli('subset', '--target', '25%', '--session', self.session, 'dotnet')
+        result = self.cli('subset', 'dotnet', '--session', self.session, '--target', '25%')
         self.assert_exit_code(result, 1)
 
         result = self.cli(
-            'subset',
+            'subset', 'dotnet', '--session',
+            self.session,
             '--target',
             '25%',
-            '--session',
-            self.session,
             '--get-tests-from-previous-sessions',
-            'dotnet',
             mix_stderr=False)
         self.assert_success(result)
 
@@ -76,10 +74,8 @@ class DotnetTest(CliTestCase):
         self.assertEqual(result.output, output)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', '--session', '--target',
             '25%',
-            '--session',
             self.session,
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
@@ -139,13 +135,11 @@ class DotnetTest(CliTestCase):
             status=200)
 
         result = self.cli(
-            'subset',
+            'subset', 'dotnet', '--session',
+            self.session,
             '--target',
             '25%',
-            '--session',
-            self.session,
             '--get-tests-from-previous-sessions',
-            'dotnet',
             '--bare',
             mix_stderr=False)
         self.assert_success(result)
@@ -154,10 +148,8 @@ class DotnetTest(CliTestCase):
         self.assertEqual(result.output, output)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', '--session', '--target',
             '25%',
-            '--session',
             self.session,
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
@@ -222,7 +214,6 @@ class DotnetTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_tests(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'dotnet', str(self.test_files_dir) + "/test-result.xml")
+        result = self.cli('record', 'test', 'dotnet', '--session', self.session, str(self.test_files_dir) + "/test-result.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")

--- a/tests/test_runners/test_go_test.py
+++ b/tests/test_runners/test_go_test.py
@@ -15,7 +15,7 @@ class GoTestTest(CliTestCase):
     def test_subset_with_session(self):
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\n" \
                "ok      github.com/launchableinc/rocket-car-gotest      0.268s"
-        result = self.cli('subset', '--target', '10%', '--session', self.session, 'go-test', input=pipe)
+        result = self.cli('subset', 'go-test', '--session', self.session, '--target', '10%', input=pipe)
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -27,7 +27,7 @@ class GoTestTest(CliTestCase):
 
         pipe = "TestExample1\nTestExample2\nTestExample3\nTestExample4\n" \
                "ok      github.com/launchableinc/rocket-car-gotest      0.268s"
-        result = self.cli('subset', '--target', '10%', 'go-test', input=pipe)
+        result = self.cli('subset', 'go-test', '--target', '10%', input=pipe)
 
         self.assert_success(result)
 
@@ -37,8 +37,8 @@ class GoTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_tests_with_session(self):
-        result = self.cli('record', 'tests', '--session',
-                          self.session, 'go-test', str(self.test_files_dir.joinpath('reportv1')) + "/")
+        result = self.cli('record', 'test', 'go-test', '--session', self.session,
+                          str(self.test_files_dir.joinpath('reportv1')) + "/")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
@@ -48,7 +48,7 @@ class GoTestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'go-test', str(self.test_files_dir.joinpath('reportv1')) + "/")
+        result = self.cli('record', 'test', 'go-test', str(self.test_files_dir.joinpath('reportv1')) + "/")
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)
@@ -57,8 +57,8 @@ class GoTestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_tests_v2(self):
-        result = self.cli('record', 'tests', '--session',
-                          self.session, 'go-test', str(self.test_files_dir.joinpath('reportv2')) + "/")
+        result = self.cli('record', 'test', 'go-test', '--session', self.session,
+                          str(self.test_files_dir.joinpath('reportv2')) + "/")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 

--- a/tests/test_runners/test_googletest.py
+++ b/tests/test_runners/test_googletest.py
@@ -16,15 +16,14 @@ class GoogleTestTest(CliTestCase):
   Baz
   Foo
         """
-        result = self.cli('subset', '--target', '10%', '--session', self.session, 'googletest', input=pipe)
+        result = self.cli('subset', 'googletest', '--session', self.session, '--target', '10%', input=pipe)
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_googletest(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'googletest', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'test', 'googletest', '--session', self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
@@ -32,8 +31,7 @@ class GoogleTestTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_failed_test_googletest(self):
         # ./test_a --gtest_output=xml:output.xml
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'googletest', str(self.test_files_dir) + "/fail/")
+        result = self.cli('record', 'test', 'googletest', '--session', self.session, str(self.test_files_dir) + "/fail/")
         self.assert_success(result)
         self.assert_record_tests_payload('fail/record_test_result.json')
 
@@ -41,7 +39,6 @@ class GoogleTestTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_empty_dir(self):
         path = 'latest/gtest_*_results.xml'
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'googletest', path)
+        result = self.cli('record', 'test', 'googletest', '--session', self.session, path)
         self.assertEqual(result.output.rstrip('\n'), "No matches found: {}".format(path))
         self.assert_success(result)

--- a/tests/test_runners/test_gradle.py
+++ b/tests/test_runners/test_gradle.py
@@ -42,8 +42,7 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset', '--target', '10%', 'gradle',
-            str(self.test_files_dir.joinpath('java/app/src/test').resolve()))
+            'subset', 'gradle', '--target', '10%', str(self.test_files_dir.joinpath('java/app/src/test').resolve()))
         # TODO: we need to assert on the request payload to make sure it found
         # test list all right
         self.assert_success(result)
@@ -90,7 +89,7 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset', '--target', '10%', '--rest', rest.name, 'gradle',
+            'subset', 'gradle', '--target', '10%', '--rest', rest.name,
             str(self.test_files_dir.joinpath('java/app/src/test/java').resolve()))
 
         self.assert_success(result)
@@ -137,12 +136,10 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', 'gradle', '--target',
             '10%',
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
-            'gradle',
             mix_stderr=False)
 
         if result.exit_code != 0:
@@ -191,12 +188,10 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', 'gradle', '--target',
             '10%',
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
-            'gradle',
             mix_stderr=False)
 
         if result.exit_code != 0:
@@ -242,12 +237,10 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', 'gradle', '--target',
             '10%',
             '--get-tests-from-previous-sessions',
             '--output-exclusion-rules',
-            'gradle',
             str(self.test_files_dir.joinpath('java/app/src/test').resolve()),
             mix_stderr=False)
 
@@ -292,11 +285,9 @@ class GradleTest(CliTestCase):
         write_build(self.build_name)
 
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', 'gradle', '--target',
             '10%',
             '--split',
-            'gradle',
             str(self.test_files_dir.joinpath('java/app/src/test/java').resolve()))
 
         self.assert_success(result)
@@ -403,7 +394,7 @@ class GradleTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_gradle(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'gradle', str(self.test_files_dir) + "/**/reports")
+        result = self.cli('record', 'test', 'gradle', '--session', self.session,
+                          str(self.test_files_dir) + "/**/reports")
         self.assert_success(result)
         self.assert_record_tests_payload('recursion/expected.json')

--- a/tests/test_runners/test_jest.py
+++ b/tests/test_runners/test_jest.py
@@ -35,8 +35,7 @@ class JestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '10%', '--base',
-                          os.getcwd(), 'jest', input=self.subset_input)
+        result = self.cli('subset', 'jest', '--base', os.getcwd(), '--target', '10%', input=self.subset_input)
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -65,8 +64,8 @@ class JestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('subset', '--target', '20%', '--base', os.getcwd(), '--split',
-                          'jest', input=self.subset_input)
+        result = self.cli('subset', 'jest', '--base', os.getcwd(), '--target', '20%', '--split',
+                          input=self.subset_input)
 
         self.assert_success(result)
 
@@ -78,6 +77,6 @@ class JestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'jest', str(self.test_files_dir.joinpath("junit.xml")))
+        result = self.cli('record', 'test', 'jest', str(self.test_files_dir.joinpath("junit.xml")))
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_maven.py
+++ b/tests/test_runners/test_maven.py
@@ -14,8 +14,8 @@ class MavenTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):
-        result = self.cli('subset', '--target', '10%', '--session',
-                          self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
+        result = self.cli('subset', 'maven', '--session', self.session, '--target', '10%',
+                          str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -47,12 +47,8 @@ class MavenTest(CliTestCase):
         save_file(list_1, "createdFile_1.lst")
         save_file(list_2, "createdFile_2.lst")
 
-        result = self.cli('subset',
-                          '--target',
+        result = self.cli('subset', 'maven', '--session', self.session, '--target',
                           '10%',
-                          '--session',
-                          self.session,
-                          'maven',
                           "--test-compile-created-file",
                           str(self.test_files_dir.joinpath("createdFile_1.lst")),
                           "--test-compile-created-file",
@@ -82,12 +78,8 @@ class MavenTest(CliTestCase):
             for test_class in list:
                 file.write(test_class.replace(".", os.path.sep) + ".class\n")
 
-        result = self.cli('subset',
-                          '--target',
+        result = self.cli('subset', 'maven', '--session', self.session, '--target',
                           '10%',
-                          '--session',
-                          self.session,
-                          'maven',
                           "--scan-test-compile-lst")
         # clean up test directory
         shutil.rmtree(base_tmp_dir)
@@ -98,16 +90,16 @@ class MavenTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset_by_absolute_time(self):
-        result = self.cli('subset', '--time', '1h30m', '--session',
-                          self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
+        result = self.cli('subset', 'maven', '--session', self.session, '--time', '1h30m',
+                          str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
         self.assert_subset_payload('subset_by_absolute_time_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset_by_confidence(self):
-        result = self.cli('subset', '--confidence', '90%', '--session',
-                          self.session, 'maven', str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
+        result = self.cli('subset', 'maven', '--session', self.session, '--confidence', '90%',
+                          str(self.test_files_dir.joinpath('java/test/src/java/').resolve()))
         self.assert_success(result)
         self.assert_subset_payload('subset_by_confidence_result.json')
 
@@ -160,8 +152,7 @@ class MavenTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_maven(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'maven', str(self.test_files_dir) + "/**/reports")
+        result = self.cli('record', 'test', 'maven', '--session', self.session, str(self.test_files_dir) + "/**/reports")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")
 
@@ -201,8 +192,7 @@ class MavenTest(CliTestCase):
         self.assertNotIn("$", result_path[0]["name"])
 
         # Now run the actual CLI command to ensure integration works
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'maven',
+        result = self.cli('record', 'test', 'maven', '--session', self.session,
                           str(self.test_files_dir) + "/maven/reports/TEST-1.xml",
                           str(self.test_files_dir) + "/maven/reports/TEST-2.xml",
                           str(self.test_files_dir) + "/maven/reports/TEST-nested.xml")

--- a/tests/test_runners/test_minitest.py
+++ b/tests/test_runners/test_minitest.py
@@ -16,15 +16,15 @@ class MinitestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_minitest(self):
-        result = self.cli('record', 'tests', '--session', self.session, 'minitest', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'test', 'minitest', '--session', self.session, str(self.test_files_dir) + "/")
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_minitest_chunked(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          '--post-chunk', 5, 'minitest', str(self.test_files_dir) + "/")
+        result = self.cli('record', 'test', 'minitest', '--session', self.session,
+                          '--post-chunk', 5, str(self.test_files_dir) + "/")
         self.assert_success(result)
 
         payload1 = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
@@ -62,8 +62,8 @@ class MinitestTest(CliTestCase):
                                 },
                           status=200)
 
-        result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir),
-                          'minitest', str(self.test_files_dir) + "/test/**/*.rb")
+        result = self.cli('subset', 'minitest', '--session', self.session, '--target', '20%', '--base', str(self.test_files_dir),
+                          str(self.test_files_dir) + "/test/**/*.rb")
 
         self.assert_success(result)
 
@@ -73,8 +73,8 @@ class MinitestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset_with_invalid_path(self):
-        result = self.cli('subset', '--target', '20%', '--session', self.session, '--base', str(self.test_files_dir),
-                          'minitest', str(self.test_files_dir) + "/dummy")
+        result = self.cli('subset', 'minitest', '--session', self.session, '--target', '20%', '--base', str(self.test_files_dir),
+                          str(self.test_files_dir) + "/dummy")
 
         self.assert_success(result)
 
@@ -102,8 +102,8 @@ class MinitestTest(CliTestCase):
                                 },
                           status=200)
 
-        result = self.cli('subset', '--target', '20%', '--session', self.session, '--base',
-                          str(self.test_files_dir), '--split', 'minitest', str(self.test_files_dir) + "/test/**/*.rb")
+        result = self.cli('subset', 'minitest', '--session', self.session, '--target', '20%', '--base',
+                          str(self.test_files_dir), '--split', str(self.test_files_dir) + "/test/**/*.rb")
 
         self.assert_success(result)
 

--- a/tests/test_runners/test_nunit.py
+++ b/tests/test_runners/test_nunit.py
@@ -74,7 +74,7 @@ class NUnitTest(CliTestCase):
                 },
             }, status=200)
 
-        result = self.cli('subset', '--target', '10%', '--session', self.session, 'nunit',
+        result = self.cli('subset', 'nunit', '--session', self.session, '--target', '10%',
                           str(self.test_files_dir) + "/list.xml")
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
@@ -152,24 +152,22 @@ class NUnitTest(CliTestCase):
     @mock.patch.dict(os.environ,
                      {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_on_linux(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'nunit', str(self.test_files_dir) + "/output-linux.xml")
+        result = self.cli('record', 'test', 'nunit', '--session', self.session, str(self.test_files_dir) + "/output-linux.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result-linux.json")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_on_windows(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'nunit', str(self.test_files_dir) + "/output-windows.xml")
+        result = self.cli('record', 'test', 'nunit', '--session', self.session, str(self.test_files_dir) + "/output-windows.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result-windows.json")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_with_nunit_reporter_bug(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'nunit', str(self.test_files_dir) + "/nunit-reporter-bug-with-nested-type.xml")
+        result = self.cli('record', 'test', 'nunit', '--session', self.session,
+                          str(self.test_files_dir) + "/nunit-reporter-bug-with-nested-type.xml")
         self.assert_success(result)
         # turns out we collapse all TestFixtures to TestSuitest so the golden file has TestSuite=Outer+Inner,
         # not TestFixture=Outer+Inner

--- a/tests/test_runners/test_playwright.py
+++ b/tests/test_runners/test_playwright.py
@@ -17,8 +17,8 @@ class PlaywrightTest(CliTestCase):
     @mock.patch.dict(os.environ,
                      {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'playwright', str(self.test_files_dir.joinpath("report.xml")))
+        result = self.cli('record', 'test', 'playwright', '--session', self.session,
+                          str(self.test_files_dir.joinpath("report.xml")))
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
@@ -32,8 +32,8 @@ class PlaywrightTest(CliTestCase):
                      {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_with_json_option(self):
         # report.json was created by `launchableinc/example/playwright`` project
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'playwright', '--json', str(self.test_files_dir.joinpath("report.json")))
+        result = self.cli('record', 'test', 'playwright', '--session', self.session,
+                          '--json', str(self.test_files_dir.joinpath("report.json")))
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result_with_json.json')
@@ -54,13 +54,13 @@ class PlaywrightTest(CliTestCase):
         target_test_path = "file=tests/timeout-example.spec.ts#testcase=time-out"
 
         # XML Report Case
-        self.cli('record', 'tests', '--session', self.session, 'playwright', str(self.test_files_dir.joinpath("report.xml")))
+        self.cli('record', 'test', 'playwright', '--session', self.session, str(self.test_files_dir.joinpath("report.xml")))
         xml_payload = json.loads(gzip.decompress(self.find_request('/events').request.body).decode())
 
         self.assertEqual(_test_test_path_status(xml_payload, target_test_path, CaseEvent.TEST_FAILED), True)
 
         # JSON Report Case
-        self.cli('record', 'tests', '--session', self.session,
-                 'playwright', '--json', str(self.test_files_dir.joinpath("report.json")))
+        self.cli('record', 'test', 'playwright', '--session', self.session,
+                 '--json', str(self.test_files_dir.joinpath("report.json")))
         json_payload = json.loads(gzip.decompress(self.find_request('/events', 1).request.body).decode())
         self.assertEqual(_test_test_path_status(json_payload, target_test_path, CaseEvent.TEST_FAILED), True)

--- a/tests/test_runners/test_prove.py
+++ b/tests/test_runners/test_prove.py
@@ -35,7 +35,7 @@ class ProveTestTest(CliTestCase):
         # emulate launchable record build
         write_build(self.build_name)
 
-        result = self.cli('record', 'tests', 'prove', str(self.test_files_dir.joinpath('report.xml')))
+        result = self.cli('record', 'test', 'prove', str(self.test_files_dir.joinpath('report.xml')))
         self.assert_success(result)
 
         self.assertEqual(read_session(self.build_name), self.session)

--- a/tests/test_runners/test_pytest.py
+++ b/tests/test_runners/test_pytest.py
@@ -26,8 +26,8 @@ tests/fooo/filenameonly_test.py
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):
-        result = self.cli('subset', '--target', '10%', '--session',
-                          self.session, 'pytest', input=self.subset_input)
+        result = self.cli('subset', 'pytest', '--target', '10%', '--session',
+                          self.session, input=self.subset_input)
         self.assert_success(result)
 
         payload = json.loads(gzip.decompress(self.find_request('/subset').request.body).decode())
@@ -39,8 +39,8 @@ tests/fooo/filenameonly_test.py
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_pytest(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'pytest', str(self.test_files_dir.joinpath("report.xml")))
+        result = self.cli('record', 'test', 'pytest', '--session', self.session,
+                          str(self.test_files_dir.joinpath("report.xml")))
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
@@ -48,8 +48,8 @@ tests/fooo/filenameonly_test.py
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_with_json_option(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'pytest', '--json', str(self.test_files_dir.joinpath("report.json")))
+        result = self.cli('record', 'test', 'pytest', '--session', self.session,
+                          '--json', str(self.test_files_dir.joinpath("report.json")))
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result_json.json')

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -51,8 +51,8 @@ class RawTest(CliTestCase):
             # emulate launchable record build
             write_build(self.build_name)
 
-            result = self.cli('subset', '--target', '10%',
-                              'raw', test_path_file, mix_stderr=False)
+            result = self.cli('subset', 'raw', '--target', '10%',
+                              test_path_file, mix_stderr=False)
             self.assert_success(result)
 
             # Check request body
@@ -106,12 +106,9 @@ class RawTest(CliTestCase):
         # Don't use with for Windows environment
         rest = tempfile.NamedTemporaryFile(mode="+w", encoding="utf-8", delete=False)
         result = self.cli(
-            'subset',
-            '--target',
+            'subset', 'raw', '--get-tests-from-previous-sessions', '--target',
             '10%',
-            '--get-tests-from-previous-sessions',
             "--rest", rest.name,
-            'raw',
             mix_stderr=False)
         self.assert_success(result)
 
@@ -220,7 +217,7 @@ class RawTest(CliTestCase):
             # emulate launchable record build
             write_build(self.build_name)
 
-            result = self.cli('record', 'tests', 'raw', test_path_file, test_path_file2, test_path_file3, mix_stderr=False)
+            result = self.cli('record', 'test', 'raw', test_path_file, test_path_file2, test_path_file3, mix_stderr=False)
             self.assert_success(result)
 
             # Check request body
@@ -323,7 +320,7 @@ class RawTest(CliTestCase):
             # emulate launchable record build
             write_build(self.build_name)
 
-            result = self.cli('record', 'tests', 'raw', test_path_file, test_path_file2, mix_stderr=False)
+            result = self.cli('record', 'test', 'raw', test_path_file, test_path_file2, mix_stderr=False)
             if result.exit_code != 0:
                 self.assertEqual(
                     result.exit_code,

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -10,8 +10,8 @@ class RobotTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):
-        result = self.cli('subset', '--target', '10%', '--session',
-                          self.session, 'robot', str(self.test_files_dir) + "/dryrun.xml")
+        result = self.cli('subset', 'robot', '--target', '10%', '--session',
+                          self.session, str(self.test_files_dir) + "/dryrun.xml")
         self.assert_success(result)
         self.assert_subset_payload('subset_result.json')
 
@@ -19,8 +19,7 @@ class RobotTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test(self):
 
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'robot', str(self.test_files_dir) + "/output.xml")
+        result = self.cli('record', 'test', 'robot', '--session', self.session, str(self.test_files_dir) + "/output.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")
 
@@ -29,7 +28,6 @@ class RobotTest(CliTestCase):
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_executed_only_one_file(self):
 
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'robot', str(self.test_files_dir) + "/single-output.xml")
+        result = self.cli('record', 'test', 'robot', '--session', self.session, str(self.test_files_dir) + "/single-output.xml")
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_executed_only_one_file_result.json")

--- a/tests/test_runners/test_rspec.py
+++ b/tests/test_runners/test_rspec.py
@@ -11,7 +11,7 @@ class RspecTest(CliTestCase):
     @mock.patch.dict(os.environ,
                      {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test_rspec(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'rspec', str(self.test_files_dir.joinpath("rspec.xml")))
+        result = self.cli('record', 'test', 'rspec', '--session', self.session,
+                          str(self.test_files_dir.joinpath("rspec.xml")))
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_vitest.py
+++ b/tests/test_runners/test_vitest.py
@@ -10,7 +10,6 @@ class VitestTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_tests(self):
-        result = self.cli('record', 'tests', '--session',
-                          self.session, 'vitest', str(self.test_files_dir.joinpath("report.xml")))
+        result = self.cli('record', 'test', 'vitest', '--session', self.session, str(self.test_files_dir.joinpath("report.xml")))
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')

--- a/tests/test_runners/test_xctest.py
+++ b/tests/test_runners/test_xctest.py
@@ -12,8 +12,8 @@ class XCTestTest(CliTestCase):
     @mock.patch.dict(os.environ,
                      {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_record_test(self):
-        result = self.cli('record', 'tests', '--session', self.session,
-                          'xctest', str(self.test_files_dir.joinpath("junit.xml")))
+        result = self.cli('record', 'test', 'xctest', '--session', self.session,
+                          str(self.test_files_dir.joinpath("junit.xml")))
 
         self.assert_success(result)
         self.assert_record_tests_payload('record_test_result.json')
@@ -47,11 +47,9 @@ class XCTestTest(CliTestCase):
             json=mock_response,
             status=200)
 
-        result = self.cli('subset',
-                          '--session', self.session,
+        result = self.cli('subset', 'xctest', '--session', self.session,
                           '--get-tests-from-previous-sessions',
                           '--output-exclusion-rules',
-                          'xctest',
                           mix_stderr=False)
 
         self.assert_success(result)


### PR DESCRIPTION
#  Summary

  This PR implements the NestedCommand pattern for the Smart Tests CLI, introducing a new command structure where test
  runners come before options (e.g., `smart-tests subset pytest --target 25%` instead of `smart-tests subset --target 25% pytest`).

# For reviewer
This Pull Request is mainly for tracking my progress, so I’m not expecting a detailed review. If you can get a general idea of what I’m doing from the title, feel free to go ahead and approve it.

#  Key Changes

  • New Command Structure: Implemented NestedCommand pattern allowing test runner-specific commands with their own
  options
  • Dynamic Command Generation: Added DynamicCommandBuilder class to dynamically create commands for all registered test
  runners
  • Test Runner Registry: Created a centralized registry system to manage test runner functions and enable dynamic
  command creation
  • Backward Compatibility: Maintained legacy command structure as fallback when NestedCommand fails
  • Plugin Support: Enhanced plugin loading system to work with the new command structure
  • CI Integration: Updated GitHub Actions workflow to use the new command syntax

#  Technical Implementation

###  • New Files:
  - smart_tests/utils/dynamic_commands.py - Core dynamic command building logic
  - smart_tests/utils/test_runner_registry.py - Test runner registration system

###  • Modified Files:
  - smart_tests/__main__.py - Added NestedCommand apps and plugin rebuilding logic
  - smart_tests/commands/subset.py - Added NestedCommand support
  - smart_tests/commands/record/tests.py - Added NestedCommand support
  - smart_tests/test_runners/smart_tests.py - Updated decorators for new registry system
  - Various test runner files - Enhanced with proper type annotations

#  Benefits

  • Improved UX: More intuitive command structure where test runner selection comes first
  • Type Safety: Better type annotations and parameter validation
  • Extensibility: Easier to add new test runners and options
  • Plugin Support: Better integration with external test runner plugins

#  Test Plan

  - Verify new command syntax works: smart-tests subset pytest --target 25%
  - Verify legacy command syntax still works as fallback
  - Test plugin loading with new command structure
  - Verify CI workflow uses new command syntax
  - Test all supported test runners with new structure
  - Verify backward compatibility for existing scripts

  🤖 Generated with https://claude.ai/code