### PR TITLE
Improve performance for large test sets

### DIFF
--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -3,6 +3,7 @@ import glob
 import os
 import re
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from http import HTTPStatus
 from typing import Callable, Dict, Generator, List, Optional, Sequence, Tuple, Union
 
@@ -578,19 +579,25 @@ def tests(
                         print(unparse_test_path(t['testPath']))
                     return
 
+                MAX_UPLOAD_WORKERS = 3
+
                 start = time_ns()
                 exceptions = []
-                for chunk in ichunked(tc, post_chunk):
-                    p, es = payload(
-                        cases=chunk,
-                        test_runner=test_runner,
-                        group=group,
-                        test_suite_name=test_suite if test_suite else "",
-                        flavors=dict(flavor),
-                    )
+                with ThreadPoolExecutor(max_workers=MAX_UPLOAD_WORKERS) as executor:
+                    futures = []
+                    for chunk in ichunked(tc, post_chunk):
+                        p, es = payload(
+                            cases=chunk,
+                            test_runner=test_runner,
+                            group=group,
+                            test_suite_name=test_suite if test_suite else "",
+                            flavors=dict(flavor),
+                        )
+                        exceptions.extend(es)
+                        futures.append(executor.submit(send, p))
 
-                    send(p)
-                    exceptions.extend(es)
+                    for future in as_completed(futures):
+                        future.result()
                 end = time_ns()
                 tracking_client.send_event(
                     event_name=Tracking.Event.PERFORMANCE,

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -27,6 +27,10 @@ from ..utils.launchable_client import LaunchableClient
 from .helper import find_or_create_session
 from .test_path_writer import TestPathWriter
 
+LARGE_TEST_PATHS_THRESHOLD = 100000
+DEFAULT_CONNECT_TIMEOUT = 5
+LARGE_PAYLOAD_CONNECT_TIMEOUT = 60
+
 # TODO: rename files and function accordingly once the PR landscape
 
 
@@ -567,7 +571,10 @@ def subset(
             # temporarily extend the timeout because subset API response has become slow
             # TODO: remove this line when API response return response
             # within 300 sec
-            timeout = (5, 300)
+            connect_timeout = DEFAULT_CONNECT_TIMEOUT
+            if len(self.test_paths) >= LARGE_TEST_PATHS_THRESHOLD:
+                connect_timeout = LARGE_PAYLOAD_CONNECT_TIMEOUT
+            timeout = (connect_timeout, 300)
             payload = self.get_payload(str(session_id), target, duration, str(test_runner))
 
             if is_non_blocking:


### PR DESCRIPTION
## Why

When dealing with large test sets (100k+ test paths), two performance bottlenecks exist:
1. The subset request's connect timeout (5s) is too short for large payloads, causing timeouts during transmission
2. The record tests command uploads chunks sequentially, increasing wall-clock time for large test sets

## What

- **Subset connect timeout**: Dynamically increase connect timeout from 5s to 60s when test paths >= 100,000
- **Parallel chunk uploads**: Use `ThreadPoolExecutor` with up to 3 workers to upload test event chunks concurrently in `record tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)