### PR TITLE
Rename 'properties' to 'markers' in PytestJSONReportParser for consis…

### DIFF
--- a/launchable/test_runners/pytest.py
+++ b/launchable/test_runners/pytest.py
@@ -312,7 +312,15 @@ class PytestJSONReportParser:
                 """
                 props = data.get('user_properties')
                 if isinstance(props, list):
-                    markers = [{"name": prop.name, "value": prop.value} for prop in props]
+                    markers = []
+                    for prop in props:
+                        if isinstance(prop, list) and len(prop) == 2:
+                            # prop is like ["name", "value"]
+                            # prop[0] is name, prop[1] is value
+                            if isinstance(prop[1], str):
+                                markers.append({"name": prop[0], "value": prop[1]})
+                            else:
+                                markers.append({"name": prop[0], "value": json.dumps(prop[1])})
                     if len(props) > 0:
                         props = {'markers': markers}
                     else:


### PR DESCRIPTION
…tensy

We have used `properties` to store the metadata in JSON report files. However, as you can see, `user_properties` field of JSON report files corresponds to the `<properties>` tag of XML report files. So, we should rename 'properties' to 'markers' for consistency.

## Example script

```py
import pytest

@pytest.mark.foo
@pytest.mark.order(1)
@pytest.mark.dependency(name="a")
def test_func4():
    assert 1 == True

@pytest.mark.bar
@pytest.mark.order(2)
@pytest.mark.dependency(name="b", depends=["a"])
def test_func5():
    assert 1 == False
```

## Example report files

```json
{"pytest_version": "8.4.1", "$report_type": "SessionStart"}
{"nodeid": "", "outcome": "passed", "longrepr": null, "result": null, "sections": [], "$report_type": "CollectReport"}
{"nodeid": "tests/funcs3_test.py", "outcome": "passed", "longrepr": null, "result": null, "sections": [], "$report_type": "CollectReport"}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 3, "message": "Unknown pytest.mark.foo - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 4, "message": "Unknown pytest.mark.order - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 5, "message": "Unknown pytest.mark.dependency - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 9, "message": "Unknown pytest.mark.bar - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 10, "message": "Unknown pytest.mark.order - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"category": "PytestUnknownMarkWarning", "filename": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 11, "message": "Unknown pytest.mark.dependency - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html", "$report_type": "WarningMessage", "when": "collect", "location": null}
{"nodeid": "tests/funcs3_test.py::test_func4", "location": ["tests/funcs3_test.py", 2, "test_func4"], "keywords": {"test_func4": 1, "dependency": 1, "order": 1, "foo": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "passed", "longrepr": null, "when": "setup", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "a"}], ["name", "order"], ["args", [1]], ["kwargs", {}], ["name", "foo"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.00035070799640379846, "start": 1753415193.5733702, "stop": 1753415193.5737212, "$report_type": "TestReport"}
{"nodeid": "tests/funcs3_test.py::test_func4", "location": ["tests/funcs3_test.py", 2, "test_func4"], "keywords": {"test_func4": 1, "dependency": 1, "order": 1, "foo": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "passed", "longrepr": null, "when": "call", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "a"}], ["name", "order"], ["args", [1]], ["kwargs", {}], ["name", "foo"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.000283499997749459, "start": 1753415193.573865, "stop": 1753415193.5741482, "$report_type": "TestReport"}
{"nodeid": "tests/funcs3_test.py::test_func4", "location": ["tests/funcs3_test.py", 2, "test_func4"], "keywords": {"test_func4": 1, "dependency": 1, "order": 1, "foo": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "passed", "longrepr": null, "when": "teardown", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "a"}], ["name", "order"], ["args", [1]], ["kwargs", {}], ["name", "foo"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.0002451249965815805, "start": 1753415193.57428, "stop": 1753415193.5745249, "$report_type": "TestReport"}
{"nodeid": "tests/funcs3_test.py::test_func5", "location": ["tests/funcs3_test.py", 8, "test_func5"], "keywords": {"test_func5": 1, "dependency": 1, "order": 1, "bar": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "passed", "longrepr": null, "when": "setup", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "b", "depends": ["a"]}], ["name", "order"], ["args", [2]], ["kwargs", {}], ["name", "bar"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.0002393750037299469, "start": 1753415193.5747368, "stop": 1753415193.574976, "$report_type": "TestReport"}
{"nodeid": "tests/funcs3_test.py::test_func5", "location": ["tests/funcs3_test.py", 8, "test_func5"], "keywords": {"test_func5": 1, "dependency": 1, "order": 1, "bar": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "failed", "longrepr": {"reprcrash": {"path": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 13, "message": "assert 1 == False"}, "reprtraceback": {"reprentries": [{"type": "ReprEntry", "data": {"lines": ["    @pytest.mark.bar", "    @pytest.mark.order(2)", "    @pytest.mark.dependency(name=\"b\", depends=[\"a\"])", "    def test_func5():", ">       assert 1 == False", "E       assert 1 == False"], "reprfuncargs": {"args": []}, "reprlocals": null, "reprfileloc": {"path": "tests/funcs3_test.py", "lineno": 13, "message": "AssertionError"}, "style": "long"}}], "extraline": null, "style": "long"}, "sections": [], "chain": [[{"reprentries": [{"type": "ReprEntry", "data": {"lines": ["    @pytest.mark.bar", "    @pytest.mark.order(2)", "    @pytest.mark.dependency(name=\"b\", depends=[\"a\"])", "    def test_func5():", ">       assert 1 == False", "E       assert 1 == False"], "reprfuncargs": {"args": []}, "reprlocals": null, "reprfileloc": {"path": "tests/funcs3_test.py", "lineno": 13, "message": "AssertionError"}, "style": "long"}}], "extraline": null, "style": "long"}, {"path": "/Users/ono-max/src/github.com/launchableinc/examples/pytest/tests/funcs3_test.py", "lineno": 13, "message": "assert 1 == False"}, null]]}, "when": "call", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "b", "depends": ["a"]}], ["name", "order"], ["args", [2]], ["kwargs", {}], ["name", "bar"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.0003500829989206977, "start": 1753415193.575045, "stop": 1753415193.575395, "$report_type": "TestReport"}
{"nodeid": "tests/funcs3_test.py::test_func5", "location": ["tests/funcs3_test.py", 8, "test_func5"], "keywords": {"test_func5": 1, "dependency": 1, "order": 1, "bar": 1, "pytestmark": 1, "funcs3_test.py": 1, "tests": 1, "pytest": 1, "": 1}, "outcome": "passed", "longrepr": null, "when": "teardown", "user_properties": [["name", "dependency"], ["args", []], ["kwargs", {"name": "b", "depends": ["a"]}], ["name", "order"], ["args", [2]], ["kwargs", {}], ["name", "bar"], ["args", []], ["kwargs", {}]], "sections": [], "duration": 0.00026429099671076983, "start": 1753415193.587457, "stop": 1753415193.587722, "$report_type": "TestReport"}
{"exitstatus": 1, "$report_type": "SessionFinish"}
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites name="pytest tests">
    <testsuite name="pytest" errors="0" failures="1" skipped="0" tests="2" time="0.031"
        timestamp="2025-07-25T12:45:18.474452+09:00"
        hostname="ip-192-168-0-28.us-west-2.compute.internal">
        <testcase classname="tests.funcs3_test" name="test_func4" time="0.001">
            <properties>
                <property name="name" value="dependency" />
                <property name="args" value="()" />
                <property name="kwargs" value="{'name': 'a'}" />
                <property name="name" value="order" />
                <property name="args" value="(1,)" />
                <property name="kwargs" value="{}" />
                <property name="name" value="foo" />
                <property name="args" value="()" />
                <property name="kwargs" value="{}" />
            </properties>
        </testcase>
        <testcase classname="tests.funcs3_test" name="test_func5" time="0.001">
            <properties>
                <property name="name" value="dependency" />
                <property name="args" value="()" />
                <property name="kwargs" value="{'name': 'b', 'depends': ['a']}" />
                <property name="name" value="order" />
                <property name="args" value="(2,)" />
                <property name="kwargs" value="{}" />
                <property name="name" value="bar" />
                <property name="args" value="()" />
                <property name="kwargs" value="{}" />
            </properties>
            <failure message="assert 1 == False">@pytest.mark.bar
                @pytest.mark.order(2)
                @pytest.mark.dependency(name="b", depends=["a"])
                def test_func5():
                &gt; assert 1 == False
                E assert 1 == False

                tests/funcs3_test.py:13: AssertionError</failure>
        </testcase>
    </testsuite>
</testsuites>
```


