### PR TITLE
Validate session flag format in subset command

### DIFF
--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -9,7 +9,7 @@ from launchable.utils.tracking import TrackingClient
 
 from ..app import Application
 from ..utils.launchable_client import LaunchableClient
-from ..utils.session import parse_session, read_build, read_session
+from ..utils.session import read_build, read_session, validate_session_format
 
 
 def require_session(
@@ -22,7 +22,7 @@ def require_session(
        See https://github.com/launchableinc/cli/pull/342
     """
     if session:
-        parse_session(session)  # make sure session is in the right format
+        validate_session_format(session)
         return session
 
     session = read_session(require_build())
@@ -89,6 +89,7 @@ def find_or_create_session(
     from .record.session import session as session_command
 
     if session:
+        validate_session_format(session)
         _check_observation_mode_status(session, is_observation, tracking_client=tracking_client, app=context.obj)
         return session
 

--- a/launchable/commands/record/attachment.py
+++ b/launchable/commands/record/attachment.py
@@ -10,7 +10,7 @@ from ..helper import require_session
 @click.option(
     '--session',
     'session',
-    help='Test session ID',
+    help='In the format builds/<build-name>/test_sessions/<test-session-id>',
     type=str,
 )
 @click.argument('attachments', nargs=-1)  # type=click.Path(exists=True)

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -56,7 +56,7 @@ def _validate_group(ctx, param, value):
 @click.option(
     '--session',
     'session',
-    help='Test session ID',
+    help='In the format builds/<build-name>/test_sessions/<test-session-id>',
     type=str,
 )
 @click.option(

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -58,7 +58,7 @@ from .test_path_writer import TestPathWriter
 @click.option(
     '--session',
     'session',
-    help='Test session ID',
+    help='In the format builds/<build-name>/test_sessions/<test-session-id>',
     type=str,
 )
 @click.option(

--- a/launchable/utils/session.py
+++ b/launchable/utils/session.py
@@ -98,11 +98,15 @@ def clean_session_files(days_ago: int = 0) -> None:
     remove_session()
 
 
-def parse_session(session: str):
+def validate_session_format(session: str):
     # session format:
     # builds/<build name>/test_sessions/<test session id>
     if session.count("/") != 3:
         raise ParseSessionException(session=session)
+
+
+def parse_session(session: str):
+    validate_session_format(session)
 
     _, build_name, _, session_id = session.split("/")
     return build_name, session_id

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,8 +3,9 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-from launchable.utils.session import (SESSION_DIR_KEY, clean_session_files, parse_session, read_build,
-                                      read_session, remove_session, write_build, write_session)
+from launchable.utils.exceptions import ParseSessionException
+from launchable.utils.session import (SESSION_DIR_KEY, clean_session_files, parse_session, read_build, read_session,
+                                      remove_session, validate_session_format, write_build, write_session)
 
 
 class SessionTestClass(TestCase):
@@ -44,3 +45,17 @@ class SessionTestClass(TestCase):
 
         with self.assertRaises(Exception):
             parse_session("hoge/fuga")
+
+    def test_validate_session_format(self):
+        # Test with a valid session format
+        validate_session_format("builds/build-name/test_sessions/123")
+
+        # Test with invalid session formats
+        invalid_sessions = [
+            "123",                                              # Only id
+            "workspaces/mothership/builds/123/test_sessions/13"  # Too many parts
+        ]
+
+        for invalid_session in invalid_sessions:
+            with self.assertRaises(ParseSessionException):
+                validate_session_format(invalid_session)


### PR DESCRIPTION
**Before:**
Previously --session flag was not validated when the observation mode is on.

```
% launchable subset --help
Usage: launchable subset [OPTIONS] COMMAND [ARGS]...
  Subsetting tests
Options:
  .....
  --session TEXT                  Test session ID
```

```
% launchable subset --target 25% --session 4785415 --observation gradle src/test/java              
An error occurred on Launchable CLI. You can ignore this message since the process will continue. 
Error: HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Max retries exceeded with url: /intake/organizations/defaulttm/workspaces/my-initial-tests/4785415 (Caused by ResponseError('too many 500 error responses'))
--tests example.MulTest --tests example.Add2Test --tests example.DB1Test --tests example.DB0Test --tests example.AddTest --tests example.SubTest --tests example.DivTest --tests example.File1Test --tests example.File0Test
```
The above command would send requests to intake server with invalid session string.

**After:**

```
% launchable subset --help
Usage: launchable subset [OPTIONS] COMMAND [ARGS]...
  Subsetting tests
Options:
  .....
  --session TEXT                  In the format builds/<build-
                                  name>/test_sessions/<test-session-id>
```

```
% launchable subset --target 25% --session 4785415 --observation gradle src/test/java                           
An error occurred on Launchable CLI. You can ignore this message since the process will continue. 
Error: Wrong session format; session format is like 'builds/<build name>/test_sessions/<test session id>'.: 4785415
--tests example.MulTest --tests example.Add2Test --tests example.DB1Test --tests example.DB0Test --tests example.AddTest --tests example.SubTest --tests example.DivTest --tests example.File1Test --tests example.File0Test
```
The session flag value is now validated in the CLI side.

And the command now outputs more appropriate error indicating that the session format is invalid.