### PR TITLE
refactor(420): update test status terminology and parameter names for…

### DIFF
--- a/smart_tests/commands/view/flaky_tests.py
+++ b/smart_tests/commands/view/flaky_tests.py
@@ -61,10 +61,10 @@ def flaky_tests(
         type=parse_datetime_with_timezone,
         metavar="DATE"
     )] = None,
-    test_suite: Annotated[str | None, typer.Option(
-        "--test-suite",
-        help="Test suite name filter (e.g., 'unit-tests')",
-        metavar="NAME"
+    test_path: Annotated[str | None, typer.Option(
+        "--test-path",
+        help="Test path filter (full path string, e.g., 'class=MyTest')",
+        metavar="PATH"
     )] = None,
     limit: Annotated[int | None, typer.Option(
         "--limit",
@@ -83,11 +83,11 @@ def flaky_tests(
     if weeks:
         params["weeks"] = str(weeks)
     if from_date:
-        params["from"] = str(from_date)
+        params["from"] = from_date.datetime().strftime("%Y-%m-%d")
     if to_date:
-        params["to"] = str(to_date)
-    if test_suite:
-        params["test-suite"] = test_suite
+        params["to"] = to_date.datetime().strftime("%Y-%m-%d")
+    if test_path:
+        params["test-path"] = test_path
     if limit:
         params["limit"] = str(limit)
 

--- a/smart_tests/commands/view/test_results.py
+++ b/smart_tests/commands/view/test_results.py
@@ -18,9 +18,9 @@ from ...utils.typer_types import DateTimeWithTimezone, parse_datetime_with_timez
 
 class TestStatus(str, Enum):
     """Test execution status"""
-    PASSED = "PASSED"
-    FAILED = "FAILED"
-    SKIPPED = "SKIPPED"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    SKIP = "SKIP"
     FLAKE = "FLAKE"
 
     @staticmethod
@@ -30,7 +30,7 @@ class TestStatus(str, Enum):
             if member.value.lower() == value.lower():
                 return member
         raise BadCmdLineException(
-            f"Invalid status: '{value}'. Valid values: PASSED, FAILED, SKIPPED, FLAKE"
+            f"Invalid status: '{value}'. Valid values: SUCCESS, FAILURE, SKIP, FLAKE"
         )
 
 
@@ -45,7 +45,7 @@ def test_results(
     )],
     status: Annotated[TestStatus | None, typer.Option(
         "--status",
-        help="Filter by test status (PASSED, FAILED, SKIPPED, FLAKE)",
+        help="Filter by test status (SUCCESS, FAILURE, SKIP, FLAKE)",
         type=TestStatus.from_str,
         metavar="STATUS"
     )] = None,
@@ -102,9 +102,9 @@ def test_results(
     if test_suite:
         params["test-suite"] = test_suite
     if from_date:
-        params["from"] = str(from_date)
+        params["from"] = from_date.datetime().strftime("%Y-%m-%d")
     if to_date:
-        params["to"] = str(to_date)
+        params["to"] = to_date.datetime().strftime("%Y-%m-%d")
     if logs:
         params["include-logs"] = "true"
     if limit:

--- a/tests/commands/test_view_flaky_tests.py
+++ b/tests/commands/test_view_flaky_tests.py
@@ -197,34 +197,38 @@ class ViewFlakyTestsTest(CliTestCase):
         )
         self.assert_success(result)
 
-        # Verify the request was made and query parameters were passed
+        # Verify the request was made and query parameters were plain YYYY-MM-DD dates
         self.assertGreater(len(responses.calls), 0)
         self.assertIn("/view/flaky-tests", responses.calls[0].request.url)
-        self.assertIn("from=", responses.calls[0].request.url)
-        self.assertIn("to=", responses.calls[0].request.url)
+        self.assertIn("from=2026-04-08", responses.calls[0].request.url)
+        self.assertIn("to=2026-04-14", responses.calls[0].request.url)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
-    def test_flaky_tests_with_test_suite(self):
-        """Test flaky tests query with test-suite filter"""
+    def test_flaky_tests_with_test_path(self):
+        """Test flaky tests query with test-path filter"""
         mock_json_response = {
             "data": {
-                "weeks": [
+                "results": [
                     {
-                        "weekDate": "2026-W19",
-                        "calculationStatus": "CALCULATED",
-                        "calculationTime": "2026-05-11T10:30:00Z",
-                        "flakyTests": [],
-                        "flakyTestCount": 0
-                    }
-                ]
-            },
+                        "id": "0197c5cc-8468-73f0-ade2-619e21d20049",
+                        "testPath": "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite#testcase=C000001 Sanity. Create service with deployment definitions from yaml file ",
+                        "status": "SUCCESS",
+                        "totalDuration": 145087,
+                        "passed": 1,
+                        "failed": 0,
+                        "skipped": 0,
+                        "session": {
+                            "id": 4595735,
+                            "buildId": 4196923,
+                            "branch": "master",
+                            "links": [],
+                            "createdAt": "2025-07-01T07:50:22.322649Z"},
+                        "createdAt": "2025-07-01T11:43:24.246347Z"}]},
             "metadata": {
-                "weeksRequested": 1,
-                "weeksReturned": 1,
-                "latestWeek": "2026-W19"
-            }
-        }
+                        "totalCount": 3,
+                        "limit": 50,
+                "offset": 0}}
 
         responses.add(
             responses.GET,
@@ -233,13 +237,20 @@ class ViewFlakyTestsTest(CliTestCase):
             status=200,
         )
 
-        result = self.cli("view", "flaky-tests", "--test-suite", "unit-tests", mix_stderr=False)
+        result = self.cli(
+            "view",
+            "flaky-tests",
+            "--test-path",
+            "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite#testcase=C000001 Sanity. Create service with deployment definitions from yaml file ",
+            mix_stderr=False)
         self.assert_success(result)
 
-        # Verify the request was made and query parameter was passed
+# Verify the request was made and query parameter was passed
         self.assertGreater(len(responses.calls), 0)
         self.assertIn("/view/flaky-tests", responses.calls[0].request.url)
-        self.assertIn("test-suite=unit-tests", responses.calls[0].request.url)
+        self.assertIn(
+            "test-path=class%3Dcom.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite%23testcase%3DC000001+Sanity.+Create+service+with+deployment+definitions+from+yaml+file+",
+            responses.calls[0].request.url)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})

--- a/tests/commands/test_view_flaky_tests.py
+++ b/tests/commands/test_view_flaky_tests.py
@@ -212,7 +212,10 @@ class ViewFlakyTestsTest(CliTestCase):
                 "results": [
                     {
                         "id": "0197c5cc-8468-73f0-ade2-619e21d20049",
-                        "testPath": "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite#testcase=C000001 Sanity. Create service with deployment definitions from yaml file ",
+                        "testPath": (
+                            "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite"
+                            "#testcase=C000001 Sanity. Create service with deployment definitions from yaml file "
+                        ),
                         "status": "SUCCESS",
                         "totalDuration": 145087,
                         "passed": 1,
@@ -241,7 +244,8 @@ class ViewFlakyTestsTest(CliTestCase):
             "view",
             "flaky-tests",
             "--test-path",
-            "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite#testcase=C000001 Sanity. Create service with deployment definitions from yaml file ",
+            "class=com.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite"
+            "#testcase=C000001 Sanity. Create service with deployment definitions from yaml file ",
             mix_stderr=False)
         self.assert_success(result)
 
@@ -249,7 +253,8 @@ class ViewFlakyTestsTest(CliTestCase):
         self.assertGreater(len(responses.calls), 0)
         self.assertIn("/view/flaky-tests", responses.calls[0].request.url)
         self.assertIn(
-            "test-path=class%3Dcom.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite%23testcase%3DC000001+Sanity.+Create+service+with+deployment+definitions+from+yaml+file+",
+            "test-path=class%3Dcom.cloudbees.plugin.spec.CreateOrUpdateObjectsSuite"
+            "%23testcase%3DC000001+Sanity.+Create+service+with+deployment+definitions+from+yaml+file+",
             responses.calls[0].request.url)
 
     @responses.activate

--- a/tests/commands/test_view_flaky_tests.py
+++ b/tests/commands/test_view_flaky_tests.py
@@ -209,7 +209,7 @@ class ViewFlakyTestsTest(CliTestCase):
         """Test flaky tests query with test-path filter"""
         mock_json_response = {
             "data": {
-                "results": [
+                "weeks": [
                     {
                         "id": "0197c5cc-8468-73f0-ade2-619e21d20049",
                         "testPath": (

--- a/tests/commands/test_view_test_results.py
+++ b/tests/commands/test_view_test_results.py
@@ -19,7 +19,7 @@ class ViewTestResultsTest(CliTestCase):
                     {
                         "id": "550e8400-e29b-41d4-a716-446655440000",
                         "testPath": "com.example.TestClass#testMethod",
-                        "status": "FAILED",
+                        "status": "FAILURE",
                         "totalDuration": 5200,
                         "passed": 0,
                         "failed": 1,
@@ -35,7 +35,7 @@ class ViewTestResultsTest(CliTestCase):
                     {
                         "id": "890a1234-e29b-41d4-a716-446655440001",
                         "testPath": "com.example.TestClass#testMethod2",
-                        "status": "PASSED",
+                        "status": "SUCCESS",
                         "totalDuration": 3400,
                         "passed": 1,
                         "failed": 0,
@@ -134,15 +134,15 @@ class ViewTestResultsTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
-    def test_test_results_with_status_failed(self):
-        """Test test results query with status=FAILED filter"""
+    def test_test_results_with_status_failure(self):
+        """Test test results query with status=FAILURE filter"""
         mock_json_response = {
             "data": {
                 "results": [
                     {
                         "id": "550e8400-e29b-41d4-a716-446655440000",
                         "testPath": "com.example.FailingTest#testMethod",
-                        "status": "FAILED",
+                        "status": "FAILURE",
                         "totalDuration": 5200,
                         "passed": 0,
                         "failed": 1,
@@ -174,23 +174,21 @@ class ViewTestResultsTest(CliTestCase):
         )
 
         result = self.cli(
-            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "FAILED", mix_stderr=False
+            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "FAILURE", mix_stderr=False
         )
         self.assert_success(result)
 
-        # Verify the query parameter was passed
-        # Check request was made
         self.assertGreater(len(responses.calls), 0)
-        self.assertIn("status=FAILED", responses.calls[0].request.url)
+        self.assertIn("status=FAILURE", responses.calls[0].request.url)
 
         # Verify output
         output_json = json.loads(result.stdout)
-        self.assertEqual(output_json["data"]["results"][0]["status"], "FAILED")
+        self.assertEqual(output_json["data"]["results"][0]["status"], "FAILURE")
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
-    def test_test_results_with_status_passed(self):
-        """Test test results query with status=PASSED filter"""
+    def test_test_results_with_status_success(self):
+        """Test test results query with status=SUCCESS filter"""
         mock_json_response = {
             "data": {
                 "results": []
@@ -212,14 +210,12 @@ class ViewTestResultsTest(CliTestCase):
         )
 
         result = self.cli(
-            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "PASSED", mix_stderr=False
+            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "SUCCESS", mix_stderr=False
         )
         self.assert_success(result)
 
-        # Verify the query parameter was passed
-        # Check request was made
         self.assertGreater(len(responses.calls), 0)
-        self.assertIn("status=PASSED", responses.calls[0].request.url)
+        self.assertIn("status=SUCCESS", responses.calls[0].request.url)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
@@ -371,7 +367,7 @@ class ViewTestResultsTest(CliTestCase):
                     {
                         "id": "550e8400-e29b-41d4-a716-446655440000",
                         "testPath": "com.example.TestClass#testMethod",
-                        "status": "FAILED",
+                        "status": "FAILURE",
                         "totalDuration": 5200,
                         "passed": 0,
                         "failed": 1,
@@ -450,17 +446,15 @@ class ViewTestResultsTest(CliTestCase):
         result = self.cli(
             "view", "test-results",
             "--test-path", "class=MyTest#method=test1",
-            "--status", "FAILED",
+            "--status", "FAILURE",
             "--branch", "main",
             "--limit", "200",
             mix_stderr=False
         )
         self.assert_success(result)
 
-        # Verify all query parameters were passed
-        # Check request was made
         self.assertGreater(len(responses.calls), 0)
-        self.assertIn("status=FAILED", responses.calls[0].request.url)
+        self.assertIn("status=FAILURE", responses.calls[0].request.url)
         self.assertIn("branch=main", responses.calls[0].request.url)
         self.assertIn("limit=200", responses.calls[0].request.url)
 
@@ -500,7 +494,7 @@ class ViewTestResultsTest(CliTestCase):
         )
         self.assert_exit_code(result, 1)
         self.assertIn("Invalid status", result.stderr)
-        self.assertIn("PASSED, FAILED, SKIPPED, FLAKE", result.stderr)
+        self.assertIn("SUCCESS, FAILURE, SKIP, FLAKE", result.stderr)
 
     def test_test_results_invalid_limit(self):
         """Test test results query with out-of-range limit"""
@@ -578,8 +572,8 @@ class ViewTestResultsTest(CliTestCase):
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
-    def test_test_results_with_status_passed_case_insensitive(self):
-        """Test test results query with status PASSED (case insensitive)"""
+    def test_test_results_with_status_success_case_insensitive(self):
+        """Test test results query with status success (case insensitive)"""
         responses.add(
             responses.GET,
             f"{get_base_url()}/intake/organizations/{self.organization}/workspaces/{self.workspace}/view/test-results",
@@ -597,16 +591,16 @@ class ViewTestResultsTest(CliTestCase):
         )
 
         result = self.cli(
-            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "passed", mix_stderr=False
+            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "success", mix_stderr=False
         )
         self.assert_success(result)
         self.assertGreater(len(responses.calls), 0)
-        self.assertIn("status=PASSED", responses.calls[0].request.url)
+        self.assertIn("status=SUCCESS", responses.calls[0].request.url)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
-    def test_test_results_with_status_skipped(self):
-        """Test test results query with status SKIPPED"""
+    def test_test_results_with_status_skip(self):
+        """Test test results query with status SKIP"""
         responses.add(
             responses.GET,
             f"{get_base_url()}/intake/organizations/{self.organization}/workspaces/{self.workspace}/view/test-results",
@@ -624,11 +618,11 @@ class ViewTestResultsTest(CliTestCase):
         )
 
         result = self.cli(
-            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "SKIPPED", mix_stderr=False
+            "view", "test-results", "--test-path", "class=MyTest#method=test1", "--status", "SKIP", mix_stderr=False
         )
         self.assert_success(result)
         self.assertGreater(len(responses.calls), 0)
-        self.assertIn("status=SKIPPED", responses.calls[0].request.url)
+        self.assertIn("status=SKIP", responses.calls[0].request.url)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})


### PR DESCRIPTION
This pull request updates the test status terminology in the CLI and API to use more standardized names, improves date formatting for API requests, and updates related tests accordingly. The main focus is to ensure consistency between user input, API parameters, and test output.

**Test status terminology standardization:**

* Changed the `TestStatus` enum and all related code, options, and error messages from `PASSED`, `FAILED`, `SKIPPED` to `SUCCESS`, `FAILURE`, `SKIP` for consistency with API and industry standards (`smart_tests/commands/view/test_results.py`, `tests/commands/test_view_test_results.py`). [[1]](diffhunk://#diff-71d685cebf65f467f5330cd38347b4355c947de79bbe66e1b171b61c7b12d846L21-R23) [[2]](diffhunk://#diff-71d685cebf65f467f5330cd38347b4355c947de79bbe66e1b171b61c7b12d846L33-R33) [[3]](diffhunk://#diff-71d685cebf65f467f5330cd38347b4355c947de79bbe66e1b171b61c7b12d846L48-R48) [[4]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L22-R22) [[5]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L38-R38) [[6]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L137-R145) [[7]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L177-R191) [[8]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L215-R218) [[9]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L374-R370) [[10]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L453-R457) [[11]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L503-R497) [[12]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L581-R576) [[13]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L600-R603) [[14]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L627-R625)

**API parameter and filter improvements:**

* Updated date parameters in API requests to use plain `YYYY-MM-DD` format instead of full datetime strings for both test results and flaky tests queries (`smart_tests/commands/view/test_results.py`, `smart_tests/commands/view/flaky_tests.py`). [[1]](diffhunk://#diff-71d685cebf65f467f5330cd38347b4355c947de79bbe66e1b171b61c7b12d846L105-R107) [[2]](diffhunk://#diff-fb83875c24a2f37010f05cd35015c3a7d028b47c15d366c33ffe57121b600b50L86-R90)
* Changed the flaky tests filter option from `--test-suite` to `--test-path` to allow filtering by full test path, and updated the corresponding API parameter (`smart_tests/commands/view/flaky_tests.py`). [[1]](diffhunk://#diff-fb83875c24a2f37010f05cd35015c3a7d028b47c15d366c33ffe57121b600b50L64-R67) [[2]](diffhunk://#diff-fb83875c24a2f37010f05cd35015c3a7d028b47c15d366c33ffe57121b600b50L86-R90)

**Test updates:**

* Updated test cases to reflect the new status values and date formatting, ensuring that both the CLI and API interactions are validated against the new standards (`tests/commands/test_view_test_results.py`, `tests/commands/test_view_flaky_tests.py`). [[1]](diffhunk://#diff-ab685f05b723aa4ffe176ea4fa7358fac0fc06172e7ca2780de55cd2b2ad52dbL200-R204) [[2]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L22-R22) [[3]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L38-R38) [[4]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L137-R145) [[5]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L177-R191) [[6]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L215-R218) [[7]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L374-R370) [[8]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L453-R457) [[9]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L503-R497) [[10]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L581-R576) [[11]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L600-R603) [[12]](diffhunk://#diff-27bb3299954f36dc218ee77a2717fef2a69b605b8796776e27c43ed337bd19a3L627-R625)

These changes improve consistency, clarity, and correctness in how test statuses and filters are handled throughout the CLI and its integration tests.… clarity


manual test:

<img width="1191" height="196" alt="image" src="https://github.com/user-attachments/assets/bce51689-fefa-4a25-9540-4667cf5f0f68" />

<img width="1186" height="296" alt="image" src="https://github.com/user-attachments/assets/81b75a9f-6733-4d1e-9f03-7caf4c13fb9b" />


![Uploading image.png…]()
