### PR TITLE
Use cloudbees.io URL when CBP workspace

### DIFF
--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -56,8 +56,9 @@ class TestResultAbstractDisplay(metaclass=ABCMeta):
 
 
 class TestResultJSONDisplay(TestResultAbstractDisplay):
-    def __init__(self, results: TestResults):
+    def __init__(self, results: TestResults, client: LaunchableClient):
         super().__init__(results)
+        self._client = client
 
     def display(self):
         result_json = {}
@@ -88,11 +89,19 @@ class TestResultJSONDisplay(TestResultAbstractDisplay):
                 "created_at": result._created_at
             })
 
-        org, workspace = ensure_org_workspace()
-        result_json["test_session_app_url"] = "https://app.launchableinc.com/organizations/{}/workspaces/{}/test-sessions/{}".format(  # noqa: E501
-            org, workspace, self._results._test_session_id)
-
+        result_json["test_session_app_url"] = self._get_test_session_url()
         click.echo(json.dumps(result_json, indent=2))
+
+    def _get_test_session_url(self) -> str:
+        cbp_workspace = self._client.get_cbp_workspace()
+        if cbp_workspace:
+            org_cbp_id, ws_cbp_id = cbp_workspace
+            return "https://cloudbees.io/{}/{}/smart-tests/test-sessions/{}".format(
+                org_cbp_id, ws_cbp_id, self._results._test_session_id)
+        else:
+            org, workspace = ensure_org_workspace()
+            return "https://app.launchableinc.com/organizations/{}/workspaces/{}/test-sessions/{}".format(
+                org, workspace, self._results._test_session_id)
 
 
 class TestResultTableDisplay(TestResultAbstractDisplay):
@@ -179,7 +188,7 @@ def tests(context: click.core.Context, test_session_id: int, is_json_format: boo
 
     displayer: TestResultAbstractDisplay
     if is_json_format:
-        displayer = TestResultJSONDisplay(test_results)
+        displayer = TestResultJSONDisplay(test_results, client=client)
     else:
         displayer = TestResultTableDisplay(test_results)
 

--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -362,14 +362,18 @@ def build(
         header = ["Name", "Path", "HEAD Commit"]
         rows = [[w.name, w.dir, w.commit_hash] for w in ws]
         click.echo(tabulate(rows, header, tablefmt="github"))
-        click.echo(
-            "\nVisit https://app.launchableinc.com/organizations/{organization}/workspaces/"
-            "{workspace}/data/builds/{build_id} to view this build and its test sessions"
-            .format(
-                organization=org,
-                workspace=workspace,
-                build_id=build_id,
-            ))
+        url = _get_build_url(build_id, org, workspace)
+        click.echo("\nVisit {} to view this build and its test sessions".format(url))
+
+    def _get_build_url(build_id, org, workspace) -> str:
+        cbp_workspace = client.get_cbp_workspace()
+        if cbp_workspace:
+            org_cbp_id, ws_cbp_id = cbp_workspace
+            url = "https://cloudbees.io/{}/{}/smart-tests/data/builds/{}".format(org_cbp_id, ws_cbp_id, build_id)
+        else:
+            url = "https://app.launchableinc.com/organizations/{}/workspaces/{}/data/builds/{}".format(
+                org, workspace, build_id)
+        return url
 
     # all the logics at the high level
     if len(commits) == 0:

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -650,15 +650,21 @@ def tests(
                 click.echo(click.style("\nTotal test duration is 0."
                                        "\nPlease check whether the test duration times in report files are correct.", "yellow"))
 
+            url = self._get_test_session_url()
             click.echo(
-                "\nVisit https://app.launchableinc.com/organizations/{organization}/workspaces/"
-                "{workspace}/test-sessions/{test_session_id} to view uploaded test results "
-                "(or run `launchable inspect tests --test-session-id {test_session_id}`)"
-                .format(
-                    organization=org,
-                    workspace=workspace,
-                    test_session_id=self.test_session_id,
-                ))
+                "\nVisit {} to view uploaded test results "
+                "(or run `launchable inspect tests --test-session-id {}`)".format(url, self.test_session_id))
+
+        def _get_test_session_url(self) -> str:
+            cbp_workspace = client.get_cbp_workspace()
+            if cbp_workspace:
+                org_cbp_id, ws_cbp_id = cbp_workspace
+                url = "https://cloudbees.io/{}/{}/smart-tests/test-sessions/{}".format(
+                    org_cbp_id, ws_cbp_id, self.test_session_id)
+            else:
+                url = "https://app.launchableinc.com/organizations/{}/workspaces/{}/test-sessions/{}".format(
+                    org, workspace, self.test_session_id)
+            return url
 
     context.obj = RecordTests(dry_run=context.obj.dry_run)
 

--- a/launchable/utils/launchable_client.py
+++ b/launchable/utils/launchable_client.py
@@ -25,6 +25,7 @@ class LaunchableClient:
         self.tracking_client = tracking_client
         self.organization, self.workspace = ensure_org_workspace()
         self._workspace_state_cache: Optional[Dict[str, Union[str, bool]]] = None
+        self._cbp_workspace_cache: Optional[Tuple[str, str]] = None
 
     def request(
         self,
@@ -106,6 +107,27 @@ class LaunchableClient:
         state = self._get_workspace_state()
         return state.get('pts_v2', False)
 
+    def get_cbp_workspace(self) -> Optional[Tuple[str, str]]:
+        """
+        Returns (org_cbp_id, workspace_cbp_id) if this is a CBP workspace, else None.
+        """
+        state = self._get_workspace_state()
+        if not state.get('is_cbp_workspace', False):
+            return None
+
+        if self._cbp_workspace_cache is not None:
+            return self._cbp_workspace_cache
+
+        try:
+            res = self.request("get", "cbp-workspace")
+            res.raise_for_status()
+            data = res.json()
+            self._cbp_workspace_cache = (data['organizationCbpId'], data['workspaceCbpId'])
+            return self._cbp_workspace_cache
+        except Exception as e:
+            self.print_exception_and_recover(e, "Failed to get CBP workspace info")
+            return None
+
     def _get_workspace_state(self) -> dict:
         """
         Get the current state of the workspace.
@@ -120,6 +142,7 @@ class LaunchableClient:
             self._workspace_state_cache = {
                 'fail_fast_mode': state.get('isFailFastMode', False),
                 'pts_v2': state.get('isPtsV2Enabled', False),
+                'is_cbp_workspace': state.get('isCbpWorkspace', False),
             }
             return self._workspace_state_cache
         except Exception as e:


### PR DESCRIPTION
v1 changes to use cloudbees.io URL instead of app.launchableinc.com when workspace is a CBP workspace.