### PR TITLE
fixes intermittent test errors occrued due to lagcy token usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ bazel-*
 
 .DS_Store
 .idea/*
+test-results
+.local

--- a/tests/test_runners/test_codeceptjs.py
+++ b/tests/test_runners/test_codeceptjs.py
@@ -9,10 +9,12 @@ import responses  # type: ignore
 from smart_tests.utils.http_client import get_base_url
 from tests.cli_test_case import CliTestCase
 
+_TOKEN = {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token}
+
 
 class CodeceptjsTest(CliTestCase):
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    @mock.patch.dict(os.environ, _TOKEN)
     def test_record_test_codeceptjs(self):
         result = self.cli(
             "record",
@@ -27,7 +29,7 @@ class CodeceptjsTest(CliTestCase):
         self.assert_record_tests_payload("record_test_result.json")
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    @mock.patch.dict(os.environ, _TOKEN)
     def test_subset(self):
         """Test basic subset functionality with multiple test files"""
         pipe = "test/example_test.js\ntest/login_test.js\n"
@@ -70,7 +72,7 @@ class CodeceptjsTest(CliTestCase):
         )
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    @mock.patch.dict(os.environ, _TOKEN)
     def test_subset_with_rest(self):
         """Test subset functionality with --rest option to save remaining tests"""
         pipe = "test/example_test.js\ntest/other_test.js\n"
@@ -132,7 +134,7 @@ class CodeceptjsTest(CliTestCase):
                 Path(rest_file_path).unlink()
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    @mock.patch.dict(os.environ, _TOKEN)
     def test_subset_with_single_test(self):
         """Test subset functionality with a single test file"""
         pipe = "test/single_test.js\n"
@@ -172,7 +174,7 @@ class CodeceptjsTest(CliTestCase):
         self.assertEqual(output_json["tests"], ["test/single_test.js"])
 
     @responses.activate
-    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    @mock.patch.dict(os.environ, _TOKEN)
     def test_subset_strips_newlines(self):
         """Test that subset properly strips newlines from test paths"""
         # Test with various newline formats


### PR DESCRIPTION
### Summary
  
  Replace LAUNCHABLE_TOKEN with SMART_TESTS_TOKEN in` test_codeceptjs.py` to fix test failures in a scenario  when SMART_TESTS_TOKEN is already set in the environment before executing `uv run poe test-xml.`

### Problem
  
  `LAUNCHABLE_TOKEN` is only a fallback in get_token(). If `SMART_TESTS_TOKEN` was already set in the developer's environment, it took precedence over the injected mock token, causing requests to hit unregistered mock URLs and producing empty output that failed json.loads().

<img width="1159" height="303" alt="image" src="https://github.com/user-attachments/assets/226034e5-5cc9-44ea-b84f-8b8d945b337d" />

### Fix

  Use SMART_TESTS_TOKEN (the primary token) so mock.patch.dict always overwrites any real environment value. It becomes consistent with every other test file in the repo.