### PR TITLE
fix(AIENG-359): Improve text detection by using ByteBuffer and charse…

### DIFF
--- a/src/main/java/com/launchableinc/ingest/commits/GitFile.java
+++ b/src/main/java/com/launchableinc/ingest/commits/GitFile.java
@@ -5,11 +5,10 @@ import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.Reader;
+import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.CodingErrorAction;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jgit.lib.Constants.*;
@@ -67,12 +66,10 @@ final class GitFile implements VirtualFile {
    */
   public boolean isText() throws IOException {
     try {
-      char[] c = new char[1024];
-      try (Reader r = new InputStreamReader(open().openStream(), UTF_8)) {
-        while (r.read(c)!= -1) {
-          // Read the file until EOF.
-        }
-      }
+      UTF_8.newDecoder()
+          .onMalformedInput(CodingErrorAction.REPORT)
+          .onUnmappableCharacter(CodingErrorAction.REPORT)
+          .decode(ByteBuffer.wrap(open().getCachedBytes(Integer.MAX_VALUE)));
       return true;
     } catch (CharacterCodingException e) {
       return false;

--- a/src/test/java/com/launchableinc/ingest/commits/AllTests.java
+++ b/src/test/java/com/launchableinc/ingest/commits/AllTests.java
@@ -10,6 +10,7 @@ import org.junit.runners.Suite.SuiteClasses;
     MainTest.class,
     FileChunkStreamerTest.class,
     SSLBypassTest.class,
+    GitFileTest.class,
     ProgressReportingConsumerTest.class
 })
 public class AllTests {}

--- a/src/test/java/com/launchableinc/ingest/commits/GitFileTest.java
+++ b/src/test/java/com/launchableinc/ingest/commits/GitFileTest.java
@@ -1,0 +1,51 @@
+package com.launchableinc.ingest.commits;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.eclipse.jgit.lib.Constants.OBJ_BLOB;
+
+@RunWith(JUnit4.class)
+public class GitFileTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void isText_textFile_returnsTrue() throws Exception {
+    assertThat(gitFileWithContent("public class Hello {}".getBytes()).isText()).isTrue();
+  }
+
+  @Test
+  public void isText_binaryFile_returnsFalse() throws Exception {
+    // 0xFF 0xFE is invalid UTF-8
+    assertThat(gitFileWithContent(new byte[]{(byte) 0xFF, (byte) 0xFE, 0x00, 0x01}).isText()).isFalse();
+  }
+
+  @Test
+  public void isText_utf8MultiByte_returnsTrue() throws Exception {
+    assertThat(gitFileWithContent("日本語テスト".getBytes(java.nio.charset.StandardCharsets.UTF_8)).isText()).isTrue();
+  }
+
+  private GitFile gitFileWithContent(byte[] content) throws Exception {
+    File repoDir = tmp.newFolder();
+    try (Git git = Git.init().setDirectory(repoDir).call()) {
+      Repository repo = git.getRepository();
+      ObjectId blobId;
+      try (ObjectInserter inserter = repo.newObjectInserter()) {
+        blobId = inserter.insert(OBJ_BLOB, content);
+        inserter.flush();
+      }
+      return new GitFile("test", "file", blobId, repo.newObjectReader());
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates the logic for detecting whether a file is text or binary in the `GitFile` class and adds comprehensive tests to ensure correctness. The main change replaces the previous character-based reading approach with a more robust UTF-8 decoder, and new unit tests are introduced to cover various scenarios.

**Improvements to text/binary file detection:**
* The `isText()` method in `GitFile` now uses a UTF-8 decoder with strict error reporting to determine if file content is valid UTF-8, making detection of binary files more accurate and efficient.

**Testing enhancements:**
* Added a new test class `GitFileTest` with unit tests for `isText()`, covering text files, binary files, and multi-byte UTF-8 content.
* Registered `GitFileTest` in the `AllTests` suite to ensure it is run with other tests.

**Code cleanup:**
* Removed unused imports and added necessary ones in `GitFile.java` to support the new decoding logic.