### PR TITLE
Display a warning if total test duration is 0

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -641,6 +641,10 @@ def tests(
             rows = [[file_count, test_count, success_count, fail_count, duration]]
             click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
 
+            if duration == 0:
+                click.echo(click.style("\nTotal test duration is 0."
+                                       "\nPlease check whether the test duration times in report files are correct.", "yellow"))
+
             click.echo(
                 "\nVisit https://app.launchableinc.com/organizations/{organization}/workspaces/"
                 "{workspace}/test-sessions/{test_session_id} to view uploaded test results "

--- a/tests/commands/record/test_tests.py
+++ b/tests/commands/record/test_tests.py
@@ -95,3 +95,15 @@ class TestsTest(CliTestCase):
         self.assertEqual(parse_launchable_time2.timestamp(), 1621880944.285)
 
         self.assertEqual(INVALID_TIMESTAMP, parse_launchable_timeformat(t3))
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_when_total_test_duration_zero(self):
+        write_build(self.build_name)
+
+        zero_duration_xml1 = str(Path(__file__).parent.joinpath('../../data/googletest/output_a.xml').resolve())
+        zero_duration_xml2 = str(Path(__file__).parent.joinpath('../../data/googletest/output_b.xml').resolve())
+        result = self.cli('record', 'tests', '--build', self.build_name, 'googletest', zero_duration_xml1, zero_duration_xml2)
+
+        self.assert_success(result)
+        self.assertIn("Total test duration is 0.", result.output)


### PR DESCRIPTION
This outputs a CLI warning if the total test duration is 0 (before rounding) when user executes `launchable record tests`

<img width="1899" height="252" alt="image" src="https://github.com/user-attachments/assets/85381b54-24a8-4721-87ad-cd5003dc5d68" />
