### PR TITLE
Error reporting problem

### DIFF
--- a/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
+++ b/src/main/java/com/launchableinc/ingest/commits/CommitGraphCollector.java
@@ -211,7 +211,7 @@ public class CommitGraphCollector {
             if (dryRun) {
               return;
             }
-            handleError(latestUrl, client.execute(request));
+            handleError(url, client.execute(request));
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }


### PR DESCRIPTION
This copy/paste error meant the error message was blaming the wrong URL.