### PR TITLE
Update CBP url for test sessions

### DIFF
--- a/launchable/commands/inspect/tests.py
+++ b/launchable/commands/inspect/tests.py
@@ -96,7 +96,7 @@ class TestResultJSONDisplay(TestResultAbstractDisplay):
         cbp_workspace = self._client.get_cbp_workspace()
         if cbp_workspace:
             org_cbp_id, ws_cbp_id = cbp_workspace
-            return "https://cloudbees.io/{}/{}/smart-tests/test-sessions/{}".format(
+            return "https://cloudbees.io/{}/{}/smart-tests/data/test-sessions/{}".format(
                 org_cbp_id, ws_cbp_id, self._results._test_session_id)
         else:
             org, workspace = ensure_org_workspace()

--- a/launchable/commands/record/tests.py
+++ b/launchable/commands/record/tests.py
@@ -666,7 +666,7 @@ def tests(
             cbp_workspace = client.get_cbp_workspace()
             if cbp_workspace:
                 org_cbp_id, ws_cbp_id = cbp_workspace
-                url = "https://cloudbees.io/{}/{}/smart-tests/test-sessions/{}".format(
+                url = "https://cloudbees.io/{}/{}/smart-tests/data/test-sessions/{}".format(
                     org_cbp_id, ws_cbp_id, self.test_session_id)
             else:
                 url = "https://app.launchableinc.com/organizations/{}/workspaces/{}/test-sessions/{}".format(


### PR DESCRIPTION
When using app.launchableinc.com, and localhost, frontend automatically redirects URL path `/test-sessions/*` to `/data/test-sessions/*`

However this redirection doesn't seem to work in cloudbess.io, so using canonical URL directly.