### PR TITLE
CI: check launchable/jar/exe_deploy.jar is up to date when src/ Java files change

### DIFF
--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -32,3 +32,10 @@ jobs:
       - name: Run Bazel test
         run: |
           bazel test //...
+      - name: Check exe_deploy.jar is up to date
+        run: |
+          bazel build //src/main/java/com/launchableinc/ingest/commits:exe_deploy.jar
+          if ! diff -q bazel-bin/src/main/java/com/launchableinc/ingest/commits/exe_deploy.jar launchable/jar/exe_deploy.jar > /dev/null 2>&1; then
+            echo "launchable/jar/exe_deploy.jar is out of date. Run build-java.sh to update it."
+            exit 1
+          fi


### PR DESCRIPTION
## Why

When Java source files under `src/` are updated, `build-java.sh` must be run to regenerate and copy `exe_deploy.jar` to `launchable/jar/exe_deploy.jar`. This step is easy to forget, and there was no CI check to catch it.

## What

Added a new step to the `bazel-test.yml` workflow that:
- Runs only when `src/` Java files change (already handled by the existing `paths` trigger)
- Builds the jar with Bazel
- Compares the built jar against `launchable/jar/exe_deploy.jar` using `diff`
- Fails with a clear error message if they differ, prompting the developer to run `build-java.sh`

## Please Review Here

- The check reuses the already-built jar from the previous `bazel test //...` step via Bazel's cache, so the extra `bazel build` call should be fast.
- This PR targets `v1`. A separate PR will be needed for `main` (where the copy destination is `smart_tests/jar/exe_deploy.jar` instead).