### PR TITLE
Replace Github repo URLs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -69,7 +69,7 @@ jobs:
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       with:
-        args: 'Launchable CLI ${{ needs.tagpr.outputs.tag }} is released! https://github.com/launchableinc/cli/releases/tag/${{ needs.tagpr.outputs.tag }}'
+        args: 'Launchable CLI ${{ needs.tagpr.outputs.tag }} is released! https://github.com/cloudbees-oss/smart-tests-cli/releases/tag/${{ needs.tagpr.outputs.tag }}'
 
   docker:
     name: Push Docker image to Docker Hub

--- a/launchable/commands/helper.py
+++ b/launchable/commands/helper.py
@@ -19,7 +19,7 @@ def require_session(
 
     1. If the user explicitly provides the session id via the `--session` option
     2. If the user gives no options, the current session ID is read from the session file tied to $PWD.
-       See https://github.com/launchableinc/cli/pull/342
+       See https://github.com/cloudbees-oss/smart-tests-cli/pull/342
     """
     if session:
         validate_session_format(session)
@@ -71,7 +71,7 @@ def find_or_create_session(
 
     1. If the user explicitly provides the session id via the `--session` option
     2. If the user gives no options, the current session ID is read from the session file tied to $PWD,
-       or one is created from the current build name. See https://github.com/launchableinc/cli/pull/342
+       or one is created from the current build name. See https://github.com/cloudbees-oss/smart-tests-cli/pull/342
     3. The `--build` option is legacy compatible behaviour, in which case a session gets created and tied
        to the build. This usage still requires a locally recorded build name that must match the specified name.
        Kohsuke is not sure what the historical motivation for this behaviour is.

--- a/tests/commands/test_split_subset.py
+++ b/tests/commands/test_split_subset.py
@@ -150,7 +150,7 @@ class SplitSubsetTest(CliTestCase):
          Note(Konboi):
             Don't know the cause, but in the Python 3.10 environment,
             the settings configured with responses.replace disappear on the second call.
-            see: https://github.com/launchableinc/cli/actions/runs/11697720998/job/32576899978#step:10:88
+            see: https://github.com/cloudbees-oss/smart-tests-cli/actions/runs/11697720998/job/32576899978#step:10:88
             So, to call it each time, `replace_response` was defined.
         """
         def replace_response():


### PR DESCRIPTION
We transferred the Launchable CLI GitHub repo from https://github.com/launchableinc/cli to https://github.com/cloudbees-oss/smart-tests-cli. Let's update the repo URLs in the code.