### PR TITLE
Fix raw subset to allow --input-snapshot-id without TEST_PATH_FILE

### DIFF
--- a/smart_tests/test_runners/raw.py
+++ b/smart_tests/test_runners/raw.py
@@ -16,6 +16,15 @@ from ..testpath import TestPath, parse_test_path, unparse_test_path
 from . import smart_tests
 
 
+def _needs_test_path_file(client: Subset) -> bool:
+    """Check if the client requires test paths to be provided via a file."""
+    if client.is_get_tests_from_previous_sessions:
+        return False
+    if client.input_snapshot_id is not None:
+        return False
+    return True
+
+
 @smart_tests.subset
 def subset(
     client: Subset,
@@ -31,7 +40,7 @@ def subset(
     considered as a comment and ignored.
     """
 
-    if not client.is_get_tests_from_previous_sessions and test_path_file is None:
+    if _needs_test_path_file(client) and test_path_file is None:
         raise BadCmdLineException("Missing argument 'TEST_PATH_FILE'.")
 
     if client.is_output_exclusion_rules:
@@ -39,7 +48,7 @@ def subset(
             "Don't need to use `--output-exclusion-rules` option. Please use `--rest` option and use it for exclusion"
         )
 
-    if not client.is_get_tests_from_previous_sessions:
+    if _needs_test_path_file(client):
         assert test_path_file is not None  # Guaranteed by earlier check
         with open(test_path_file, 'r') as f:
             tps = [s.strip() for s in f.readlines()]

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -21,17 +21,10 @@ class RawTest(CliTestCase):
         client.input_snapshot_id = input_snapshot_id
         return client
 
-    def test_needs_test_path_file_default(self):
-        client = self._make_subset_client()
-        self.assertTrue(_needs_test_path_file(client))
-
-    def test_needs_test_path_file_with_previous_sessions(self):
-        client = self._make_subset_client(is_get_tests_from_previous_sessions=True)
-        self.assertFalse(_needs_test_path_file(client))
-
-    def test_needs_test_path_file_with_input_snapshot_id(self):
-        client = self._make_subset_client(input_snapshot_id=InputSnapshotId(123))
-        self.assertFalse(_needs_test_path_file(client))
+    def test_needs_test_path_file(self):
+        self.assertTrue(_needs_test_path_file(self._make_subset_client()))
+        self.assertFalse(_needs_test_path_file(self._make_subset_client(is_get_tests_from_previous_sessions=True)))
+        self.assertFalse(_needs_test_path_file(self._make_subset_client(input_snapshot_id=InputSnapshotId(123))))
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})

--- a/tests/test_runners/test_raw.py
+++ b/tests/test_runners/test_raw.py
@@ -8,11 +8,31 @@ import dateutil.parser
 import responses  # type: ignore
 from dateutil.tz import tzlocal
 
+from smart_tests.test_runners.raw import _needs_test_path_file
 from smart_tests.utils.http_client import get_base_url
+from smart_tests.utils.input_snapshot import InputSnapshotId
 from tests.cli_test_case import CliTestCase
 
 
 class RawTest(CliTestCase):
+    def _make_subset_client(self, is_get_tests_from_previous_sessions=False, input_snapshot_id=None):
+        client = mock.MagicMock()
+        client.is_get_tests_from_previous_sessions = is_get_tests_from_previous_sessions
+        client.input_snapshot_id = input_snapshot_id
+        return client
+
+    def test_needs_test_path_file_default(self):
+        client = self._make_subset_client()
+        self.assertTrue(_needs_test_path_file(client))
+
+    def test_needs_test_path_file_with_previous_sessions(self):
+        client = self._make_subset_client(is_get_tests_from_previous_sessions=True)
+        self.assertFalse(_needs_test_path_file(client))
+
+    def test_needs_test_path_file_with_input_snapshot_id(self):
+        client = self._make_subset_client(input_snapshot_id=InputSnapshotId(123))
+        self.assertFalse(_needs_test_path_file(client))
+
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
     def test_subset(self):


### PR DESCRIPTION
## Summary
- Raw profile's `subset` command incorrectly required `TEST_PATH_FILE` argument when `--input-snapshot-id` was provided
- Extracted `_needs_test_path_file()` to centralize the validation logic, making conditions readable and consistent
- Added unit tests for `_needs_test_path_file()` covering default, `--get-tests-from-previous-sessions`, and `--input-snapshot-id` cases

Resolves [LCHUX-433](https://cloudbees.atlassian.net/browse/LCHUX-433)

## Test plan
- [x] `_needs_test_path_file` unit tests pass for all 3 cases
- [x] Existing raw subset tests still pass
- [ ] Manual verification: `smart-tests subset raw --session <session> --target 10% --input-snapshot-id <id>` succeeds without TEST_PATH_FILE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LCHUX-433]: https://cloudbees.atlassian.net/browse/LCHUX-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ