### PR TITLE
Add a new option --fallback-sampling-target so users can specify different ratio with --target

### DIFF
--- a/smart_tests/commands/subset.py
+++ b/smart_tests/commands/subset.py
@@ -623,6 +623,7 @@ class Subset(TestPathWriter):
             )
             sys.exit(1)
         elif self.fallback_mode == FallbackMode.RANDOM_SAMPLE:
+            assert self.fallback_sampling_target is not None
             target_fraction = float(self.fallback_sampling_target)
             click.echo(
                 f"Warning: Smart Tests could not retrieve a subset. "

--- a/smart_tests/commands/subset.py
+++ b/smart_tests/commands/subset.py
@@ -239,6 +239,7 @@ class Subset(TestPathWriter):
             )] = FallbackMode.RUN_ALL,
             fallback_sampling_target: Annotated[Percentage | None, typer.Option(
                 "--fallback-sampling-target",
+                hidden=True,
                 type=parse_percentage,
                 help="Sampling ratio (0%–100%) used when --fallback-mode=random-sample. "
                      "Required when --fallback-mode=random-sample is specified.",

--- a/smart_tests/commands/subset.py
+++ b/smart_tests/commands/subset.py
@@ -234,9 +234,16 @@ class Subset(TestPathWriter):
                 hidden=True,
                 help="Behavior when the subset API is unavailable or the model is untrained. "
                      "'run-all' (default) runs all tests as usual; 'stop' exits with a non-zero status so CI halts; "
-                     "'random-sample' picks a random subset locally based on the count derived from --target "
+                     "'random-sample' picks a random subset locally based on the count derived from --fallback-sampling-target "
                      "(no duration estimates are available in this path).",
             )] = FallbackMode.RUN_ALL,
+            fallback_sampling_target: Annotated[Percentage | None, typer.Option(
+                "--fallback-sampling-target",
+                type=parse_percentage,
+                help="Sampling ratio (0%–100%) used when --fallback-mode=random-sample. "
+                     "Required when --fallback-mode=random-sample is specified.",
+                metavar="PERCENTAGE"
+            )] = None,
             test_runner: Annotated[str | None, typer.Argument()] = None,
     ):
         super().__init__(app)
@@ -296,6 +303,20 @@ class Subset(TestPathWriter):
                 self.tracking_client,
                 Tracking.ErrorEvent.INTERNAL_CLI_ERROR)
 
+        if fallback_mode == FallbackMode.RANDOM_SAMPLE and fallback_sampling_target is None:
+            print_error_and_die(
+                "--fallback-sampling-target is required when --fallback-mode=random-sample",
+                self.tracking_client,
+                Tracking.ErrorEvent.USER_ERROR
+            )
+
+        if fallback_sampling_target is not None and fallback_mode != FallbackMode.RANDOM_SAMPLE:
+            print_error_and_die(
+                "--fallback-sampling-target can only be used with --fallback-mode=random-sample",
+                self.tracking_client,
+                Tracking.ErrorEvent.USER_ERROR
+            )
+
         self.target = target
         self.time = time
         self.confidence = confidence
@@ -319,6 +340,7 @@ class Subset(TestPathWriter):
         self.is_get_tests_from_guess = is_get_tests_from_guess
         self.use_case = use_case
         self.fallback_mode = fallback_mode
+        self.fallback_sampling_target = fallback_sampling_target
 
         self._validate_print_input_snapshot_option()
 
@@ -601,7 +623,7 @@ class Subset(TestPathWriter):
             )
             sys.exit(1)
         elif self.fallback_mode == FallbackMode.RANDOM_SAMPLE:
-            target_fraction = float(self.target) if self.target is not None else 1.0
+            target_fraction = float(self.fallback_sampling_target)
             click.echo(
                 f"Warning: Smart Tests could not retrieve a subset. "
                 f"Falling back to local random sample at {target_fraction:.0%}.",

--- a/smart_tests/utils/exceptions.py
+++ b/smart_tests/utils/exceptions.py
@@ -1,5 +1,6 @@
 # TODO: add cli-specific custom exceptions
 import sys
+from typing import NoReturn
 
 import click
 
@@ -28,7 +29,7 @@ class InvalidJUnitXMLException(Exception):
         super().__init__(self.message)
 
 
-def print_error_and_die(msg: str, tracking_client: TrackingClient, event: Tracking.ErrorEvent):
+def print_error_and_die(msg: str, tracking_client: TrackingClient, event: Tracking.ErrorEvent) -> NoReturn:
     click.secho(msg, fg='red', err=True)
     tracking_client.send_error_event(event_name=event, stack_trace=msg)
     sys.exit(1)

--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -457,9 +457,11 @@ class FallbackModeTest(CliTestCase):
             status=500)
 
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
-            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "random-sample")), mix_stderr=False)
+            extra = ("--fallback-mode", "random-sample", "--fallback-sampling-target", "100%")
+            result = self.cli(*self._subset_args(rest_file.name, extra), mix_stderr=False)
             self.assert_success(result)
             self.assertIn("example_test.rb", result.stdout)
+            self.assertIn("100%", result.stderr)
 
     @responses.activate
     @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
@@ -502,7 +504,8 @@ class FallbackModeTest(CliTestCase):
             status=200)
 
         with tempfile.NamedTemporaryFile(delete=False) as rest_file:
-            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "random-sample")), mix_stderr=False)
+            extra = ("--fallback-mode", "random-sample", "--fallback-sampling-target", "50%")
+            result = self.cli(*self._subset_args(rest_file.name, extra), mix_stderr=False)
             self.assert_success(result)
             self.assertIn("example_test.rb", result.stdout)
 
@@ -520,3 +523,13 @@ class FallbackModeTest(CliTestCase):
             result = self.cli(*self._subset_args(rest_file.name), mix_stderr=False)
             self.assert_success(result)
             self.assertIn("example_test.rb", result.stdout)
+
+    # --- Validation error cases ---
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
+    def test_random_sample_without_fallback_sampling_target_fails(self):
+        with tempfile.NamedTemporaryFile(delete=False) as rest_file:
+            result = self.cli(*self._subset_args(rest_file.name, ("--fallback-mode", "random-sample")), mix_stderr=False)
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("--fallback-sampling-target", result.stderr)


### PR DESCRIPTION
I noticed that --fallback-mode=random-sample can be used without --target option technically. In that case, we don’t know the how many (ratio) we choose tests from all tests. Relevant code is [subset.py](https://github.com/cloudbees-oss/smart-tests-cli/blob/043e61238dd510d6630cdfa323614cd412d36b12/smart_tests/commands/subset.py#L597) 

To overcome the situation, I considered several options below:

Option1: Add a new option --fallback-sampling-target so users can specify different ratio with --target

Option2: Raise error when --target is not specified with random-sample ->  --fallback-mode=random-sample must use with --target

Option3: Return 50% of tests as subset when --target is not specified

We chose the option 1 to specify the target of random sampling percentage when using fallback mode = random-sample