### PR TITLE
Add fallback-mode option for subset

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -20,7 +20,7 @@ from launchable.utils.tracking import Tracking, TrackingClient
 
 from ..app import Application
 from ..testpath import FilePathNormalizer, TestPath
-from ..utils.click import DURATION, KEY_VALUE, PERCENTAGE, DurationType, PercentageType, ignorable_error
+from ..utils.click import DURATION, KEY_VALUE, PERCENTAGE, DurationType, ignorable_error
 from ..utils.commands import Command
 from ..utils.env_keys import REPORT_ERROR_KEY
 from ..utils.fail_fast_mode import (FailFastModeValidateParams, fail_fast_mode_validate,
@@ -254,14 +254,14 @@ LARGE_PAYLOAD_CONNECT_TIMEOUT = 60
 @click.pass_context
 def subset(
     context: click.core.Context,
-    target: Optional[PercentageType],
+    target: Optional[float],
     session: Optional[str],
     base_path: Optional[str],
     build_name: Optional[str],
     rest: str,
     duration: Optional[DurationType],
     flavor: Sequence[Tuple[str, str]],
-    confidence: Optional[PercentageType],
+    confidence: Optional[float],
     goal_spec: Optional[str],
     split: bool,
     no_base_path_inference: bool,
@@ -518,7 +518,7 @@ def subset(
         def get_payload(
             self,
             session_id: str,
-            target: Optional[PercentageType],
+            target: Optional[float],
             duration: Optional[DurationType],
             test_runner: str,
         ):

--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -2,9 +2,11 @@ import glob
 import json
 import os
 import pathlib
+import random
 import re
 import subprocess
 import sys
+from enum import Enum
 from multiprocessing import Process
 from os.path import join
 from typing import Any, Callable, Dict, List, Optional, Sequence, TextIO, Tuple, Union
@@ -26,6 +28,13 @@ from ..utils.fail_fast_mode import (FailFastModeValidateParams, fail_fast_mode_v
 from ..utils.launchable_client import LaunchableClient
 from .helper import find_or_create_session
 from .test_path_writer import TestPathWriter
+
+
+class FallbackMode(str, Enum):
+    RUN_ALL = "run-all"
+    STOP = "stop"
+    RANDOM_SAMPLE = "random-sample"
+
 
 LARGE_TEST_PATHS_THRESHOLD = 100000
 DEFAULT_CONNECT_TIMEOUT = 5
@@ -231,6 +240,17 @@ LARGE_PAYLOAD_CONNECT_TIMEOUT = 60
     type=str,
     hidden=True,
 )
+@click.option(
+    "--fallback-mode",
+    "fallback_mode",
+    hidden=True,
+    type=click.Choice(["run-all", "stop", "random-sample"]),
+    default="run-all",
+    help="Behavior when the subset API is unavailable or the model is untrained. "
+         "'run-all' (default) runs all tests as usual; 'stop' exits with a non-zero status so CI halts; "
+         "'random-sample' picks a random subset locally based on the count derived from --target "
+         "(no duration estimates are available in this path).",
+)
 @click.pass_context
 def subset(
     context: click.core.Context,
@@ -262,7 +282,9 @@ def subset(
     use_case: Optional[str] = None,
     similarity: Optional[float] = None,
     subset_id_file: Optional[str] = None,
+    fallback_mode: str = "run-all",
 ):
+    fallback_mode_enum = FallbackMode(fallback_mode)
     app = context.obj
     tracking_client = TrackingClient(Command.SUBSET, app=app)
     client = LaunchableClient(
@@ -402,6 +424,7 @@ def subset(
             self.is_output_exclusion_rules = is_output_exclusion_rules
             self.is_get_tests_from_guess = is_get_tests_from_guess
             self.subset_id_file = subset_id_file
+            self.fallback_mode = fallback_mode_enum
             super(Optimize, self).__init__(app=app)
 
         def _default_output_handler(self, output: List[TestPath], rests: List[TestPath]):
@@ -587,6 +610,23 @@ def subset(
             with open(self.subset_id_file, 'w', encoding='utf-8') as f:
                 f.write(str(subset_result.subset_id) + '\n')
 
+        def _fallback_result(self) -> SubsetResult:
+            if self.fallback_mode == FallbackMode.STOP:
+                click.echo(
+                    "Warning: the service failed to subset. Stopping build (--fallback-mode=stop).",
+                    err=True,
+                )
+                sys.exit(1)
+            elif self.fallback_mode == FallbackMode.RANDOM_SAMPLE:
+                target_fraction = float(target) if target is not None else 1.0
+                click.echo(
+                    "Warning: the service failed to subset. Falling back to local random sample at {:.0%}.".format(
+                        target_fraction),
+                    err=True,)
+                return SubsetResult.from_random_sample(self.test_paths, target_fraction)
+            else:
+                return SubsetResult.from_test_paths(self.test_paths)
+
         def request_subset(self) -> SubsetResult:
             test_runner = context.invoked_subcommand
             # temporarily extend the timeout because subset API response has become slow
@@ -622,7 +662,7 @@ def subset(
                 )
                 client.print_exception_and_recover(
                     e, "Warning: the service failed to subset. Falling back to running all tests")
-                return SubsetResult.from_test_paths(self.test_paths)
+                return self._fallback_result()
 
         def run(self):
             """called after tests are scanned to compute the optimized order"""
@@ -642,9 +682,15 @@ def subset(
             if not session_id:
                 # Session ID in --session is missing. It might be caused by
                 # Launchable API errors.
-                subset_result = SubsetResult.from_test_paths(self.test_paths)
+                subset_result = self._fallback_result()
             else:
                 subset_result = self.request_subset()
+
+            if subset_result.is_brainless:
+                click.echo("Your model is currently in training", err=True)
+                # brainless mode splits tests on server, so skip client-side fallback for random-sample
+                if self.fallback_mode != FallbackMode.RANDOM_SAMPLE:
+                    subset_result = self._fallback_result()
 
             if len(subset_result.subset) == 0:
                 if len(subset_result.rest) > 0 and client.is_pts_v2_enabled() and confidence is not None:
@@ -706,10 +752,6 @@ def subset(
                     summary["subset"].get("duration", 0.0) + summary["rest"].get("duration", 0.0),
                 ],
             ]
-
-            if subset_result.is_brainless:
-                click.echo(
-                    "Your model is currently in training", err=True)
 
             click.echo(
                 "Launchable created subset {} for build {} (test session {}) in workspace {}/{}".format(
@@ -775,3 +817,11 @@ class SubsetResult:
             is_brainless=False,
             is_observation=False
         )
+
+    @classmethod
+    def from_random_sample(cls, test_paths: List[TestPath], target: float) -> 'SubsetResult':
+        count = max(1, round(len(test_paths) * target))
+        sampled = random.sample(test_paths, min(count, len(test_paths)))
+        sampled_set = {id(t): t for t in sampled}
+        rest = [t for t in test_paths if id(t) not in sampled_set]
+        return cls(subset=sampled, rest=rest, subset_id='', summary={}, is_brainless=False, is_observation=False)

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -473,3 +473,110 @@ class APIErrorTest(CliTestCase):
                 if attempt > 10:
                     break
             self.assertEqual(tracking.call_count, count)
+
+
+class FallbackModeTest(CliTestCase):
+    test_files_dir = Path(__file__).parent.joinpath('../data/minitest/').resolve()
+
+    def _subset_args(self, rest_file_name, extra_args=()):
+        return (
+            "subset", "--target", "50%",
+            "--session", self.session,
+            "--rest", rest_file_name,
+        ) + tuple(extra_args) + (
+            "minitest",
+            str(self.test_files_dir) + "/test/**/*.rb",
+        )
+
+    # --- API error cases ---
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_api_error_fallback_stop(self):
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            status=500)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "stop")), mix_stderr=False)
+            self.assertEqual(result.exit_code, 1)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_api_error_fallback_random_sample(self):
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            status=500)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "random-sample")), mix_stderr=False)
+            self.assert_success(result)
+            self.assertIn("example_test.rb", result.stdout)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_api_error_fallback_run_all_default(self):
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            status=500)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name), mix_stderr=False)
+            self.assert_success(result)
+            self.assertIn("example_test.rb", result.stdout)
+
+    # --- Brainless mode cases ---
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_brainless_fallback_stop(self):
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            json={"testPaths": [[{"type": "file", "name": "example_test.rb"}]],
+                  "rest": [], "subsettingId": 1, "isBrainless": True, "summary": {}},
+            status=200)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "stop")), mix_stderr=False)
+            self.assertEqual(result.exit_code, 1)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_brainless_fallback_random_sample(self):
+        # In brainless mode the server already split the tests, so random-sample keeps the server's result as-is.
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            json={"testPaths": [[{"type": "file", "name": "example_test.rb"}]],
+                  "rest": [], "subsettingId": 1, "isBrainless": True, "summary": {}},
+            status=200)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "random-sample")), mix_stderr=False)
+            self.assert_success(result)
+            self.assertIn("example_test.rb", result.stdout)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.launchable_token})
+    def test_brainless_fallback_run_all_default(self):
+        responses.replace(
+            responses.POST,
+            "{base}/intake/organizations/{org}/workspaces/{ws}/subset".format(
+                base=get_base_url(), org=self.organization, ws=self.workspace),
+            json={"testPaths": [[{"type": "file", "name": "example_test.rb"}]],
+                  "rest": [], "subsettingId": 1, "isBrainless": True, "summary": {}},
+            status=200)
+
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name), mix_stderr=False)
+            self.assert_success(result)
+            self.assertIn("example_test.rb", result.stdout)


### PR DESCRIPTION
# Backgroud

backport v2 merged code from https://github.com/cloudbees-oss/smart-tests-cli/pull/1308


# Critical change

This PR also change subset arguments type hints from Optional[PercentageType] to Optional[float]

We had the type error: https://github.com/cloudbees-oss/smart-tests-cli/actions/runs/27386061774/job/80933216605

```
Run pipenv run type
launchable/commands/subset.py:621: error: Argument 1 to "float" has incompatible type "PercentageType"; expected "Union[SupportsFloat, SupportsIndex, str, Buffer]"  [arg-type]
```

Click's type system works like this:

1. User runs: launchable subset --target 50%
2. Click receives the raw string "50%"
3. Click sees type=PERCENTAGE on the option, so it calls PercentageType.convert("50%", ...)
4. convert() parses "50%" and returns 0.5
5. Click passes 0.5 as target to subset()

PercentageType is called a "converter" because it converts the raw CLI string into a Python value. It's Click's extension point for custom argument types, which similar to how type=int makes Click convert "5" to 5. PercentageType does the same for percentages. The key point: convert() runs inside Click's internals, not in your code. Your function only ever sees the return value of convert(), which is a float. PercentageType itself never appears as a value anywhere in your code. This is why Optional[PercentageType] is misleading. It suggests the function receives a PercentageType instance, but it actually receives whatever convert() returned, which is float.


# Question

If we want to keep using `target: Optional[PercentageType]` type as the type hint, we need to suppress the warning from mypy.

```
error: Argument 1 to "float" has incompatible type "PercentageType"; 
```

See the log https://github.com/cloudbees-oss/smart-tests-cli/actions/runs/27386061774/job/80933216605