### PR TITLE
fix: Extend timeout for inspect subset and compare subsets

### DIFF
--- a/launchable/commands/compare/subsets.py
+++ b/launchable/commands/compare/subsets.py
@@ -66,7 +66,7 @@ class SubsetResults(SubsetResultBases[SubsetResult]):
     @classmethod
     def load(cls, client: LaunchableClient, subset_id: int) -> "SubsetResults":
         try:
-            response = client.request("get", f"subset/{subset_id}")
+            response = client.request("get", f"subset/{subset_id}", timeout=(30, 300))
             if response.status_code == HTTPStatus.NOT_FOUND:
                 raise click.ClickException(
                     f"Subset {subset_id} not found. Check subset ID and try again."

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -110,7 +110,7 @@ def subset(context: click.core.Context, subset_id: int, is_json_format: bool):
     rest = []
     client = LaunchableClient(app=context.obj)
     try:
-        res = client.request("get", "subset/{}".format(subset_id))
+        res = client.request("get", "subset/{}".format(subset_id), timeout=(30, 300))
 
         if res.status_code == HTTPStatus.NOT_FOUND:
             click.echo(click.style(


### PR DESCRIPTION
## Summary
- Large subsets occasionally take well over the default 15s read timeout to fetch, causing `launchable inspect subset` and `launchable compare subsets` to fail with `ReadTimeoutError` (observed ~65s for a single inspect call).
- Override the per-request timeout on those GET calls to `(30, 300)` (connect / read) so big responses have enough time to complete.

## Test plan
- [ ] `launchable inspect subset --subset-id <large-id>` completes without `ReadTimeoutError`
- [ ] `launchable compare subsets --subset-id-before <a> --subset-id-after <b>` (with large subsets) completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)