### PR TITLE
Add smart-tests-results-upload-action to CI workflows

### DIFF
--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -41,3 +41,7 @@ jobs:
             echo "smart_tests/jar/exe_deploy.jar is out of date. Run build-java.sh to update it."
             exit 1
           fi
+
+      - name: Upload test results
+        uses: cloudbees-oss/smart-tests-results-upload-action@v1
+        if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,3 +130,7 @@ jobs:
         env:
           SMART_TESTS_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN_GRADLE }}
         working-directory: examples/gradle
+
+      - name: Upload test results
+        uses: cloudbees-oss/smart-tests-results-upload-action@v1
+        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,3 +95,7 @@ jobs:
           # Test rest of tests
           uv run poe test-xml $(tr '\r\n' '\n' < smart-tests-remainder.txt)
         shell: bash
+
+      - name: Upload test results
+        uses: cloudbees-oss/smart-tests-results-upload-action@v1
+        if: always()


### PR DESCRIPTION
## Why

Test artifacts (XML reports, etc.) were not being preserved after CI runs, making it difficult to diagnose failures or feed results into Smart Tests analysis.

## What

Added `cloudbees-oss/smart-tests-results-upload-action@v1` as the final step in all three CI workflows:

- **`test.yml`** — after Python unit tests complete
- **`bazel-test.yml`** — after Bazel tests complete
- **`e2e.yml`** — after all e2e tests (bazel, go, gradle) complete

All steps use `if: always()` so artifacts are uploaded even when tests fail.
The action uses its default `files` patterns which cover `**/*.xml`, `**/*.json`, `**/test-results/**`, and more.