### PR TITLE
Make `--name` optional in `record commit` command

### DIFF
--- a/smart_tests/commands/record/commit.py
+++ b/smart_tests/commands/record/commit.py
@@ -28,9 +28,9 @@ app = typer.Typer(name="commit", help="Record commit information")
 @app.callback(invoke_without_command=True)
 def commit(
     ctx: typer.Context,
-    name: Annotated[str, typer.Option(
+    name: Annotated[str | None, typer.Option(
         help="repository name"
-    )],
+    )] = None,
     source: Annotated[str, typer.Option(
         help="repository path"
     )] = os.getcwd(),


### PR DESCRIPTION
e2e in #1114 failed because the smart-tests branch made `--name` option in `record commit` command required. It was incorrect integration in #1117. So, let's fix it making the `--name` optional.