### PR TITLE
use openjdk-21 instead of 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip wheel --no-cache-dir -w /wheels .
 FROM python:3.11-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-17-jre-headless git && \
+    apt-get install -y --no-install-recommends openjdk-21-jre-headless git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels pip install --no-cache-dir /wheels/*.whl


### PR DESCRIPTION
To fix docker image build error 

```
------
 > [linux/amd64 stage-1 2/5] RUN apt-get update &&     apt-get install -y --no-install-recommends openjdk-17-jre-headless git &&     rm -rf /var/lib/apt/lists/*:


2.902 Reading state information...
2.933 Package openjdk-17-jre-headless is not available, but is referred to by another package.
2.933 This may mean that the package is missing, has been obsoleted, or
2.933 is only available from another source
2.933 However the following packages replace it:
2.933   openjdk-21-jre openjdk-21-jdk-headless
2.933 
2.936 E: Package 'openjdk-17-jre-headless' has no installation candidate
------
Dockerfile:13
--------------------
  12 |     
  13 | >>> RUN apt-get update && \
  14 | >>>     apt-get install -y --no-install-recommends openjdk-17-jre-headless git && \
  15 | >>>     rm -rf /var/lib/apt/lists/*
  16 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends openjdk-17-jre-headless git &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

https://github.com/cloudbees-oss/smart-tests-cli/actions/runs/17029581351/job/48278969730#step:5:347