### PR TITLE
for PTS v2

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -523,10 +523,10 @@ def subset(
                 git_managed_files = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
                                                    universal_newlines=True, check=True).stdout.strip().split('\n')
             except subprocess.CalledProcessError as e:
-                warn(f"git ls-files failed (exit code={e.returncode})")
+                warn_and_exit_if_fail_fast_mode(f"git ls-files failed (exit code={e.returncode})")
                 return
             except OSError as e:
-                warn(f"git ls-files failed: {e}")
+                warn_and_exit_if_fail_fast_mode(f"git ls-files failed: {e}")
                 return
 
             found = False
@@ -536,7 +536,7 @@ def subset(
                     found = True
 
             if not found:
-                warn("Nothing that looks like a test file in the current git repository.")
+                warn_and_exit_if_fail_fast_mode("Nothing that looks like a test file in the current git repository.")
 
         def request_subset(self) -> SubsetResult:
             test_runner = context.invoked_subcommand

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -627,7 +627,8 @@ def subset(
             """
             if len(subset_result.subset) == 0 and client.is_enabled_pts_v2():
                 self._collect_potential_test_files()
-                subset_result = self.request_subset()
+                if len(self.test_paths) > 0:
+                    subset_result = self.request_subset()
 
             if len(subset_result.subset) == 0:
                 warn_and_exit_if_fail_fast_mode("Error: no tests found matching the path.")

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -534,7 +534,7 @@ def subset(
 
             return payload
 
-        def _collect_test_like_files(self):
+        def _collect_potential_test_files(self):
             LOOSE_TEST_FILE_PATTERN = r'(\.(test|spec)\.|_test\.|Test\.|Spec\.|test/|tests/|__tests__/|src/test/)'
             EXCLUDE_PATTERN = r'\.(xml|json|txt|yml|yaml|md)$'
 
@@ -626,7 +626,7 @@ def subset(
             CLI will try to collect the test files automatically, and request the subset again.
             """
             if len(subset_result.subset) == 0 and client.is_enabled_pts_v2():
-                self._collect_test_like_files()
+                self._collect_potential_test_files()
                 subset_result = self.request_subset()
 
             if len(subset_result.subset) == 0:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -260,6 +260,12 @@ def subset(
         tracking_client.send_error_event(event_name=event, stack_trace=msg)
         sys.exit(1)
 
+    if is_get_tests_from_guess and is_get_tests_from_previous_sessions:
+        print_error_and_die(
+            "--get-tests-from-guess (list up tests from git ls-files and subset from there) and --get-tests-from-previous-sessions (list up tests from the recent runs and subset from there) are mutually exclusive. Which one do you want to use?",  # noqa E501
+            Tracking.ErrorEvent.USER_ERROR
+        )
+
     if is_observation and is_output_exclusion_rules:
         msg = (
             "WARNING: --observation and --output-exclusion-rules are set. "

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -538,7 +538,8 @@ def subset(
             LOOSE_TEST_FILE_PATTERN = r'(\.(test|spec)\.|_test\.|Test\.|Spec\.|test/|tests/|__tests__/|src/test/)'
             EXCLUDE_PATTERN = r'\.(xml|json|txt|yml|yaml|md)$'
 
-            git_managed_files = subprocess.run(['git', 'ls-files'], capture_output=True, text=True).stdout.strip().split('\n')
+            git_managed_files = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
+                                               universal_newlines=True).stdout.strip().split('\n')
 
             git_managed_test_files = []
             for f in git_managed_files:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -733,7 +733,7 @@ class SubsetResult:
         )
 
     @classmethod
-    def from_test_paths(cls, test_paths: List[List[Dict[str, str]]]) -> 'SubsetResult':
+    def from_test_paths(cls, test_paths: List[TestPath]) -> 'SubsetResult':
         return cls(
             subset=test_paths,
             rest=[],

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -580,9 +580,6 @@ def subset(
             if not self.is_get_tests_from_previous_sessions and len(self.test_paths) == 0:
                 if self.input_given:
                     print_error_and_die("ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent.", Tracking.ErrorEvent.USER_ERROR)  # noqa E501
-                if client.is_pts_v2_enabled():
-                    click.echo("INFO: Subset input is empty, enabling `--get-tests-from-previous-sessions` option", err=True)
-                    self.is_get_tests_from_previous_sessions = True
                 else:
                     print_error_and_die(
                         "ERROR: Expecting tests to be given, but none provided. See https://www.launchableinc.com/docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/subsetting-with-the-launchable-cli/ and provide ones, or use the `--get-tests-from-previous-sessions` option",  # noqa E501

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -489,7 +489,7 @@ def subset(
                     "id": os.path.basename(session_id)
                 },
                 "ignoreNewTests": ignore_new_tests,
-                "getTestsFromPreviousSessions": is_get_tests_from_previous_sessions,
+                "getTestsFromPreviousSessions": self.is_get_tests_from_previous_sessions,
             }
 
             if target is not None:
@@ -613,7 +613,7 @@ def subset(
             else:
                 output_subset, output_rests = original_subset, original_rests
 
-                if is_observation:
+                if subset_result.is_observation:
                     output_subset = output_subset + output_rests
                     output_rests = []
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -541,7 +541,7 @@ def subset(
             git_managed_files = []
             try:
                 git_managed_files = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
-                                                   universal_newlines=True).stdout.strip().split('\n')
+                                                   universal_newlines=True, check=True).stdout.strip().split('\n')
             except subprocess.CalledProcessError:
                 click.echo(
                     click.style(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -622,10 +622,10 @@ def subset(
                 subset_result = self.request_subset()
 
             """
-            If the subset response is empty and the workspace is enabled to PTS v2,
+            If the zero input subset response is empty and the workspace is enabled to PTS v2,
             CLI will try to collect the test files automatically, and request the subset again.
             """
-            if len(subset_result.subset) == 0 and client.is_enabled_pts_v2():
+            if client.is_enabled_pts_v2() and self.is_get_tests_from_previous_sessions and len(subset_result.subset) == 0:
                 self._collect_potential_test_files()
                 if len(self.test_paths) > 0:
                     subset_result = self.request_subset()

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -425,16 +425,17 @@ def subset(
                 self.test_paths.append(self.to_test_path(rel_base_path(path)))
 
         def stdin(self) -> Union[TextIO, List]:
-            # To avoid the cli continue to wait from stdin
-            if self.is_get_tests_from_previous_sessions or self.is_get_tests_from_guess:
-                return []
-
             """
             Returns sys.stdin, but after ensuring that it's connected to something reasonable.
 
             This prevents a typical problem where users think CLI is hanging because
             they didn't feed anything from stdin
             """
+
+            # To avoid the cli continue to wait from stdin
+            if self.is_get_tests_from_previous_sessions or self.is_get_tests_from_guess:
+                return []
+
             if sys.stdin.isatty():
                 warn_and_exit_if_fail_fast_mode(
                     "Warning: this command reads from stdin but it doesn't appear to be connected to anything. "
@@ -597,10 +598,11 @@ def subset(
                 return SubsetResult.from_test_paths(self.test_paths)
 
         def run(self):
+            """called after tests are scanned to compute the optimized order"""
+
             if self.is_get_tests_from_guess:
                 self._collect_potential_test_files()
 
-            """called after tests are scanned to compute the optimized order"""
             if not self.is_get_tests_from_previous_sessions and len(self.test_paths) == 0:
                 if self.input_given:
                     msg = "ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent."  # noqa E501

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -431,7 +431,7 @@ def subset(
                 """
                 Note: If pts v2 (state if HANDS_ON_LAB_V2), we allow empty stdin
                 """
-                if client.is_enabled_pts_v2():
+                if client.is_pts_v2_enabled():
                     return []
 
                 warn_and_exit_if_fail_fast_mode(
@@ -602,7 +602,7 @@ def subset(
                 msg = None
                 if self.input_given:
                     msg = "ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent."  # noqa E501
-                elif client.is_enabled_pts_v2():
+                elif client.is_pts_v2_enabled():
                     click.echo("INFO: Subset input is empty, enabling `--get-tests-from-previous-sessions` option", err=True)
                     self.is_get_tests_from_previous_sessions = True
                 else:
@@ -625,7 +625,7 @@ def subset(
             If the zero input subset response is empty and the workspace is enabled to PTS v2,
             CLI will try to collect the test files automatically, and request the subset again.
             """
-            if client.is_enabled_pts_v2() and self.is_get_tests_from_previous_sessions and len(subset_result.subset) == 0:
+            if client.is_pts_v2_enabled() and self.is_get_tests_from_previous_sessions and len(subset_result.subset) == 0:
                 self._collect_potential_test_files()
                 if len(self.test_paths) > 0:
                     subset_result = self.request_subset()

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -545,7 +545,7 @@ def subset(
             except subprocess.CalledProcessError:
                 click.echo(
                     click.style(
-                        "Warning: git ls-files failed. Falling back to globbing.",
+                        "Warning: git ls-files failed.",
                         fg="yellow"),
                     err=True)
 

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -529,12 +529,18 @@ def subset(
         def run(self):
             """called after tests are scanned to compute the optimized order"""
             if not is_get_tests_from_previous_sessions and len(self.test_paths) == 0:
+                msg = None
                 if self.input_given:
                     msg = "ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent."  # noqa E501
+                elif client.is_enabled_pts_v2():
+                    click.echo("INFO: Subset input is empty, enabling `--get-tests-from-previous-sessions` option", err=True)
+                    self.is_get_tests_from_previous_sessions = True
                 else:
                     msg = "ERROR: Expecting tests to be given, but none provided. See https://www.launchableinc.com/docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/subsetting-with-the-launchable-cli/ and provide ones, or use the `--get-tests-from-previous-sessions` option"  # noqa E501
-                click.echo(click.style(msg, fg="red"), err=True)
-                exit(1)
+
+                if msg:
+                    click.echo(click.style(msg, fg="red"), err=True)
+                    exit(1)
 
             # When Error occurs, return the test name as it is passed.
             original_subset = self.test_paths

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -549,12 +549,10 @@ def subset(
                         fg="yellow"),
                     err=True)
 
-            git_managed_test_files = []
             for f in git_managed_files:
                 if re.search(LOOSE_TEST_FILE_PATTERN, f) and not re.search(EXCLUDE_PATTERN, f):
-                    git_managed_test_files.append(self.to_test_path(f))
+                    self.test_paths.append(self.to_test_path(f))
 
-            self.test_paths = git_managed_test_files
             self.is_get_tests_from_previous_sessions = False
 
         def request_subset(self) -> SubsetResult:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -538,8 +538,16 @@ def subset(
             LOOSE_TEST_FILE_PATTERN = r'(\.(test|spec)\.|_test\.|Test\.|Spec\.|test/|tests/|__tests__/|src/test/)'
             EXCLUDE_PATTERN = r'\.(xml|json|txt|yml|yaml|md)$'
 
-            git_managed_files = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
-                                               universal_newlines=True).stdout.strip().split('\n')
+            git_managed_files = []
+            try:
+                git_managed_files = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE,
+                                                   universal_newlines=True).stdout.strip().split('\n')
+            except subprocess.CalledProcessError:
+                click.echo(
+                    click.style(
+                        "Warning: git ls-files failed. Falling back to globbing.",
+                        fg="yellow"),
+                    err=True)
 
             git_managed_test_files = []
             for f in git_managed_files:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -560,7 +560,7 @@ def subset(
         def request_subset(self) -> SubsetResult:
             test_runner = context.invoked_subcommand
             # temporarily extend the timeout because subset API response has become slow
-            # TODO: remove this line when API response return respose
+            # TODO: remove this line when API response return response
             # within 300 sec
             timeout = (5, 300)
             payload = self.get_payload(str(session_id), target, duration, str(test_runner))
@@ -571,6 +571,7 @@ def subset(
                 process.start()
                 click.echo("The subset was requested in non-blocking mode.", err=True)
                 self.output_handler(self.test_paths, [])
+                # With non-blocking mode, we don't need to wait for the response
                 sys.exit(0)
 
             try:

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -553,8 +553,6 @@ def subset(
                 if re.search(LOOSE_TEST_FILE_PATTERN, f) and not re.search(EXCLUDE_PATTERN, f):
                     self.test_paths.append(self.to_test_path(f))
 
-            self.is_get_tests_from_previous_sessions = False
-
         def request_subset(self) -> SubsetResult:
             test_runner = context.invoked_subcommand
             # temporarily extend the timeout because subset API response has become slow

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -580,7 +580,7 @@ def subset(
             if not self.is_get_tests_from_previous_sessions and len(self.test_paths) == 0:
                 if self.input_given:
                     print_error_and_die("ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent.", Tracking.ErrorEvent.USER_ERROR)  # noqa E501
-                if client.is_enabled_pts_v2():
+                if client.is_pts_v2_enabled():
                     click.echo("INFO: Subset input is empty, enabling `--get-tests-from-previous-sessions` option", err=True)
                     self.is_get_tests_from_previous_sessions = True
                 else:

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -107,7 +107,7 @@ class LaunchableClient:
 
     def is_pts_v2_enabled(self) -> bool:
         state = self._get_workspace_state()
-        return state.get('state', "") == "HANDS_ON_LAB_V2"
+        return state.get('pts_v2', False)
 
     def _get_workspace_state(self) -> dict:
         """
@@ -121,8 +121,8 @@ class LaunchableClient:
 
             state = res.json()
             self._workspace_state_cache = {
-                'state': state.get('state', ""),
-                'fail_fast_mode': state.get('isFailFastMode', False)
+                'fail_fast_mode': state.get('isFailFastMode', False),
+                'pts_v2': state.get('isPtsV2Enabled', False),
             }
             return self._workspace_state_cache
         except Exception as e:

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -105,7 +105,7 @@ class LaunchableClient:
         state = self._get_workspace_state()
         return state.get('fail_fast_mode', False)
 
-    def is_enabled_pts_v2(self) -> bool:
+    def is_pts_v2_enabled(self) -> bool:
         state = self._get_workspace_state()
         return state.get('state', "") == "HANDS_ON_LAB_V2"
 

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -30,7 +30,7 @@ class LaunchableClient:
                 "Confirm that you set LAUNCHABLE_TOKEN "
                 "(or LAUNCHABLE_ORGANIZATION and LAUNCHABLE_WORKSPACE) environment variable(s)\n"
                 "See https://docs.launchableinc.com/getting-started#setting-your-api-key")
-        self._workspace_state_cache: Optional[Dict] = None
+        self._workspace_state_cache: Optional[Dict[str, Union[str, bool]]] = None
 
     def request(
         self,

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -117,13 +117,14 @@ class LaunchableClient:
             return self._workspace_state_cache
         try:
             res = self.request("get", "state")
-            if res.status_code == 200:
-                state = res.json()
-                self._workspace_state_cache = {
-                    'state': state.get('state', ""),
-                    'fail_fast_mode': state.get('isFailFastMode', False)
-                }
-                return self._workspace_state_cache
+            res.raise_for_status()
+
+            state = res.json()
+            self._workspace_state_cache = {
+                'state': state.get('state', ""),
+                'fail_fast_mode': state.get('isFailFastMode', False)
+            }
+            return self._workspace_state_cache
         except Exception as e:
             self.print_exception_and_recover(e, "Failed to get workspace state")
 

--- a/tests/cli_test_case.py
+++ b/tests/cli_test_case.py
@@ -192,7 +192,7 @@ class CliTestCase(unittest.TestCase):
                 get_base_url(),
                 self.organization,
                 self.workspace),
-            json={'isFailFastMode': False},
+            json={'isFailFastMode': False, 'isPtsV2Enabled': False},
             status=200)
 
     def get_test_files_dir(self):

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -454,12 +454,12 @@ class APIErrorTest(CliTestCase):
             self.assert_success(result)
 
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
-        self.assert_tracking_count(tracking=tracking, count=9)
+        self.assert_tracking_count(tracking=tracking, count=10)
 
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
-        self.assert_tracking_count(tracking=tracking, count=13)
+        self.assert_tracking_count(tracking=tracking, count=14)
 
     def assert_tracking_count(self, tracking, count: int):
         # Prior to 3.6, `Response` object can't be obtained.

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -454,12 +454,12 @@ class APIErrorTest(CliTestCase):
             self.assert_success(result)
 
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
-        self.assert_tracking_count(tracking=tracking, count=10)
+        self.assert_tracking_count(tracking=tracking, count=9)
 
         result = self.cli("record", "tests", "--session", self.session, "minitest", str(self.test_files_dir) + "/")
         self.assert_success(result)
         # Since Timeout error is caught inside of LaunchableClient, the tracking event is sent twice.
-        self.assert_tracking_count(tracking=tracking, count=14)
+        self.assert_tracking_count(tracking=tracking, count=13)
 
     def assert_tracking_count(self, tracking, count: int):
         # Prior to 3.6, `Response` object can't be obtained.

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -499,7 +499,7 @@ class SubsetTest(CliTestCase):
 
         self.assert_success(result)
         self.assertEqual(result.stdout, "")
-        self.assertIn("WARNING: --observation and --output-exclusion-rules are set.", result.stderr)
+        self.assertIn("Warning: --observation and --output-exclusion-rules are set.", result.stderr)
 
         self.assertEqual(rest.read().decode(), os.linesep.join(
             ["test_aaa.py", "test_bbb.py", "test_ccc.py", "test_111.py", "test_222.py", "test_333.py"]))

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -547,3 +547,26 @@ class SubsetTest(CliTestCase):
 
         payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
         self.assertEqual(payload.get('hoursToPrioritizeFailedTest'), 24)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_enable_get_tests_from_previous_sessions_when_pts_v2_enabled(self):
+        responses.replace(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/state".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={"state": 'HANDS_ON_LAB_V2', "isFailFastMode": False},
+            status=200)
+
+        result = self.cli(
+            "subset",
+            "--session",
+            self.session,
+            "file",
+        )
+
+        self.assert_success(result)
+        payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
+        self.assertEqual(payload.get("getTestsFromPreviousSessions"), True)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -561,7 +561,7 @@ class SubsetTest(CliTestCase):
             status=200)
         """
         1. Returns 400 error since the zero input test paths isn't calculated yet
-        2. Retruns 200 OK with the test paths from auto collection
+        2. Returns 200 OK with the test paths from auto collection
         """
         responses.replace(
             responses.POST,
@@ -593,7 +593,7 @@ class SubsetTest(CliTestCase):
         1. request to  /state
         2. request to /subset with getTestsFromPreviousSessions = True
         3, 4. request to cli_tracking
-        4. request to /subset with getTestsFromPreviousSessions = False and testPaths from auto collection
+        5. request to /subset with getTestsFromPreviousSessions = False and testPaths from auto collection
         """
         payload = json.loads(gzip.decompress(responses.calls[1].request.body).decode())
         self.assertEqual(payload.get("getTestsFromPreviousSessions"), True)


### PR DESCRIPTION
To Enable PTS v2 Support

- ~~Add logic to check whether PTS v2 is enabled~~
- ~~When PTS v2 is enabled and no input is provided, enable Zero Input Subset (ZIS) by default~~
- ~~If ZIS has not been computed, automatically list files that look like test files~~

- Add `--get-tests-from-guess` option