### PR TITLE
fix: Support Robot Framework 7.0+ output.xml format in robot plugin

### DIFF
--- a/launchable/test_runners/robot.py
+++ b/launchable/test_runners/robot.py
@@ -25,19 +25,26 @@ def parse_func(p: str) -> ET.ElementTree:
             nested_status = nested_status_node.get('status') if nested_status_node is not None else None
 
             if status is not None:
-                start_time_str = status_node.get('starttime') if status_node is not None else ''
-                end_time_str = status_node.get('endtime') if status_node is not None else ''
+                duration_seconds = None
 
-                if start_time_str != '' and end_time_str != '':
-                    start_time = datetime.strptime(str(start_time_str), DATETIME_FORMAT)
-                    end_time = datetime.strptime(str(end_time_str), DATETIME_FORMAT)
-
-                    duration = end_time - start_time
+                if status_node is not None:
+                    # RF 7.0+: elapsed attribute in seconds
+                    elapsed_str = status_node.get('elapsed')
+                    if elapsed_str is not None:
+                        duration_seconds = float(elapsed_str)
+                    else:
+                        # RF < 7.0: starttime/endtime attributes
+                        start_time_str = status_node.get('starttime', '')
+                        end_time_str = status_node.get('endtime', '')
+                        if start_time_str and end_time_str:
+                            start_time = datetime.strptime(start_time_str, DATETIME_FORMAT)
+                            end_time = datetime.strptime(end_time_str, DATETIME_FORMAT)
+                            duration_seconds = (end_time - start_time).total_seconds()
 
                 testcase = ET.SubElement(testsuite, "testcase", {
                     "name": str(test_name),
                     "classname": str(suite_name),
-                    "time": str(duration.total_seconds()) if duration is not None else '0',
+                    "time": str(duration_seconds) if duration_seconds is not None else '0',
                 })
 
                 if status == "FAIL":

--- a/tests/data/robot/output.xml
+++ b/tests/data/robot/output.xml
@@ -1,129 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.2.2 (Python 3.9.1 on darwin)" generated="20210319 11:34:50.044" rpa="false">
-<suite id="s1" name="Rocket-Car-Robot" source="/src/github.com/launchableinc/rocket-car-robot">
-<suite id="s1-s1" name="Minus" source="/src/github.com/launchableinc/rocket-car-robot/minus.robot">
-<test id="s1-s1-t1" name="Check method">
-<kw name="Result Is" library="Calculator">
-<arguments>
+<robot generator="Robot 7.4.2 (Python 3.13.13 on darwin)" generated="2026-06-04T16:18:55.667057" rpa="false" schemaversion="5">
+<suite id="s1" name="Robot" source="/Users/ryabuki/src/github.com/cloudbees-oss/smart-tests-integration-examples/robot">
+<suite id="s1-s1" name="Minus" source="/Users/ryabuki/src/github.com/cloudbees-oss/smart-tests-integration-examples/robot/minus.robot">
+<test id="s1-s1-t1" name="Check method" line="6">
+<kw name="Result Is" owner="Calculator">
 <arg>-1</arg>
-</arguments>
-<msg timestamp="20210319 11:34:50.087" level="FAIL">0 != -1</msg>
-<status status="FAIL" starttime="20210319 11:34:50.085" endtime="20210319 11:34:50.087"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688016" elapsed="0.000060"/>
 </kw>
-<status status="FAIL" starttime="20210319 11:34:50.085" endtime="20210319 11:34:50.087" critical="yes">0 != -1</status>
+<status status="PASS" start="2026-06-04T16:18:55.687743" elapsed="0.000411"/>
 </test>
-<test id="s1-s1-t2" name="Minus method">
-<kw name="Plus" library="Calculator">
-<arguments>
+<test id="s1-s1-t2" name="Minus method" line="9">
+<kw name="Plus" owner="Calculator">
 <arg>1</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.088" endtime="20210319 11:34:50.088"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688330" elapsed="0.000034"/>
 </kw>
-<kw name="Minus" library="Calculator">
-<arguments>
+<kw name="Minus" owner="Calculator">
 <arg>1</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.088" endtime="20210319 11:34:50.089"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688410" elapsed="0.000021"/>
 </kw>
-<kw name="Result Is" library="Calculator">
-<arguments>
+<kw name="Result Is" owner="Calculator">
 <arg>0</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.089" endtime="20210319 11:34:50.089"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688468" elapsed="0.000018"/>
 </kw>
-<status status="PASS" starttime="20210319 11:34:50.087" endtime="20210319 11:34:50.089" critical="yes"></status>
+<status status="PASS" start="2026-06-04T16:18:55.688231" elapsed="0.000296"/>
 </test>
-<test id="s1-s1-t3" name="Minus method 2">
-<kw name="Plus" library="Calculator">
-<arguments>
+<test id="s1-s1-t3" name="Minus method 2" line="14">
+<kw name="Plus" owner="Calculator">
 <arg>10</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688668" elapsed="0.000020"/>
 </kw>
-<kw name="Minus" library="Calculator">
-<arguments>
+<kw name="Minus" owner="Calculator">
 <arg>20</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688722" elapsed="0.000017"/>
 </kw>
-<kw name="Result Is" library="Calculator">
-<arguments>
+<kw name="Result Is" owner="Calculator">
 <arg>-10</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.688772" elapsed="0.000017"/>
 </kw>
-<status status="PASS" starttime="20210319 11:34:50.089" endtime="20210319 11:34:50.091" critical="yes"></status>
+<status status="PASS" start="2026-06-04T16:18:55.688587" elapsed="0.000240"/>
 </test>
-<status status="FAIL" starttime="20210319 11:34:50.080" endtime="20210319 11:34:50.091"></status>
+<status status="PASS" start="2026-06-04T16:18:55.686349" elapsed="0.002607"/>
 </suite>
-<suite id="s1-s2" name="Plus" source="/src/github.com/launchableinc/rocket-car-robot/plus.robot">
-<test id="s1-s2-t1" name="Check method">
-<kw name="Result Is" library="Calculator">
-<arguments>
+<suite id="s1-s2" name="Plus" source="/Users/ryabuki/src/github.com/cloudbees-oss/smart-tests-integration-examples/robot/plus.robot">
+<test id="s1-s2-t1" name="Check method" line="6">
+<kw name="Result Is" owner="Calculator">
 <arg>-1</arg>
-</arguments>
-<msg timestamp="20210319 11:34:50.095" level="FAIL">0 != -1</msg>
-<status status="FAIL" starttime="20210319 11:34:50.095" endtime="20210319 11:34:50.095"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.689659" elapsed="0.000021"/>
 </kw>
-<status status="FAIL" starttime="20210319 11:34:50.094" endtime="20210319 11:34:50.095" critical="yes">0 != -1</status>
+<status status="PASS" start="2026-06-04T16:18:55.689575" elapsed="0.000142"/>
 </test>
-<test id="s1-s2-t2" name="Plus method">
-<kw name="Plus" library="Calculator">
-<arguments>
+<test id="s1-s2-t2" name="Plus method" line="9">
+<kw name="Plus" owner="Calculator">
 <arg>1</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.689845" elapsed="0.000020"/>
 </kw>
-<kw name="Plus" library="Calculator">
-<arguments>
+<kw name="Plus" owner="Calculator">
 <arg>1</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.689897" elapsed="0.000017"/>
 </kw>
-<kw name="Result Is" library="Calculator">
-<arguments>
+<kw name="Result Is" owner="Calculator">
 <arg>2</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.689945" elapsed="0.000016"/>
 </kw>
-<status status="PASS" starttime="20210319 11:34:50.095" endtime="20210319 11:34:50.097" critical="yes"></status>
+<status status="PASS" start="2026-06-04T16:18:55.689772" elapsed="0.000225"/>
 </test>
-<test id="s1-s2-t3" name="Plus method 2">
-<kw name="Plus" library="Calculator">
-<arguments>
+<test id="s1-s2-t3" name="Plus method 2" line="14">
+<kw name="Plus" owner="Calculator">
 <arg>10</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.097" endtime="20210319 11:34:50.098"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.690120" elapsed="0.000021"/>
 </kw>
-<kw name="Plus" library="Calculator">
-<arguments>
+<kw name="Plus" owner="Calculator">
 <arg>20</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.098" endtime="20210319 11:34:50.098"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.690175" elapsed="0.000018"/>
 </kw>
-<kw name="Result Is" library="Calculator">
-<arguments>
+<kw name="Result Is" owner="Calculator">
 <arg>30</arg>
-</arguments>
-<status status="PASS" starttime="20210319 11:34:50.098" endtime="20210319 11:34:50.098"></status>
+<status status="NOT RUN" start="2026-06-04T16:18:55.690226" elapsed="0.000016"/>
 </kw>
-<status status="PASS" starttime="20210319 11:34:50.097" endtime="20210319 11:34:50.099" critical="yes"></status>
+<status status="PASS" start="2026-06-04T16:18:55.690050" elapsed="0.000227"/>
 </test>
-<status status="FAIL" starttime="20210319 11:34:50.092" endtime="20210319 11:34:50.099"></status>
+<status status="PASS" start="2026-06-04T16:18:55.689089" elapsed="0.001258"/>
 </suite>
-<status status="FAIL" starttime="20210319 11:34:50.046" endtime="20210319 11:34:50.100"></status>
+<status status="PASS" start="2026-06-04T16:18:55.668356" elapsed="0.022122"/>
 </suite>
 <statistics>
 <total>
-<stat pass="4" fail="2">Critical Tests</stat>
-<stat pass="4" fail="2">All Tests</stat>
+<stat pass="6" fail="0" skip="0">All Tests</stat>
 </total>
 <tag>
 </tag>
 <suite>
-<stat pass="4" fail="2" id="s1" name="Rocket-Car-Robot">Rocket-Car-Robot</stat>
-<stat pass="2" fail="1" id="s1-s1" name="Minus">Rocket-Car-Robot.Minus</stat>
-<stat pass="2" fail="1" id="s1-s2" name="Plus">Rocket-Car-Robot.Plus</stat>
+<stat name="Robot" id="s1" pass="6" fail="0" skip="0">Robot</stat>
+<stat name="Minus" id="s1-s1" pass="3" fail="0" skip="0">Robot.Minus</stat>
+<stat name="Plus" id="s1-s2" pass="3" fail="0" skip="0">Robot.Plus</stat>
 </suite>
 </statistics>
 <errors>

--- a/tests/data/robot/output_legacy.xml
+++ b/tests/data/robot/output_legacy.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 3.2.2 (Python 3.9.1 on darwin)" generated="20210319 11:34:50.044" rpa="false">
+<suite id="s1" name="Rocket-Car-Robot" source="/src/github.com/launchableinc/rocket-car-robot">
+<suite id="s1-s1" name="Minus" source="/src/github.com/launchableinc/rocket-car-robot/minus.robot">
+<test id="s1-s1-t1" name="Check method">
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>-1</arg>
+</arguments>
+<msg timestamp="20210319 11:34:50.087" level="FAIL">0 != -1</msg>
+<status status="FAIL" starttime="20210319 11:34:50.085" endtime="20210319 11:34:50.087"></status>
+</kw>
+<status status="FAIL" starttime="20210319 11:34:50.085" endtime="20210319 11:34:50.087" critical="yes">0 != -1</status>
+</test>
+<test id="s1-s1-t2" name="Minus method">
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>1</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.088" endtime="20210319 11:34:50.088"></status>
+</kw>
+<kw name="Minus" library="Calculator">
+<arguments>
+<arg>1</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.088" endtime="20210319 11:34:50.089"></status>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>0</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.089" endtime="20210319 11:34:50.089"></status>
+</kw>
+<status status="PASS" starttime="20210319 11:34:50.087" endtime="20210319 11:34:50.089" critical="yes"></status>
+</test>
+<test id="s1-s1-t3" name="Minus method 2">
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>10</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+</kw>
+<kw name="Minus" library="Calculator">
+<arguments>
+<arg>20</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>-10</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.090" endtime="20210319 11:34:50.090"></status>
+</kw>
+<status status="PASS" starttime="20210319 11:34:50.089" endtime="20210319 11:34:50.091" critical="yes"></status>
+</test>
+<status status="FAIL" starttime="20210319 11:34:50.080" endtime="20210319 11:34:50.091"></status>
+</suite>
+<suite id="s1-s2" name="Plus" source="/src/github.com/launchableinc/rocket-car-robot/plus.robot">
+<test id="s1-s2-t1" name="Check method">
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>-1</arg>
+</arguments>
+<msg timestamp="20210319 11:34:50.095" level="FAIL">0 != -1</msg>
+<status status="FAIL" starttime="20210319 11:34:50.095" endtime="20210319 11:34:50.095"></status>
+</kw>
+<status status="FAIL" starttime="20210319 11:34:50.094" endtime="20210319 11:34:50.095" critical="yes">0 != -1</status>
+</test>
+<test id="s1-s2-t2" name="Plus method">
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>1</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+</kw>
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>1</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>2</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.096" endtime="20210319 11:34:50.096"></status>
+</kw>
+<status status="PASS" starttime="20210319 11:34:50.095" endtime="20210319 11:34:50.097" critical="yes"></status>
+</test>
+<test id="s1-s2-t3" name="Plus method 2">
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>10</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.097" endtime="20210319 11:34:50.098"></status>
+</kw>
+<kw name="Plus" library="Calculator">
+<arguments>
+<arg>20</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.098" endtime="20210319 11:34:50.098"></status>
+</kw>
+<kw name="Result Is" library="Calculator">
+<arguments>
+<arg>30</arg>
+</arguments>
+<status status="PASS" starttime="20210319 11:34:50.098" endtime="20210319 11:34:50.098"></status>
+</kw>
+<status status="PASS" starttime="20210319 11:34:50.097" endtime="20210319 11:34:50.099" critical="yes"></status>
+</test>
+<status status="FAIL" starttime="20210319 11:34:50.092" endtime="20210319 11:34:50.099"></status>
+</suite>
+<status status="FAIL" starttime="20210319 11:34:50.046" endtime="20210319 11:34:50.100"></status>
+</suite>
+<statistics>
+<total>
+<stat pass="4" fail="2">Critical Tests</stat>
+<stat pass="4" fail="2">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="4" fail="2" id="s1" name="Rocket-Car-Robot">Rocket-Car-Robot</stat>
+<stat pass="2" fail="1" id="s1-s1" name="Minus">Rocket-Car-Robot.Minus</stat>
+<stat pass="2" fail="1" id="s1-s2" name="Plus">Rocket-Car-Robot.Plus</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/data/robot/record_test_legacy_result.json
+++ b/tests/data/robot/record_test_legacy_result.json
@@ -12,10 +12,10 @@
           "name": "Check method"
         }
       ],
-      "duration": 0.000411,
-      "status": 1,
+      "duration": 0.002,
+      "status": 0,
       "stdout": "",
-      "stderr": "",
+      "stderr": "0 != -1",
       "data": null
     },
     {
@@ -30,7 +30,7 @@
           "name": "Minus method"
         }
       ],
-      "duration": 0.000296,
+      "duration": 0.002,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -48,7 +48,7 @@
           "name": "Minus method 2"
         }
       ],
-      "duration": 0.00024,
+      "duration": 0.002,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -66,10 +66,10 @@
           "name": "Check method"
         }
       ],
-      "duration": 0.000142,
-      "status": 1,
+      "duration": 0.001,
+      "status": 0,
       "stdout": "",
-      "stderr": "",
+      "stderr": "0 != -1",
       "data": null
     },
     {
@@ -84,7 +84,7 @@
           "name": "Plus method"
         }
       ],
-      "duration": 0.000225,
+      "duration": 0.002,
       "status": 1,
       "stdout": "",
       "stderr": "",
@@ -102,7 +102,7 @@
           "name": "Plus method 2"
         }
       ],
-      "duration": 0.000227,
+      "duration": 0.002,
       "status": 1,
       "stdout": "",
       "stderr": "",

--- a/tests/test_runners/test_robot.py
+++ b/tests/test_runners/test_robot.py
@@ -24,6 +24,16 @@ class RobotTest(CliTestCase):
         self.assert_success(result)
         self.assert_record_tests_payload("record_test_result.json")
 
+    # for RF < 7.0 legacy format (starttime/endtime attributes)
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_record_test_legacy(self):
+
+        result = self.cli('record', 'tests', '--session', self.session,
+                          'robot', str(self.test_files_dir) + "/output_legacy.xml")
+        self.assert_success(result)
+        self.assert_record_tests_payload("record_test_legacy_result.json")
+
     # for #637
     @responses.activate
     @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})


### PR DESCRIPTION
## Why

Robot Framework 7.0 (released January 2024) changed the output.xml format for status timestamps:

- **RF < 7.0**: `starttime`/`endtime` attributes with format `YYYYMMDD HH:MM:SS.fff`
- **RF >= 7.0**: `start`/`elapsed` attributes where `elapsed` is a float in seconds (ISO 8601 timestamp for `start`)

This change was introduced in RF 7.0 as part of [#4258](https://github.com/robotframework/robotframework/issues/4258). The robot plugin only handled the old format, causing duration to always be `0` when parsing RF 7.0+ output files.

## What

- **`launchable/test_runners/robot.py`**: Updated `parse_func` to detect the format by checking for the `elapsed` attribute first (RF 7.0+), falling back to `starttime`/`endtime` parsing (RF < 7.0).
- **`tests/data/robot/output.xml`**: Updated to a real RF 7.4.2 output file (new format).
- **`tests/data/robot/record_test_result.json`**: Updated golden file to match the new `output.xml`.
- **`tests/data/robot/output_legacy.xml`**: Added legacy RF 3.2.2 output file (old `starttime`/`endtime` format) to keep test coverage for the old format.
- **`tests/data/robot/record_test_legacy_result.json`**: Added golden file for the legacy format test.
- **`tests/test_runners/test_robot.py`**: Added `test_record_test_legacy` test case covering the RF < 7.0 format.