### PR TITLE
send only file name instead of repo + file name

### DIFF
--- a/src/main/java/com/launchableinc/ingest/commits/FileChunkStreamer.java
+++ b/src/main/java/com/launchableinc/ingest/commits/FileChunkStreamer.java
@@ -24,7 +24,7 @@ final class FileChunkStreamer extends ChunkStreamer<VirtualFile> {
       tar.setLongFileMode(LONGFILE_POSIX);
 
       for (VirtualFile f : files) {
-        TarArchiveEntry e = new TarArchiveEntry("repo:"+f.repo()+"/"+f.path());
+        TarArchiveEntry e = new TarArchiveEntry(f.path());
         e.setSize(f.size());
         tar.putArchiveEntry(e);
         f.writeTo(tar);

--- a/src/test/java/com/launchableinc/ingest/commits/FileChunkStreamerTest.java
+++ b/src/test/java/com/launchableinc/ingest/commits/FileChunkStreamerTest.java
@@ -30,10 +30,10 @@ public class FileChunkStreamerTest {
     try (FileChunkStreamer fs = new FileChunkStreamer(content -> {
       switch(count[0]++) {
       case 0:
-        assertThat(readEntries(content)).containsExactly("repo:test/foo.txt", "repo:test/bar.txt").inOrder();
+        assertThat(readEntries(content)).containsExactly("foo.txt", "bar.txt").inOrder();
         break;
       case 1:
-        assertThat(readEntries(content)).containsExactly("repo:test/zot.txt").inOrder();
+        assertThat(readEntries(content)).containsExactly("zot.txt").inOrder();
         break;
       default:
         fail();


### PR DESCRIPTION
revert this change https://github.com/launchableinc/cli/pull/1092/files#diff-3d1f54ea9449652274261178ede80ec176beefebdb4d1d83e84c3f20bf6ccfa0R27

because server side doesn't support this format