### PR TITLE
Handle error when java -version returns error

### DIFF
--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -3,6 +3,7 @@ import platform
 import re
 import subprocess
 import sys
+from subprocess import CalledProcessError
 from typing import List
 
 import click
@@ -32,7 +33,10 @@ def compare_version(a: List[int], b: List[int]):
 
 
 def compare_java_version(output: str) -> int:
-    """Check if the Java version meets what we need. returns >=0 if we meet the requirement"""
+    """
+    Check if the Java version meets what we need.
+    Returns >=0 if we meet the requirement, or if we couldn't determine the version to be on the safe side
+    """
     pattern = re.compile('"([^"]+)"')
     for l in output.splitlines():
         if l.find("java version") != -1:
@@ -49,9 +53,15 @@ def compare_java_version(output: str) -> int:
 
 
 def check_java_version(javacmd: str) -> int:
-    """Check if the Java version meets what we need. returns >=0 if we meet the requirement"""
-    v = subprocess.run([javacmd, "-version"], check=True, stderr=subprocess.PIPE, universal_newlines=True)
-    return compare_java_version(v.stderr)
+    """
+    Check if the Java version meets what we need.
+    Returns >=0 if we meet the requirement, or if we couldn't determine the version to be on the safe side
+    """
+    try:
+        v = subprocess.run([javacmd, "-version"], check=True, stderr=subprocess.PIPE, universal_newlines=True)
+        return compare_java_version(v.stderr)
+    except CalledProcessError:
+        return 0
 
 
 @click.command(name="verify")

--- a/launchable/commands/verify.py
+++ b/launchable/commands/verify.py
@@ -33,10 +33,7 @@ def compare_version(a: List[int], b: List[int]):
 
 
 def compare_java_version(output: str) -> int:
-    """
-    Check if the Java version meets what we need.
-    Returns >=0 if we meet the requirement, or if we couldn't determine the version to be on the safe side
-    """
+    """Check if the Java version meets what we need. returns >=0 if we meet the requirement"""
     pattern = re.compile('"([^"]+)"')
     for l in output.splitlines():
         if l.find("java version") != -1:
@@ -55,13 +52,14 @@ def compare_java_version(output: str) -> int:
 def check_java_version(javacmd: str) -> int:
     """
     Check if the Java version meets what we need.
-    Returns >=0 if we meet the requirement, or if we couldn't determine the version to be on the safe side
+    Returns >=0 if we meet the requirement
+    Returns -1 if 'java -version' command returns non-zero exit status
     """
     try:
         v = subprocess.run([javacmd, "-version"], check=True, stderr=subprocess.PIPE, universal_newlines=True)
         return compare_java_version(v.stderr)
     except CalledProcessError:
-        return 0
+        return -1
 
 
 @click.command(name="verify")

--- a/tests/commands/test_verify.py
+++ b/tests/commands/test_verify.py
@@ -44,4 +44,4 @@ class VersionTest(TestCase):
     def test_check_java_version(self, mock_run):
         mock_run.side_effect = CalledProcessError(1, 'java -version')
         result = check_java_version('java')
-        self.assertEqual(result, 0)
+        self.assertEqual(result, -1)

--- a/tests/commands/test_verify.py
+++ b/tests/commands/test_verify.py
@@ -1,6 +1,8 @@
+from subprocess import CalledProcessError
 from unittest import TestCase
+from unittest.mock import patch
 
-from launchable.commands.verify import compare_java_version, compare_version
+from launchable.commands.verify import check_java_version, compare_java_version, compare_version
 
 
 class VersionTest(TestCase):
@@ -37,3 +39,9 @@ class VersionTest(TestCase):
     Java HotSpot(TM) 64-Bit Server VM (build 1.5.0_22-b03, mixed mode)
     """
         ) < 0)
+
+    @patch('launchable.commands.verify.subprocess.run')
+    def test_check_java_version(self, mock_run):
+        mock_run.side_effect = CalledProcessError(1, 'java -version')
+        result = check_java_version('java')
+        self.assertEqual(result, 0)


### PR DESCRIPTION
This PR addresses the following error:

```
% java -version
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

% launchable verify                                    

  warnings.warn(
Organization: 'defaulttm'
Workspace: 'my-initial-tests'
Proxy: None
Platform: 'macOS-15.5-arm64-arm-64bit'
Python version: '3.9.6'
Java command: 'java'
launchable version: '1.106.0'
Traceback (most recent call last):
  File "/Users/gweerakutti/Library/Python/3.9/bin/launchable", line 8, in <module>
    sys.exit(main())
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/launchable/commands/verify.py", line 137, in verify
    if check_java_version(java) < 0:
  File "/Users/gweerakutti/Library/Python/3.9/lib/python/site-packages/launchable/commands/verify.py", line 53, in check_java_version
    v = subprocess.run([javacmd, "-version"], check=True, stderr=subprocess.PIPE, universal_newlines=True)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['java', '-version']' returned non-zero exit status 1.
```

While `/usr/bin/java` might exist on users macOS system, when no JDK or JRE is installed, it typically act as a placeholder or symlink meant to guide users toward installing Java. So in such case, when we call `java -version` in our code, as the command returns an non-zero error code instead of the version, we need to handle it.

New behavior:
```
% java -version; echo "Exit code: $?"
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

Exit code: 1

% launchable verify        
/Users/gweerakutti/.local/share/virtualenvs/cli-JevRS2r6/lib/python3.9/site-packages/launchable/version.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
Organization: 'defaulttm'
Workspace: 'my-initial-tests'
Proxy: None
Platform: 'macOS-15.5-arm64-arm-64bit'
Python version: '3.9.6'
Java command: 'java'
launchable version: '1.106.2.dev1+ge25829f3.d20250718'
Usage: launchable verify [OPTIONS]
Try 'launchable verify --help' for help.

Error: Java 8 or later is required
```