### PR TITLE
Fix misleading error for empty adaptive subsets

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -626,8 +626,11 @@ def subset(
                 subset_result = self.request_subset()
 
             if len(subset_result.subset) == 0:
-                warn_and_exit_if_fail_fast_mode("Error: no tests found matching the path.")
-                return
+                if len(subset_result.rest) == 0:
+                    warn_and_exit_if_fail_fast_mode("Error: no tests found matching the path.")
+                    return
+                else:
+                    click.echo(click.style("No tests were selected for this code change.", fg="yellow"), err=True)
 
             if split:
                 click.echo("subset/{}".format(subset_result.subset_id))

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -626,11 +626,13 @@ def subset(
                 subset_result = self.request_subset()
 
             if len(subset_result.subset) == 0:
-                if len(subset_result.rest) == 0:
+                if len(subset_result.rest) > 0 and client.is_pts_v2_enabled() and confidence is not None:
+                    # Adaptive Dynamic Subset can return an empty subset when the model
+                    # determines no tests in that suite are relevant to the code change.
+                    click.echo(click.style("No tests were selected for this code change.", fg="yellow"), err=True)
+                else:
                     warn_and_exit_if_fail_fast_mode("Error: no tests found matching the path.")
                     return
-                else:
-                    click.echo(click.style("No tests were selected for this code change.", fg="yellow"), err=True)
 
             if split:
                 click.echo("subset/{}".format(subset_result.subset_id))

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -210,8 +210,16 @@ class SubsetTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_subset_with_empty_valid_subset(self):
+    def test_confidence_subset_with_empty_valid_subset_when_pts_v2_enabled(self):
         pipe = "test_aaa.py\ntest_bbb.py\ntest_ccc.py"
+        responses.replace(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/state".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={"isFailFastMode": False, "isPtsV2Enabled": True},
+            status=200)
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(
@@ -237,8 +245,8 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
-            "--target",
-            "30%",
+            "--confidence",
+            "90%",
             "--session",
             self.session,
             "file",
@@ -252,8 +260,16 @@ class SubsetTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
-    def test_subset_with_empty_subset_and_rest_is_error_even_if_summary_has_candidates(self):
+    def test_confidence_subset_with_empty_subset_and_rest_is_error_even_if_summary_has_candidates(self):
         pipe = "test_aaa.py\ntest_bbb.py\ntest_ccc.py"
+        responses.replace(
+            responses.GET,
+            "{}/intake/organizations/{}/workspaces/{}/state".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={"isFailFastMode": False, "isPtsV2Enabled": True},
+            status=200)
         responses.replace(
             responses.POST,
             "{}/intake/organizations/{}/workspaces/{}/subset".format(
@@ -275,8 +291,8 @@ class SubsetTest(CliTestCase):
 
         result = self.cli(
             "subset",
-            "--target",
-            "30%",
+            "--confidence",
+            "90%",
             "--session",
             self.session,
             "file",

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -210,6 +210,85 @@ class SubsetTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_empty_valid_subset(self):
+        pipe = "test_aaa.py\ntest_bbb.py\ntest_ccc.py"
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={
+                "testPaths": [],
+                "testRunner": "file",
+                "rest": [
+                    [{"type": "file", "name": "test_aaa.py"}],
+                    [{"type": "file", "name": "test_bbb.py"}],
+                    [{"type": "file", "name": "test_ccc.py"}],
+                ],
+                "subsettingId": 123,
+                "summary": {
+                    "subset": {"duration": 0, "candidates": 99, "rate": 0},
+                    "rest": {"duration": 30, "candidates": 0, "rate": 100}
+                },
+                "isObservation": False,
+            },
+            status=200)
+
+        result = self.cli(
+            "subset",
+            "--target",
+            "30%",
+            "--session",
+            self.session,
+            "file",
+            input=pipe,
+            mix_stderr=False)
+        self.assert_success(result)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("No tests were selected for this code change.", result.stderr)
+        self.assertIn("Launchable created subset 123", result.stderr)
+        self.assertNotIn("Error: no tests found matching the path.", result.stderr)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_subset_with_empty_subset_and_rest_is_error_even_if_summary_has_candidates(self):
+        pipe = "test_aaa.py\ntest_bbb.py\ntest_ccc.py"
+        responses.replace(
+            responses.POST,
+            "{}/intake/organizations/{}/workspaces/{}/subset".format(
+                get_base_url(),
+                self.organization,
+                self.workspace),
+            json={
+                "testPaths": [],
+                "testRunner": "file",
+                "rest": [],
+                "subsettingId": 123,
+                "summary": {
+                    "subset": {"duration": 0, "candidates": 99, "rate": 0},
+                    "rest": {"duration": 30, "candidates": 99, "rate": 100}
+                },
+                "isObservation": False,
+            },
+            status=200)
+
+        result = self.cli(
+            "subset",
+            "--target",
+            "30%",
+            "--session",
+            self.session,
+            "file",
+            input=pipe,
+            mix_stderr=False)
+        self.assert_success(result)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Error: no tests found matching the path.", result.stderr)
+        self.assertNotIn("No tests were selected for this code change.", result.stderr)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
     def test_subset_goalspec(self):
         # make sure --goal-spec gets translated properly to a JSON request payload
         responses.replace(


### PR DESCRIPTION
Adaptive Dynamic Subset can return an empty subset when the model decides no tests in that suite are relevant to the code change.

Until now, the CLI treated any empty `subset` as:

`Error: no tests found matching the path.`

That's confusing for users even though that empty subset is valid. I got this feedback from users, so I'd like to fix this problem.